### PR TITLE
Tooltip on active blocked card with BLOCKED reason (#20)

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -186,9 +186,12 @@ function StatusRow({
       : "working";
     const dotCls = isBlocked ? "bg-red-400" : planMode ? "bg-sky-400" : "bg-purple-400";
     const textCls = isBlocked ? "text-red-300" : planMode ? "text-sky-300" : "text-purple-300";
+    const tooltipReason = isBlocked
+      ? truncateForTooltip(activeSession.blocked_reason || "BLOCKED: (no reason given)")
+      : undefined;
     return (
       <div className="text-[11px] mt-1.5 space-y-0.5">
-        <div className="flex items-center gap-1.5">
+        <div className="flex items-center gap-1.5" title={tooltipReason}>
           <Pulse className={dotCls} />
           <span className={textCls}>{label}</span>
           {activity && activity.tool_count > 0 && (
@@ -330,6 +333,11 @@ function ActivityHint({ activity }: { activity: SessionActivity }) {
       <span className="shrink-0">· {formatElapsed(seconds)}</span>
     </div>
   );
+}
+
+function truncateForTooltip(s: string): string {
+  const trimmed = s.trim();
+  return trimmed.length > 120 ? trimmed.slice(0, 117) + "…" : trimmed;
 }
 
 function formatElapsed(s: number): string {


### PR DESCRIPTION
## Summary

Adds a native `title` tooltip to the inner pulse+label row on the `activeSession.blocked` branch in `Card.tsx`, so cards in the brief active+blocked window also surface the truncated `BLOCKED: <reason>` on hover. Closes the last gap from issue #20 (post-exit `lastFailure` path was already shipped in `c49e984`).

## Files modified

- `frontend/src/components/Card.tsx` — compute `tooltipReason` from `activeSession.blocked_reason` (truncated to 120 chars via new `truncateForTooltip` helper) and apply it as `title` on the inner row only when `isBlocked` is true.

## Verification

- Lint / typecheck: `cd frontend && npx tsc --noEmit` → exit 0
- Lint (Go sanity): `go vet ./...` → exit 0
- Build (Go sanity): `go build ./...` → exit 0
- Tests: `go test ./...` → all packages pass (4 with tests, rest no-test); frontend has no test runner configured.

## ⚠ No frontend tests run (no runner detected)

`frontend/package.json` declares no test framework (no vitest / jest / no `test` script). The plan only contains a `modify` intent (no `add`), so per the conductor-execute rule no new test was required, but the helper `truncateForTooltip` is a small pure function whose behavior is exercised at runtime by the tooltip path. If/when the repo adopts a frontend test runner, a unit test for `truncateForTooltip` (≤120 → unchanged, >120 → 117 chars + ellipsis) and a smoke render of `Card` in the blocked active state would be straightforward to add.

## Acceptance walk-through (per issue)

1. `BLOCKED:` exit captured by backend (`internal/session/manager.go:313-329`) — already shipped.
2. Hover red-glowing card during the active+blocked window: native tooltip on inner row shows truncated `BLOCKED: <reason>`. ✓ this PR
3. Post-exit (most common): tooltip on outer div + inline `⚠ <reason>` text. ✓ already shipped in `c49e984`.
4. After re-spawn, new running session has empty `BlockedReason`; `tooltipReason` resolves to `undefined`, React drops the `title` attribute. ✓

Closes #20
