### PR TITLE
Pause auto-pull toggle without deactivating goal (#21)

### DIFF
--- a/app.go
+++ b/app.go
@@ -112,6 +112,9 @@ func (a *App) startup(ctx context.Context) {
 				a.pool.SetCapacity(n)
 			}
 		}
+		if v, _ := a.store.GetSetting("auto_pull_paused"); v == "true" {
+			a.orch.SetPaused(true)
+		}
 	}
 	if r, err := workspace.New(cfgDir); err != nil {
 		log.Printf("workspace registry: %v\n", err)
@@ -813,6 +816,36 @@ func (a *App) SetWorkerPoolCapacity(n int) error {
 		_ = a.store.SetSetting("worker_pool_capacity", strconv.Itoa(n))
 	}
 	a.bus.Publish(eventbus.EvtAgentCountChanged, map[string]any{"prev": prev, "new": n})
+	return nil
+}
+
+// GetAutoPullPaused returns the live pause state from the orchestrator's
+// atomic.Bool — no DB round-trip per call.
+func (a *App) GetAutoPullPaused() bool {
+	if a.orch == nil {
+		return false
+	}
+	return a.orch.IsPaused()
+}
+
+// SetAutoPullPaused persists the toggle and updates the running orchestrator.
+// On resume (paused=false), kicks autoPull so catch-up is immediate.
+func (a *App) SetAutoPullPaused(paused bool) error {
+	if a.orch == nil || a.store == nil {
+		return fmt.Errorf("orchestrator/store unavailable")
+	}
+	a.orch.SetPaused(paused)
+	val := "false"
+	if paused {
+		val = "true"
+	}
+	if err := a.store.SetSetting("auto_pull_paused", val); err != nil {
+		return err
+	}
+	a.bus.Publish(eventbus.EvtAutoPullPausedChanged, map[string]any{"paused": paused})
+	if !paused {
+		a.orch.KickAutoPull("resumed")
+	}
 	return nil
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import { EventsOn } from "../wailsjs/runtime/runtime";
 import {
+  GetAutoPullPaused,
   GetWorkerPoolStatus,
   ListPendingPlans,
   ListSessions,
   RefreshIssuesNow,
+  SetAutoPullPaused,
   SpawnDemo,
   SpawnPlanForIssue,
 } from "../wailsjs/go/main/App";
@@ -38,6 +40,7 @@ function App() {
   const clearPlanReady = usePlanReadyStore((s) => s.clearReady);
   const issues = useIssueStore((s) => s.issues);
   const [poolStatus, setPoolStatus] = useState({ active: 0, capacity: 2 });
+  const [autoPaused, setAutoPaused] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [planTarget, setPlanTarget] = useState<PlanTarget>(null);
@@ -134,6 +137,11 @@ function App() {
     const offPoolFreed = EventsOn("bus.worker_slot_freed", refreshPool);
     const offPoolChanged = EventsOn("bus.agent_count_changed", refreshPool);
     const offPoolState = EventsOn("session.state", refreshPool);
+    GetAutoPullPaused().then(setAutoPaused).catch(() => {});
+    const offPause = EventsOn(
+      "bus.auto_pull_paused_changed",
+      (data: { paused: boolean }) => setAutoPaused(!!data?.paused),
+    );
     return () => {
       if (typeof offLine === "function") offLine();
       if (typeof offState === "function") offState();
@@ -153,6 +161,7 @@ function App() {
       if (typeof offGhClosed === "function") offGhClosed();
       if (typeof offGhLabel === "function") offGhLabel();
       if (typeof offLabelsUpdated === "function") offLabelsUpdated();
+      if (typeof offPause === "function") offPause();
     };
   }, [appendLine, setMeta, refreshWorkspaces, refreshGoals, refreshIssues, markPlanReady, clearPlanReady, selectedWorkspace]);
 
@@ -238,6 +247,30 @@ function App() {
             title="Re-fetch GitHub issues for every workspace now"
           >
             ↻ Refresh
+          </button>
+          <button
+            onClick={async () => {
+              const next = !autoPaused;
+              setAutoPaused(next);
+              try {
+                await SetAutoPullPaused(next);
+              } catch (e: any) {
+                setAutoPaused(!next);
+                alert(String(e?.message ?? e));
+              }
+            }}
+            className={
+              autoPaused
+                ? "text-xs border border-amber-700 bg-amber-950/40 hover:bg-amber-900/60 px-2 py-1 rounded text-amber-300"
+                : "text-xs border border-slate-700 hover:bg-slate-800 px-2 py-1 rounded text-slate-300"
+            }
+            title={
+              autoPaused
+                ? "Auto-pull paused — manual drag-to-PLAN still works; goal-scoped TODO filter unaffected. Click to resume."
+                : "Pause orchestrator's auto-pull. Manual drag-to-PLAN still works; goal-scoped TODO filter unaffected."
+            }
+          >
+            {autoPaused ? "⏸ auto-pull" : "▶ auto-pull"}
           </button>
           <button
             onClick={() => setDrawerOpen((v) => !v)}

--- a/frontend/src/components/GoalPane.tsx
+++ b/frontend/src/components/GoalPane.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { FilterIssuesByActiveGoal } from "../../wailsjs/go/main/App";
+import { FilterIssuesByActiveGoal, GetAutoPullPaused } from "../../wailsjs/go/main/App";
+import { EventsOn } from "../../wailsjs/runtime/runtime";
 import { types } from "../../wailsjs/go/models";
 import { useGoalStore } from "../stores/goalStore";
 import { useIssueStore } from "../stores/issueStore";
@@ -12,10 +13,22 @@ export function GoalPane() {
   const [editorOpen, setEditorOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [scopedIssues, setScopedIssues] = useState<types.Issue[] | null>(null);
+  const [paused, setPaused] = useState(false);
 
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    GetAutoPullPaused().then(setPaused).catch(() => {});
+    const off = EventsOn(
+      "bus.auto_pull_paused_changed",
+      (d: { paused: boolean }) => setPaused(!!d?.paused),
+    );
+    return () => {
+      if (typeof off === "function") off();
+    };
+  }, []);
 
   const active = goals.find((g) => g.status === "active") ?? null;
   const upNext = goals.filter((g) => g.status === "backlog");
@@ -64,7 +77,7 @@ export function GoalPane() {
               className="text-amber-300 hover:underline truncate max-w-[420px]"
               title={active.intent || ""}
             >
-              🎯 {active.title}
+              🎯 {active.title}{paused ? " (paused)" : ""}
             </button>
           ) : (
             <span className="text-slate-600">none — {goals.length === 0 ? "create one →" : "activate from Up Next →"}</span>

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -24,6 +24,8 @@ export function DeleteLabel(arg1:string,arg2:string):Promise<void>;
 
 export function FilterIssuesByActiveGoal(arg1:Array<types.Issue>):Promise<Array<types.Issue>>;
 
+export function GetAutoPullPaused():Promise<boolean>;
+
 export function GetNotifyPrefs():Promise<main.NotifyPrefs>;
 
 export function GetOllamaConfig():Promise<main.OllamaConfig>;
@@ -95,6 +97,8 @@ export function RunOrchestrator():Promise<void>;
 export function SaveGoal(arg1:types.Goal):Promise<void>;
 
 export function SendInput(arg1:string,arg2:string):Promise<void>;
+
+export function SetAutoPullPaused(arg1:boolean):Promise<void>;
 
 export function SetGoalStatus(arg1:string,arg2:string):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -34,6 +34,10 @@ export function FilterIssuesByActiveGoal(arg1) {
   return window['go']['main']['App']['FilterIssuesByActiveGoal'](arg1);
 }
 
+export function GetAutoPullPaused() {
+  return window['go']['main']['App']['GetAutoPullPaused']();
+}
+
 export function GetNotifyPrefs() {
   return window['go']['main']['App']['GetNotifyPrefs']();
 }
@@ -176,6 +180,10 @@ export function SaveGoal(arg1) {
 
 export function SendInput(arg1, arg2) {
   return window['go']['main']['App']['SendInput'](arg1, arg2);
+}
+
+export function SetAutoPullPaused(arg1) {
+  return window['go']['main']['App']['SetAutoPullPaused'](arg1);
 }
 
 export function SetGoalStatus(arg1, arg2) {

--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -24,6 +24,7 @@ const (
 	EvtCardMovedManually EventType = "card_moved_manually"
 	EvtAgentCountChanged EventType = "agent_count_changed"
 	EvtLabelsUpdated     EventType = "labels_updated"
+	EvtAutoPullPausedChanged EventType = "auto_pull_paused_changed"
 )
 
 type Event struct {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"prismconductor/internal/eventbus"
@@ -47,6 +48,20 @@ type Orchestrator struct {
 
 	mu      sync.Mutex
 	running bool
+	paused  atomic.Bool
+}
+
+// SetPaused suspends/resumes auto-pull. Manual drag-to-PLAN (which goes
+// through App.MoveIssueColumn, not the orchestrator) is unaffected.
+func (o *Orchestrator) SetPaused(b bool) { o.paused.Store(b) }
+
+// IsPaused returns the current pause state.
+func (o *Orchestrator) IsPaused() bool { return o.paused.Load() }
+
+// KickAutoPull triggers an auto-pull pass from outside the bus (e.g., the
+// resume path on SetAutoPullPaused(false)). Async to match the bus handlers.
+func (o *Orchestrator) KickAutoPull(reason string) {
+	go o.autoPull(reason)
 }
 
 func New(bus *eventbus.Bus, llm LLM) *Orchestrator {
@@ -109,6 +124,9 @@ func (o *Orchestrator) handle(e eventbus.Event) {
 // but defensive). Respects manual moves implicitly: a card the user just
 // dragged into PLAN is no longer in TODO so won't be re-pulled.
 func (o *Orchestrator) autoPull(reason string) {
+	if o.paused.Load() {
+		return
+	}
 	if o.pool == nil || o.spawn == nil || o.store == nil {
 		return
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1,0 +1,126 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"prismconductor/internal/eventbus"
+	"prismconductor/internal/types"
+)
+
+// stubStore satisfies the Store interface; only ListGoals/ListIssues are
+// reached by autoPull's happy path.
+type stubStore struct {
+	goals       []types.Goal
+	issues      []types.Issue
+	listGoalsHits  int
+	listIssuesHits int
+}
+
+func (s *stubStore) ListIssues(string) ([]types.Issue, error) {
+	s.listIssuesHits++
+	return s.issues, nil
+}
+func (s *stubStore) SaveIssue(types.Issue) error { return nil }
+func (s *stubStore) ListGoals() ([]types.Goal, error) {
+	s.listGoalsHits++
+	return s.goals, nil
+}
+func (s *stubStore) GetGoal(string) (types.Goal, error)             { return types.Goal{}, nil }
+func (s *stubStore) DepCacheGet(string, int, string, string) (string, bool, error) {
+	return "", false, nil
+}
+func (s *stubStore) DepCachePut(string, int, string, string, any) error { return nil }
+func (s *stubStore) MoveIssueColumn(string, int, types.BoardColumn) error { return nil }
+
+type stubPool struct {
+	free        int
+	tryAcquires int
+	releases    int
+	freeHits    int
+}
+
+func (p *stubPool) Capacity() int { return 2 }
+func (p *stubPool) Active() int   { return 0 }
+func (p *stubPool) Free() int     { p.freeHits++; return p.free }
+func (p *stubPool) TryAcquire() bool {
+	p.tryAcquires++
+	if p.free <= 0 {
+		return false
+	}
+	p.free--
+	return true
+}
+func (p *stubPool) Release() { p.releases++; p.free++ }
+
+func TestSetPausedToggles(t *testing.T) {
+	o := New(eventbus.New(), nil)
+	if o.IsPaused() {
+		t.Fatal("IsPaused should default to false")
+	}
+	o.SetPaused(true)
+	if !o.IsPaused() {
+		t.Fatal("IsPaused should be true after SetPaused(true)")
+	}
+	o.SetPaused(false)
+	if o.IsPaused() {
+		t.Fatal("IsPaused should be false after SetPaused(false)")
+	}
+}
+
+func TestAutoPullShortCircuitsWhenPaused(t *testing.T) {
+	st := &stubStore{
+		goals: []types.Goal{
+			{ID: "g1", WorkspaceID: "ws1", Status: types.GoalActive, Title: "t"},
+		},
+		issues: []types.Issue{
+			{WorkspaceID: "ws1", Number: 1, State: "open", Column: types.ColTodo},
+		},
+	}
+	pool := &stubPool{free: 1}
+	spawnHits := 0
+	spawn := func(string, int) error { spawnHits++; return nil }
+
+	o := New(eventbus.New(), nil)
+	o.SetStore(st)
+	o.SetAutoPull(pool, spawn)
+	o.SetPaused(true)
+
+	o.autoPull("test")
+
+	if st.listGoalsHits != 0 {
+		t.Errorf("paused autoPull touched store.ListGoals (hits=%d), expected short-circuit", st.listGoalsHits)
+	}
+	if pool.freeHits != 0 {
+		t.Errorf("paused autoPull touched pool.Free (hits=%d), expected short-circuit", pool.freeHits)
+	}
+	if spawnHits != 0 {
+		t.Errorf("paused autoPull invoked spawn (hits=%d), expected short-circuit", spawnHits)
+	}
+}
+
+func TestAutoPullProceedsWhenNotPaused(t *testing.T) {
+	st := &stubStore{
+		goals: []types.Goal{
+			{ID: "g1", WorkspaceID: "ws1", Status: types.GoalActive, Title: "t"},
+		},
+		issues: []types.Issue{
+			{WorkspaceID: "ws1", Number: 1, State: "open", Column: types.ColTodo},
+		},
+	}
+	pool := &stubPool{free: 1}
+	spawnHits := 0
+	spawn := func(string, int) error { spawnHits++; return nil }
+
+	o := New(eventbus.New(), nil)
+	o.SetStore(st)
+	o.SetAutoPull(pool, spawn)
+
+	o.autoPull("test")
+
+	if st.listGoalsHits == 0 {
+		t.Error("unpaused autoPull did not call ListGoals")
+	}
+	if spawnHits != 1 {
+		t.Errorf("unpaused autoPull spawned %d times, want 1", spawnHits)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a global pause toggle that suspends `Orchestrator.autoPull` without deactivating the active goal. Manual drag-to-PLAN keeps working; goal-scoped TODO filter unaffected. Persists across relaunch.

## Files modified

- `internal/eventbus/bus.go` — new `EvtAutoPullPausedChanged` event type.
- `internal/orchestrator/orchestrator.go` — `paused atomic.Bool`, `SetPaused`, `IsPaused`, `KickAutoPull`; `autoPull` short-circuits when paused.
- `internal/orchestrator/orchestrator_test.go` — new tests for `SetPaused/IsPaused`, the paused short-circuit, and the unpaused happy path.
- `app.go` — startup hydrates `auto_pull_paused` from settings; `GetAutoPullPaused` / `SetAutoPullPaused` bound methods (persist + publish bus event + kick auto-pull on resume).
- `frontend/src/App.tsx` — header pill between `↻ Refresh` and `Drawer`; optimistic flip with rollback; subscribes to `bus.auto_pull_paused_changed`.
- `frontend/src/components/GoalPane.tsx` — appends `(paused)` to the active-goal label, sourced from the same bus event for consistency.
- `frontend/wailsjs/go/main/App.{d.ts,js}` — regenerated bindings (`wails generate module`).

## Verification

- **Lint:** `go vet ./...` → exit 0; `cd frontend && npx tsc --noEmit` → exit 0.
- **Build:** `go build ./...` → exit 0; `wails build` → built `prismconductor.app` in 6.6s.
- **Tests:** `go test ./...` → all pass (3 new orchestrator tests: `TestSetPausedToggles`, `TestAutoPullShortCircuitsWhenPaused`, `TestAutoPullProceedsWhenNotPaused`). No frontend test infrastructure exists in this repo, so the new React state was not covered by an automated test.

## Notes

- `atomic.Bool` over a mutex-guarded bool because the read path is hot (every event) and write is rare; avoids contending with `o.mu`.
- Paused-first ordering in `autoPull` is the cheapest early return.
- `KickAutoPull` (direct call) on resume rather than re-publishing `EvtWorkerSlotFreed`, which would corrupt slot accounting via `pool.Release()` in the bus handler.
- Reuses the `settings` kv table (matches `notify_muted` convention) — no schema migration.

Closes #21
