### PR TITLE
Auto-move card to REVIEW on PR_OPENED sentinel (#16)

### DIFF
--- a/PRISMCONDUCTOR_PLAN.md
+++ b/PRISMCONDUCTOR_PLAN.md
@@ -266,6 +266,8 @@ type Issue struct {
     Plan           *Plan           `json:"plan,omitempty"`
     SessionID      *string         `json:"session_id,omitempty"`
     LastError      string          `json:"last_error,omitempty"`
+    PRNumber       *int            `json:"pr_number,omitempty"` // set when execute worker emits PR_OPENED:
+    PRURL          string          `json:"pr_url,omitempty"`    // canonical github.com/.../pull/N
 }
 
 type BoardColumn string

--- a/app.go
+++ b/app.go
@@ -6,8 +6,10 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -120,6 +122,7 @@ func (a *App) startup(ctx context.Context) {
 	a.mgr = session.NewManager(a.bus, a.emitLine)
 	a.mgr.Configure(filepath.Join(cfgDir, "transcripts"), a.store, a.handleSessionStateChange)
 	a.mgr.SetOnPlanReady(a.handlePlanReady)
+	a.mgr.SetOnPROpened(a.handlePROpened)
 	a.mgr.SetOnActivity(func(act types.SessionActivity) {
 		wruntime.EventsEmit(a.ctx, "session.activity", act)
 	})
@@ -851,6 +854,57 @@ func (a *App) handlePlanReady(sess types.Session, relPath string) {
 	_ = a.store.MoveIssueColumn(sess.WorkspaceID, sess.IssueNumber, types.ColPlan)
 	_ = notify.Send(titleForWorkspace(a.wsReg, sess.WorkspaceID),
 		fmt.Sprintf("#%d plan ready (rev %d, %d questions)", sess.IssueNumber, plan.Revision, len(plan.Questions)))
+}
+
+// pullNumberRegexp extracts the PR number from a github.com pull URL.
+// Compiled once at package init.
+var pullNumberRegexp = regexp.MustCompile(`/pull/(\d+)`)
+
+func pullNumberFromURL(url string) (int, bool) {
+	m := pullNumberRegexp.FindStringSubmatch(url)
+	if len(m) < 2 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// handlePROpened persists the PR number + URL on the issue row, moves the
+// card to REVIEW, and fires an OS notification when a worker emits the
+// "PR_OPENED: <url>" sentinel.
+func (a *App) handlePROpened(sess types.Session, prURL string) {
+	if a.wsReg == nil || a.store == nil {
+		return
+	}
+	prURL = strings.TrimSpace(prURL)
+	if prURL == "" {
+		log.Printf("PR_OPENED: empty URL on session %s, skipping", sess.ID)
+		return
+	}
+	n, ok := pullNumberFromURL(prURL)
+	if !ok {
+		log.Printf("PR_OPENED: could not parse PR number from %q (session %s), skipping", prURL, sess.ID)
+		return
+	}
+	if _, ok := a.wsReg.Get(sess.WorkspaceID); !ok {
+		log.Printf("PR_OPENED: unknown workspace %q (session %s), skipping", sess.WorkspaceID, sess.ID)
+		return
+	}
+	if err := a.store.MarkPROpened(sess.WorkspaceID, sess.IssueNumber, n, prURL); err != nil {
+		log.Printf("PR_OPENED: MarkPROpened failed for #%d: %v", sess.IssueNumber, err)
+		return
+	}
+	a.bus.Publish(eventbus.EvtPROpened, map[string]any{
+		"workspace_id": sess.WorkspaceID,
+		"issue_number": sess.IssueNumber,
+		"pr_number":    n,
+		"pr_url":       prURL,
+	})
+	_ = notify.Send(titleForWorkspace(a.wsReg, sess.WorkspaceID),
+		fmt.Sprintf("#%d opened PR #%d", sess.IssueNumber, n))
 }
 
 // LatestPlan returns the highest-revision plan for an issue.

--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+func TestPullNumberFromURL(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   int
+		wantOK bool
+	}{
+		{"https://github.com/o/r/pull/123", 123, true},
+		{"https://github.com/o/r/pull/1", 1, true},
+		{"https://github.com/foo/bar/pull/42#issuecomment-1", 42, true},
+		{"https://github.com/o/r/issues/9", 0, false},
+		{"", 0, false},
+		{"PR_OPENED:", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := pullNumberFromURL(c.in)
+		if ok != c.wantOK || got != c.want {
+			t.Errorf("pullNumberFromURL(%q) = (%d,%v), want (%d,%v)", c.in, got, ok, c.want, c.wantOK)
+		}
+	}
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -98,6 +98,12 @@ function App() {
         setPlanTarget({ workspace_id: data.workspace_id, number: data.issue_number });
       },
     );
+    const offPROpened = EventsOn(
+      "bus.pr_opened",
+      (_data: { workspace_id: string; issue_number: number; pr_number: number; pr_url: string }) => {
+        refreshIssues(selectedWorkspace ?? "");
+      },
+    );
     const offPlanApproved = EventsOn(
       "bus.plan_approved",
       (data: { workspace_id: string; issue_number: number }) => {
@@ -136,6 +142,7 @@ function App() {
       if (typeof offGoalUpd === "function") offGoalUpd();
       if (typeof offIssue === "function") offIssue();
       if (typeof offPlanReady === "function") offPlanReady();
+      if (typeof offPROpened === "function") offPROpened();
       if (typeof offPlanApproved === "function") offPlanApproved();
       if (typeof offPlanRejected === "function") offPlanRejected();
       if (typeof offPoolFreed === "function") offPoolFreed();

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { BrowserOpenURL } from "../../wailsjs/runtime/runtime";
 import { types } from "../../wailsjs/go/models";
 import { useSessionStore, SessionActivity } from "../stores/sessionStore";
 import { usePlanReadyStore } from "../stores/planReadyStore";
@@ -101,7 +102,24 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
           #{issue.number}
           <span className="text-slate-500 truncate">{workspaceLabel ?? issue.workspace_id}</span>
         </span>
-        {issue.priority ? <span className="text-slate-500 shrink-0">P{issue.priority.toFixed(2)}</span> : null}
+        <span className="flex items-center gap-1.5 shrink-0">
+          {/* PR chip stays visible across columns/session states (rev4 q3). */}
+          {issue.pr_number != null && issue.pr_url && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                BrowserOpenURL(issue.pr_url!);
+              }}
+              onMouseDown={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
+              className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-700/40 text-emerald-200 border border-emerald-700 hover:bg-emerald-700/60"
+              title={`Open ${issue.pr_url}`}
+            >
+              ✓ PR #{issue.pr_number}
+            </button>
+          )}
+          {issue.priority ? <span className="text-slate-500">P{issue.priority.toFixed(2)}</span> : null}
+        </span>
       </div>
       <div className="text-sm text-slate-100 mt-1 line-clamp-2">{issue.title}</div>
 

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1153,6 +1153,8 @@ export namespace types {
 	    plan?: Plan;
 	    session_id?: string;
 	    last_error?: string;
+	    pr_number?: number;
+	    pr_url?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new Issue(source);
@@ -1176,6 +1178,8 @@ export namespace types {
 	        this.plan = this.convertValues(source["plan"], Plan);
 	        this.session_id = source["session_id"];
 	        this.last_error = source["last_error"];
+	        this.pr_number = source["pr_number"];
+	        this.pr_url = source["pr_url"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -15,6 +15,7 @@ const (
 	EvtIssueClosed       EventType = "issue_closed"
 	EvtIssueLabelChanged EventType = "issue_label_changed"
 	EvtPlanReady         EventType = "plan_ready"
+	EvtPROpened          EventType = "pr_opened"
 	EvtPlanApproved      EventType = "plan_approved"
 	EvtPlanRejected      EventType = "plan_rejected"
 	EvtPlanRevised       EventType = "plan_revised"

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -37,6 +38,11 @@ type StateChangeHandler func(sess types.Session, prev types.SessionState)
 // persisting it.
 type PlanReadyHandler func(sess types.Session, planPath string)
 
+// PROpenedHandler is fired when the worker prints the §10.3 "PR_OPENED: <url>"
+// sentinel. The handler is responsible for parsing the PR number, persisting
+// it on the issue row, and publishing EvtPROpened.
+type PROpenedHandler func(sess types.Session, prURL string)
+
 // ActivityHandler receives a session-liveness ping (most recent tool call,
 // running tool count). Used to drive the UI's "still alive, doing X" hint.
 // Implementations should debounce — emissions are already throttled at the
@@ -50,6 +56,7 @@ type Manager struct {
 	store         Persister
 	onStateChange StateChangeHandler
 	onPlanReady   PlanReadyHandler
+	onPROpened    PROpenedHandler
 	onActivity    ActivityHandler
 
 	mu       sync.RWMutex
@@ -86,6 +93,10 @@ func (m *Manager) Configure(transcriptDir string, store Persister, onChange Stat
 // SetOnPlanReady registers the handler invoked when a worker prints the
 // "Plan written" sentinel.
 func (m *Manager) SetOnPlanReady(h PlanReadyHandler) { m.onPlanReady = h }
+
+// SetOnPROpened registers the handler invoked when a worker prints the
+// "PR_OPENED: <url>" sentinel.
+func (m *Manager) SetOnPROpened(h PROpenedHandler) { m.onPROpened = h }
 
 // SetOnActivity registers a handler called on tool-call activity (throttled
 // to ~2/sec/session). Used to drive the UI's per-card liveness indicator.
@@ -286,6 +297,16 @@ func (m *Manager) matchPatterns(rs *runtimeSession, line string) {
 		// has the plan id; if no handler is wired, publish a generic event.
 		if m.onPlanReady == nil && m.bus != nil {
 			m.bus.Publish(eventbus.EvtPlanReady, rs.sess.ID)
+		}
+	case strings.Contains(line, PatternPROpened):
+		// No state mutation here — worker keeps running until PatternComplete.
+		// Mirrors the PatternPlanWritten arm shape.
+		idx := strings.Index(line, PatternPROpened)
+		url := strings.TrimSpace(line[idx+len(PatternPROpened):])
+		if url == "" {
+			log.Printf("PR_OPENED sentinel with empty URL on session %s", rs.sess.ID)
+		} else if m.onPROpened != nil {
+			m.onPROpened(*rs.sess, url)
 		}
 	case strings.Contains(line, PatternComplete):
 		rs.sess.State = types.StateCompleted

--- a/internal/session/patterns.go
+++ b/internal/session/patterns.go
@@ -7,4 +7,5 @@ const (
 	PatternPlanWritten = "Plan written to .prismconductor/plans/"
 	PatternComplete    = "Work complete."
 	PatternBlocked     = "BLOCKED:"
+	PatternPROpened    = "PR_OPENED: "
 )

--- a/internal/session/patterns_test.go
+++ b/internal/session/patterns_test.go
@@ -1,0 +1,27 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPatternPROpenedMatches(t *testing.T) {
+	const sample = "@asst PR_OPENED: https://github.com/o/r/pull/123"
+	if !strings.Contains(sample, PatternPROpened) {
+		t.Fatalf("expected sample to contain PatternPROpened (%q)", PatternPROpened)
+	}
+	idx := strings.Index(sample, PatternPROpened)
+	url := strings.TrimSpace(sample[idx+len(PatternPROpened):])
+	if url != "https://github.com/o/r/pull/123" {
+		t.Errorf("extracted url = %q", url)
+	}
+}
+
+func TestPatternPROpenedEmptyURLGuard(t *testing.T) {
+	const empty = "PR_OPENED: "
+	idx := strings.Index(empty, PatternPROpened)
+	url := strings.TrimSpace(empty[idx+len(PatternPROpened):])
+	if url != "" {
+		t.Errorf("expected empty url, got %q", url)
+	}
+}

--- a/internal/store/issues.go
+++ b/internal/store/issues.go
@@ -21,13 +21,27 @@ func (s *Store) SaveIssue(iss types.Issue) error {
 	}
 
 	// Look up existing column + manual_order so a poll-driven re-save doesn't
-	// nuke the user's drag-and-drop placement.
+	// nuke the user's drag-and-drop placement. Also pull the prior JSON so we
+	// can preserve conductor-managed scalars (pr_number / pr_url) that the
+	// fresh GitHub fetch knows nothing about.
 	var existingCol sql.NullString
 	var existingOrder sql.NullInt64
-	row := s.DB.QueryRow(`SELECT column_name, manual_order FROM issues WHERE workspace_id = ? AND number = ?`, iss.WorkspaceID, iss.Number)
-	_ = row.Scan(&existingCol, &existingOrder)
+	var existingJSON sql.NullString
+	row := s.DB.QueryRow(`SELECT column_name, manual_order, json FROM issues WHERE workspace_id = ? AND number = ?`, iss.WorkspaceID, iss.Number)
+	_ = row.Scan(&existingCol, &existingOrder, &existingJSON)
 	if existingCol.Valid {
 		col = types.BoardColumn(existingCol.String)
+	}
+	if existingJSON.Valid {
+		var prev types.Issue
+		if err := json.Unmarshal([]byte(existingJSON.String), &prev); err == nil {
+			if prev.PRNumber != nil {
+				iss.PRNumber = prev.PRNumber
+			}
+			if prev.PRURL != "" {
+				iss.PRURL = prev.PRURL
+			}
+		}
 	}
 	iss.Column = col
 
@@ -196,6 +210,50 @@ func (s *Store) ReconcileClosedIssues() (int, error) {
 		}
 	}
 	return len(todo), nil
+}
+
+// MarkPROpened persists the PR number + URL on an issue and moves the card
+// to REVIEW (bottom of column). Single transaction; bypasses SaveIssue's
+// column-preservation logic so the IN_PROGRESS→REVIEW jump survives the next
+// poll tick. Modeled on MarkIssueClosed.
+func (s *Store) MarkPROpened(workspaceID string, number int, prNumber int, prURL string) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	tx, err := s.DB.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var raw string
+	if err := tx.QueryRow(`SELECT json FROM issues WHERE workspace_id = ? AND number = ?`,
+		workspaceID, number).Scan(&raw); err != nil {
+		return err
+	}
+	var iss types.Issue
+	if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+		return err
+	}
+	iss.PRNumber = &prNumber
+	iss.PRURL = prURL
+	iss.Column = types.ColReview
+	b, _ := json.Marshal(iss)
+
+	var maxOrder sql.NullInt64
+	if err := tx.QueryRow(
+		`SELECT COALESCE(MAX(manual_order), -1) FROM issues WHERE workspace_id = ? AND column_name = ?`,
+		workspaceID, string(types.ColReview),
+	).Scan(&maxOrder); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		`UPDATE issues SET column_name = ?, manual_order = ?, json = ? WHERE workspace_id = ? AND number = ?`,
+		string(types.ColReview), maxOrder.Int64+1, string(b), workspaceID, number,
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // MarkIssueClosed forces state=closed AND column=done in a single transaction,

--- a/internal/store/issues_test.go
+++ b/internal/store/issues_test.go
@@ -1,0 +1,92 @@
+package store
+
+import (
+	"testing"
+
+	"prismconductor/internal/types"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestMarkPROpenedMovesCardAndPersistsFields(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      42,
+		Title:       "thing",
+		State:       "open",
+		Column:      types.ColInProgress,
+	}); err != nil {
+		t.Fatalf("SaveIssue: %v", err)
+	}
+
+	if err := s.MarkPROpened("ws1", 42, 99, "https://github.com/o/r/pull/99"); err != nil {
+		t.Fatalf("MarkPROpened: %v", err)
+	}
+
+	got, err := s.ListIssues("ws1")
+	if err != nil || len(got) != 1 {
+		t.Fatalf("ListIssues: %v len=%d", err, len(got))
+	}
+	iss := got[0]
+	if iss.Column != types.ColReview {
+		t.Errorf("column = %q, want %q", iss.Column, types.ColReview)
+	}
+	if iss.PRNumber == nil || *iss.PRNumber != 99 {
+		t.Errorf("PRNumber = %v, want 99", iss.PRNumber)
+	}
+	if iss.PRURL != "https://github.com/o/r/pull/99" {
+		t.Errorf("PRURL = %q", iss.PRURL)
+	}
+}
+
+func TestSaveIssuePreservesPRFieldsAcrossPolls(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      7,
+		Title:       "polled",
+		State:       "open",
+		Column:      types.ColInProgress,
+	}); err != nil {
+		t.Fatalf("SaveIssue initial: %v", err)
+	}
+	// Worker writes PR fields via MarkPROpened.
+	if err := s.MarkPROpened("ws1", 7, 12, "https://github.com/o/r/pull/12"); err != nil {
+		t.Fatalf("MarkPROpened: %v", err)
+	}
+	// Simulate a poll-driven re-save where GitHub knows nothing about pr_number / pr_url.
+	if err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      7,
+		Title:       "polled (refreshed)",
+		State:       "open",
+	}); err != nil {
+		t.Fatalf("SaveIssue refresh: %v", err)
+	}
+	got, err := s.ListIssues("ws1")
+	if err != nil || len(got) != 1 {
+		t.Fatalf("ListIssues: %v len=%d", err, len(got))
+	}
+	iss := got[0]
+	if iss.Title != "polled (refreshed)" {
+		t.Errorf("title not refreshed: %q", iss.Title)
+	}
+	if iss.PRNumber == nil || *iss.PRNumber != 12 {
+		t.Errorf("PRNumber lost across poll: %v", iss.PRNumber)
+	}
+	if iss.PRURL != "https://github.com/o/r/pull/12" {
+		t.Errorf("PRURL lost across poll: %q", iss.PRURL)
+	}
+	if iss.Column != types.ColReview {
+		t.Errorf("column lost across poll: %q", iss.Column)
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -105,6 +105,8 @@ type Issue struct {
 	Plan         *Plan       `json:"plan,omitempty"`
 	SessionID    *string     `json:"session_id,omitempty"`
 	LastError    string      `json:"last_error,omitempty"`
+	PRNumber     *int        `json:"pr_number,omitempty"`
+	PRURL        string      `json:"pr_url,omitempty"`
 }
 
 type BoardColumn string


### PR DESCRIPTION
## Summary

- Adds the `PR_OPENED: <url>` PTY sentinel + handler so an execute worker's draft PR auto-moves the card from IN_PROGRESS to REVIEW.
- New `Issue.PRNumber` / `Issue.PRURL` (optional, omitempty) round-trip through the existing JSON column. `SaveIssue` is widened to preserve both across GitHub poll cycles (acceptance #5).
- Card header gets a clickable `✓ PR #<n>` chip next to the priority badge; chip stays visible across columns/states (q3).
- Fires `notify.Send("PrismConductor — workspace", "#14 opened PR #15")` (acceptance #3).
- Empty / unparseable URL → log warning, no crash, no spurious move (acceptance #4).

## Files modified

- `internal/types/types.go` — `Issue` struct gains `PRNumber *int` + `PRURL string` (§6.3).
- `internal/session/patterns.go` — new `PatternPROpened = "PR_OPENED: "` (plain string contains, §10.3).
- `internal/session/manager.go` — `PROpenedHandler` type, `onPROpened` field, `SetOnPROpened`, fifth `matchPatterns` arm.
- `internal/store/issues.go` — `MarkPROpened` (single-tx, mirrors `MarkIssueClosed`); `SaveIssue` widened to preserve `pr_number`/`pr_url` from the prior JSON.
- `internal/eventbus/bus.go` — `EvtPROpened`.
- `app.go` — registers the handler in `startup`; new `handlePROpened` (validate → MarkPROpened → bus publish → notify); `pullNumberFromURL` helper.
- `frontend/src/App.tsx` — `bus.pr_opened` subscription that re-fetches issues.
- `frontend/src/components/Card.tsx` — green PR chip in header row, opens PR via `BrowserOpenURL`, swallows drag/click events.
- `frontend/wailsjs/go/models.ts` — regenerated to include `pr_number`/`pr_url` on `Issue`.
- `PRISMCONDUCTOR_PLAN.md` — §6.3 Issue schema documents the new optional fields.

## Verification

- **Lint:** `go vet ./...` → exit 0; `npx tsc --noEmit` (frontend) → exit 0.
- **Build:** `wails build` → built `prismconductor.app` in 6.259s.
- **Tests:** `go test ./...` → 3 packages PASS (`prismconductor`, `prismconductor/internal/session`, `prismconductor/internal/store`), 0 FAIL.
  - `TestPullNumberFromURL` — 6 URL parsing cases including non-pull, empty, and trailing fragment.
  - `TestPatternPROpenedMatches` + `TestPatternPROpenedEmptyURLGuard`.
  - `TestMarkPROpenedMovesCardAndPersistsFields` + `TestSaveIssuePreservesPRFieldsAcrossPolls` (the poll-survival case from acceptance #5).

## Notes / flagged for human review

- No frontend test runner is present in the repo (`frontend/package.json` has no `test` script and no Vitest/Jest deps), so the new Card chip JSX is not covered by an automated test. Manual smoke: drag a card to PLAN, approve, watch execute worker, confirm card auto-moves to REVIEW with a `✓ PR #<n>` chip and an OS notification.
- `frontend/wailsjs/go/main/App.{js,d.ts}` did not change — no new bound methods, only the `Issue` model gained fields.
- The bundled `conductor-execute.md` skill already prints `PR_OPENED: <url>` (step 17), so no worker change was needed.

Closes #16
