### PR TITLE
Per-execute git worktree off origin/main (#22)

### DIFF
--- a/PRISMCONDUCTOR_PLAN.md
+++ b/PRISMCONDUCTOR_PLAN.md
@@ -515,6 +515,31 @@ func (s *SessionManager) SpawnExecute(ws Workspace, issue Issue, plan Plan) (*Se
 }
 ```
 
+### 10.2.1 Worker isolation (issue #22)
+
+Each execute-mode worker runs inside a per-`(workspace, issue)` git worktree
+at `<RepoPath>/.prismconductor/worktrees/<wsID>-<num>`, created by the session
+manager off `origin/<DefaultBranch>` before `pty.Start`. The conductor — not
+the skill — owns the worktree's lifecycle:
+
+- **Mirror** (q1=A): plan + answers JSON are copied from the main checkout's
+  gitignored `.prismconductor/{plans,answers}/` into the worktree's so the
+  worker's cwd-relative reads succeed.
+- **Cleanup on Blocked/Failed** (q2=A): `git worktree remove --force` runs
+  synchronously in `tailAndParse` once the terminal state resolves. No
+  goroutine fanout; no post-mortem `cd` access for the user.
+- **Cleanup on Completed** (q3=A): the worktree stays on disk so reviewers can
+  inspect it. A startup walk plus a 1h ticker remove worktrees whose most
+  recent terminal session ended more than 24h ago.
+- **Submodules** (q4=D): if the new worktree contains `.gitmodules`,
+  `git submodule update --init --recursive` runs inside it on spawn.
+- **Manual recovery**: a `GCWorktrees` button in the Workspaces panel
+  force-removes every conductor-managed worktree under
+  `.prismconductor/worktrees/` for one workspace, regardless of session state.
+
+This isolation means a dirty main checkout never blocks an execute spawn, and
+parallel executes of different issues each get their own worktree.
+
 ### 10.3 PTY Output Parsing
 
 The session goroutine watches PTY output for these patterns:

--- a/app.go
+++ b/app.go
@@ -19,6 +19,7 @@ import (
 	gh "github.com/google/go-github/v62/github"
 
 	"prismconductor/internal/eventbus"
+	pcgit "prismconductor/internal/git"
 	pcgithub "prismconductor/internal/github"
 	"prismconductor/internal/logbuffer"
 	"prismconductor/internal/goalfilter"
@@ -120,6 +121,26 @@ func (a *App) startup(ctx context.Context) {
 		log.Printf("workspace registry: %v\n", err)
 	} else {
 		a.wsReg = r
+	}
+
+	// Issue #22: prune any orphan worktrees from prior conductor sessions, then
+	// remove worktrees for terminal-state sessions whose ended_at is older than
+	// 24h. Repeated on a 1h tick (q3=A) so a long-running app session catches
+	// post-success worktrees that aged in.
+	if a.wsReg != nil {
+		a.gcWorktreesAll()
+		go func() {
+			t := time.NewTicker(1 * time.Hour)
+			defer t.Stop()
+			for {
+				select {
+				case <-a.ctx.Done():
+					return
+				case <-t.C:
+					a.gcWorktreesAll()
+				}
+			}
+		}()
 	}
 
 	a.mgr = session.NewManager(a.bus, a.emitLine)
@@ -327,6 +348,80 @@ func (a *App) emitLine(sessionID, line string) {
 		"session_id": sessionID,
 		"line":       line,
 	})
+}
+
+// gcWorktreesAll prunes orphan worktree records and removes any
+// `.prismconductor/worktrees/<wsID>-<num>` directory whose most recent
+// terminal-state session ended more than 24h ago. Issue #22, q3=A.
+func (a *App) gcWorktreesAll() {
+	if a.wsReg == nil {
+		return
+	}
+	cutoff := time.Now().Add(-24 * time.Hour)
+	for _, ws := range a.wsReg.List() {
+		if ws.RepoPath == "" {
+			continue
+		}
+		if err := pcgit.Prune(ws.RepoPath); err != nil {
+			log.Printf("worktree prune %s: %v", ws.ID, err)
+		}
+		entries, err := pcgit.List(ws.RepoPath)
+		if err != nil {
+			continue
+		}
+		prefix := filepath.Join(ws.RepoPath, ".prismconductor", "worktrees")
+		for _, e := range entries {
+			if !strings.HasPrefix(e.Path, prefix) {
+				continue
+			}
+			if a.store == nil {
+				continue
+			}
+			ended, ok, err := a.store.MostRecentEndedAtForWorktree(ws.ID, e.Path)
+			if err != nil || !ok {
+				continue
+			}
+			if ended.Before(cutoff) {
+				if err := pcgit.Remove(ws.RepoPath, e.Path); err != nil {
+					log.Printf("24h GC remove %s: %v", e.Path, err)
+				}
+			}
+		}
+	}
+}
+
+// GCWorktrees force-removes every conductor-managed worktree under
+// `<RepoPath>/.prismconductor/worktrees/` for one workspace, regardless of
+// session state. Surfaced as a manual "something got jammed" recovery in the
+// Workspaces panel (issue #22). Returns the count of directories removed.
+func (a *App) GCWorktrees(workspaceID string) (int, error) {
+	if a.wsReg == nil {
+		return 0, fmt.Errorf("workspace registry unavailable")
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return 0, fmt.Errorf("unknown workspace %q", workspaceID)
+	}
+	entries, err := pcgit.List(ws.RepoPath)
+	if err != nil {
+		return 0, err
+	}
+	prefix := filepath.Join(ws.RepoPath, ".prismconductor", "worktrees")
+	removed := 0
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Path, prefix) {
+			continue
+		}
+		if err := pcgit.Remove(ws.RepoPath, e.Path); err != nil {
+			log.Printf("GCWorktrees remove %s: %v", e.Path, err)
+			continue
+		}
+		removed++
+	}
+	if err := pcgit.Prune(ws.RepoPath); err != nil {
+		log.Printf("GCWorktrees prune %s: %v", ws.ID, err)
+	}
+	return removed, nil
 }
 
 // --- Bound methods exposed to frontend ---
@@ -1069,7 +1164,16 @@ func (a *App) ApprovePlan(workspaceID string, issueNumber, revision int) error {
 	if err := a.store.MoveIssueColumn(workspaceID, issueNumber, types.ColInProgress); err != nil {
 		return err
 	}
-	if _, err := a.mgr.SpawnExecute(ws, types.Issue{Number: issueNumber, WorkspaceID: workspaceID}, plan); err != nil {
+	// Issue #22: SpawnExecute derives the branch slug from Issue.Title, so we
+	// load the full row instead of passing a stub. Fall back to the stub if
+	// the issue isn't in the store (e.g., conductor-only test rows that
+	// somehow lost their record), so an approved plan still spawns.
+	issue, err := a.store.LoadIssue(workspaceID, issueNumber)
+	if err != nil {
+		log.Printf("ApprovePlan: load issue #%d failed (%v); spawning with empty title", issueNumber, err)
+		issue = types.Issue{Number: issueNumber, WorkspaceID: workspaceID}
+	}
+	if _, err := a.mgr.SpawnExecute(ws, issue, plan); err != nil {
 		return err
 	}
 	a.bus.Publish(eventbus.EvtPlanApproved, map[string]any{

--- a/frontend/src/components/WorkspacesPanel.tsx
+++ b/frontend/src/components/WorkspacesPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { RemoveWorkspace } from "../../wailsjs/go/main/App";
+import { GCWorktrees, RemoveWorkspace } from "../../wailsjs/go/main/App";
 import { useWorkspaceStore } from "../stores/workspaceStore";
 import { AddWorkspaceForm } from "./AddWorkspaceForm";
 import { SkillProfileEditor } from "./SkillProfileEditor";
@@ -9,6 +9,7 @@ export function WorkspacesPanel() {
   const [adding, setAdding] = useState(false);
   const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<string | null>(null);
+  const [gcBusy, setGcBusy] = useState<string | null>(null);
 
   useEffect(() => {
     refresh();
@@ -18,6 +19,18 @@ export function WorkspacesPanel() {
     await RemoveWorkspace(id);
     await refresh();
     setConfirmRemove(null);
+  }
+
+  async function gc(id: string) {
+    setGcBusy(id);
+    try {
+      const removed = await GCWorktrees(id);
+      alert(`Removed ${removed} worktree(s).`);
+    } catch (err) {
+      alert(`GC worktrees failed: ${err}`);
+    } finally {
+      setGcBusy(null);
+    }
   }
 
   return (
@@ -68,6 +81,14 @@ export function WorkspacesPanel() {
                     className="text-xs text-slate-400 hover:text-slate-200"
                   >
                     {isExpanded ? "Collapse" : "Skills…"}
+                  </button>
+                  <button
+                    onClick={() => gc(ws.id)}
+                    disabled={gcBusy === ws.id}
+                    className="text-xs text-slate-400 hover:text-amber-300 disabled:opacity-50"
+                    title="Remove all per-execute git worktrees under .prismconductor/worktrees/"
+                  >
+                    {gcBusy === ws.id ? "GC…" : "GC worktrees"}
                   </button>
                   {confirmRemove === ws.id ? (
                     <div className="flex gap-1 text-xs">

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -24,6 +24,8 @@ export function DeleteLabel(arg1:string,arg2:string):Promise<void>;
 
 export function FilterIssuesByActiveGoal(arg1:Array<types.Issue>):Promise<Array<types.Issue>>;
 
+export function GCWorktrees(arg1:string):Promise<number>;
+
 export function GetAutoPullPaused():Promise<boolean>;
 
 export function GetNotifyPrefs():Promise<main.NotifyPrefs>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -34,6 +34,10 @@ export function FilterIssuesByActiveGoal(arg1) {
   return window['go']['main']['App']['FilterIssuesByActiveGoal'](arg1);
 }
 
+export function GCWorktrees(arg1) {
+  return window['go']['main']['App']['GCWorktrees'](arg1);
+}
+
 export function GetAutoPullPaused() {
   return window['go']['main']['App']['GetAutoPullPaused']();
 }

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -1,0 +1,114 @@
+// Package git wraps the small set of `git worktree` operations the session
+// manager needs to spawn and reap per-execute worktrees (issue #22).
+package git
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Add fetches origin and creates a worktree at dir on a fresh branch off
+// origin/<base>. Uses `-B` so a leftover branch from a prior failed run is
+// reset rather than reported as a conflict.
+func Add(repoPath, branch, dir, base string) error {
+	if _, err := run(repoPath, "git", "fetch", "origin"); err != nil {
+		return fmt.Errorf("fetch origin: %w", err)
+	}
+	out, err := run(repoPath, "git", "worktree", "add", "-B", branch, dir, "origin/"+base)
+	if err != nil {
+		return fmt.Errorf("worktree add %s -> %s: %w (output: %s)", branch, dir, err, out)
+	}
+	return nil
+}
+
+// Remove tears down a worktree directory and deregisters it. Force-flag is
+// always set: the conductor never asks for graceful removal because the worker
+// process owns the tree and the conductor's only opportunity to clean is post-
+// session.
+func Remove(repoPath, dir string) error {
+	out, err := run(repoPath, "git", "worktree", "remove", "--force", dir)
+	if err != nil {
+		return fmt.Errorf("worktree remove %s: %w (output: %s)", dir, err, out)
+	}
+	return nil
+}
+
+// Prune deregisters worktrees whose directories no longer exist on disk.
+func Prune(repoPath string) error {
+	_, err := run(repoPath, "git", "worktree", "prune")
+	return err
+}
+
+// Entry is one line of `git worktree list --porcelain` output.
+type Entry struct {
+	Path   string
+	Branch string
+	HEAD   string
+}
+
+// List returns the registered worktrees for repoPath, including the primary
+// checkout. Caller filters by path prefix.
+func List(repoPath string) ([]Entry, error) {
+	out, err := run(repoPath, "git", "worktree", "list", "--porcelain")
+	if err != nil {
+		return nil, err
+	}
+	return parseWorktreeList(out), nil
+}
+
+// HasSubmodules reports whether the worktree has a .gitmodules file at its
+// root. Called after Add (q4=D) so InitSubmodules only fires on repos that
+// actually use submodules.
+func HasSubmodules(worktreeDir string) bool {
+	_, err := run(worktreeDir, "test", "-f", ".gitmodules")
+	return err == nil
+}
+
+// InitSubmodules runs `git submodule update --init --recursive` from inside
+// the worktree. Slow for large submodules; this is the documented cost of the
+// q4=D "complete checkout" choice.
+func InitSubmodules(worktreeDir string) error {
+	out, err := run(worktreeDir, "git", "submodule", "update", "--init", "--recursive")
+	if err != nil {
+		return fmt.Errorf("submodule init: %w (output: %s)", err, out)
+	}
+	return nil
+}
+
+func parseWorktreeList(out string) []Entry {
+	var entries []Entry
+	var cur Entry
+	flush := func() {
+		if cur.Path != "" {
+			entries = append(entries, cur)
+		}
+		cur = Entry{}
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			flush()
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			cur.Path = strings.TrimPrefix(line, "worktree ")
+		case strings.HasPrefix(line, "HEAD "):
+			cur.HEAD = strings.TrimPrefix(line, "HEAD ")
+		case strings.HasPrefix(line, "branch "):
+			cur.Branch = strings.TrimPrefix(line, "branch ")
+		}
+	}
+	flush()
+	return entries
+}
+
+func run(dir, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -1,0 +1,61 @@
+package git
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseWorktreeList(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []Entry
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: nil,
+		},
+		{
+			name: "single worktree",
+			in: "worktree /repo\n" +
+				"HEAD abc123\n" +
+				"branch refs/heads/main\n",
+			want: []Entry{
+				{Path: "/repo", HEAD: "abc123", Branch: "refs/heads/main"},
+			},
+		},
+		{
+			name: "two worktrees with trailing whitespace",
+			in: "worktree /repo\n" +
+				"HEAD abc123\n" +
+				"branch refs/heads/main\n" +
+				"\n" +
+				"worktree /repo/.prismconductor/worktrees/ws-7\n" +
+				"HEAD def456\n" +
+				"branch refs/heads/feat/issue-7-foo\n" +
+				"\n",
+			want: []Entry{
+				{Path: "/repo", HEAD: "abc123", Branch: "refs/heads/main"},
+				{Path: "/repo/.prismconductor/worktrees/ws-7", HEAD: "def456", Branch: "refs/heads/feat/issue-7-foo"},
+			},
+		},
+		{
+			name: "detached head has no branch line",
+			in: "worktree /repo\n" +
+				"HEAD abc123\n" +
+				"detached\n",
+			want: []Entry{
+				{Path: "/repo", HEAD: "abc123"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseWorktreeList(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("parseWorktreeList\n got: %#v\nwant: %#v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 
 	"prismconductor/internal/eventbus"
+	pcgit "prismconductor/internal/git"
 	"prismconductor/internal/types"
 )
 
@@ -77,6 +78,13 @@ type runtimeSession struct {
 	lastAction     string
 	lastActionAt   time.Time
 	lastEmittedAt  time.Time
+
+	// Issue #22: per-execute worktree fields. Empty for plan/raw spawns.
+	// repoPath is captured here so the cleanup hook in tailAndParse doesn't
+	// need a workspace registry lookup at teardown time.
+	worktreeDir string
+	branch      string
+	repoPath    string
 }
 
 func NewManager(bus *eventbus.Bus, emit LineHandler) *Manager {
@@ -109,9 +117,127 @@ func (m *Manager) SpawnPlan(ws types.Workspace, issue types.Issue) (*types.Sessi
 }
 
 // SpawnExecute launches an execute-mode worker per §10.2.
+//
+// Issue #22: each execute runs inside a per-(workspace, issue) git worktree
+// off origin/<DefaultBranch>. The conductor — not the skill — owns the
+// worktree's lifecycle: created here before pty.Start, torn down by
+// tailAndParse on Blocked/Failed (immediate, q2=A) or by the 24h GC walk on
+// Completed (q3=A).
 func (m *Manager) SpawnExecute(ws types.Workspace, issue types.Issue, plan types.Plan) (*types.Session, error) {
+	base := ws.DefaultBranch
+	if base == "" {
+		base = "main"
+	}
+	slug := branchSlug(issue.Title)
+	branch := fmt.Sprintf("feat/issue-%d-%s", issue.Number, slug)
+	worktreeDir := filepath.Join(ws.RepoPath, ".prismconductor", "worktrees",
+		fmt.Sprintf("%s-%d", ws.ID, issue.Number))
+
+	// Idempotency: a prior failed run may have left a worktree at this exact
+	// path. Force-remove first so `worktree add -B` succeeds. The error is
+	// ignored because the common case is "no such worktree" — Add will fail
+	// loudly if a real problem remains.
+	_ = pcgit.Remove(ws.RepoPath, worktreeDir)
+	if err := pcgit.Add(ws.RepoPath, branch, worktreeDir, base); err != nil {
+		return nil, fmt.Errorf("prepare worktree: %w", err)
+	}
+
+	// q4=D: auto-init submodules inside the new worktree so the worker has a
+	// complete checkout. The cost is paid up-front (potentially minutes for
+	// large submodules) instead of risking a mid-run BLOCKED on a missing path.
+	if pcgit.HasSubmodules(worktreeDir) {
+		if err := pcgit.InitSubmodules(worktreeDir); err != nil {
+			_ = pcgit.Remove(ws.RepoPath, worktreeDir)
+			return nil, fmt.Errorf("prepare worktree (submodules): %w", err)
+		}
+	}
+
+	// q1=A: copy plan + answers JSON from the main checkout's .prismconductor/
+	// (gitignored, so absent in the fresh worktree) so the worker's cwd-
+	// relative reads succeed. Hard fail on missing plan — a worker can't
+	// execute without it.
+	if err := mirrorPlanArtifacts(ws.RepoPath, worktreeDir, issue.Number, plan.Revision); err != nil {
+		_ = pcgit.Remove(ws.RepoPath, worktreeDir)
+		return nil, fmt.Errorf("mirror plan artifacts: %w", err)
+	}
+
 	args := buildExecuteCommand(ws, issue, plan)
-	return m.spawn(ws, issue, types.ModeExecute, args)
+	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute, args, worktreeDir, branch)
+	if err != nil {
+		_ = pcgit.Remove(ws.RepoPath, worktreeDir)
+		return nil, err
+	}
+	return sess, nil
+}
+
+// branchSlug derives a kebab-case branch suffix from an issue title, lowering
+// case, replacing non-alphanumeric runs with single dashes, capping at 40
+// characters, and falling back to "work" when the title yields nothing.
+func branchSlug(title string) string {
+	title = strings.ToLower(title)
+	var b strings.Builder
+	prevDash := true
+	for _, r := range title {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+		if b.Len() >= 40 {
+			break
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		out = "work"
+	}
+	return out
+}
+
+// mirrorPlanArtifacts copies the rev-N plan (required) and answers (optional,
+// pre-execute may have no questions) JSON files from the main checkout's
+// .prismconductor/ into the worktree's .prismconductor/. The worker's cwd is
+// the worktree, so its relative reads in the conductor-execute skill resolve
+// here.
+func mirrorPlanArtifacts(repoPath, worktreeDir string, num, rev int) error {
+	pairs := []struct {
+		subdir   string
+		name     string
+		required bool
+	}{
+		{"plans", fmt.Sprintf("%d-rev%d.json", num, rev), true},
+		{"answers", fmt.Sprintf("%d-rev%d.json", num, rev), false},
+	}
+	for _, p := range pairs {
+		src := filepath.Join(repoPath, ".prismconductor", p.subdir, p.name)
+		info, err := os.Stat(src)
+		if err != nil {
+			if p.required {
+				return fmt.Errorf("plan file missing: %s", src)
+			}
+			continue
+		}
+		if info.IsDir() {
+			continue
+		}
+		dst := filepath.Join(worktreeDir, ".prismconductor", p.subdir, p.name)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		b, err := os.ReadFile(src)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(dst, b, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SpawnRaw runs a non-skill command via PTY (used by the day-1 demo: `claude --version`).
@@ -122,11 +248,21 @@ func (m *Manager) SpawnRaw(ws types.Workspace, name string, args []string) (*typ
 }
 
 func (m *Manager) spawn(ws types.Workspace, issue types.Issue, mode types.SessionMode, argv []string) (*types.Session, error) {
+	return m.spawnWithDir(ws, issue, mode, argv, "", "")
+}
+
+// spawnWithDir is the canonical spawn path. When worktreeDir is non-empty the
+// child process runs there instead of ws.RepoPath, and the worktree metadata
+// is captured on the runtimeSession for the cleanup hook in tailAndParse.
+func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types.SessionMode, argv []string, worktreeDir, branch string) (*types.Session, error) {
 	if len(argv) == 0 {
 		return nil, fmt.Errorf("empty command")
 	}
 	cmd := exec.Command(argv[0], argv[1:]...)
-	if ws.RepoPath != "" {
+	switch {
+	case worktreeDir != "":
+		cmd.Dir = worktreeDir
+	case ws.RepoPath != "":
 		cmd.Dir = ws.RepoPath
 	}
 	cmd.Env = append(os.Environ(), envSpecToSlice(ws.AgentEnv)...)
@@ -147,7 +283,16 @@ func (m *Manager) spawn(ws types.Workspace, issue types.Issue, mode types.Sessio
 		PID:         cmd.Process.Pid,
 	}
 
-	rs := &runtimeSession{sess: sess, cmd: cmd, pty: f, cancel: cancel, parser: NewStreamParser()}
+	rs := &runtimeSession{
+		sess:        sess,
+		cmd:         cmd,
+		pty:         f,
+		cancel:      cancel,
+		parser:      NewStreamParser(),
+		worktreeDir: worktreeDir,
+		branch:      branch,
+		repoPath:    ws.RepoPath,
+	}
 
 	if m.transcriptDir != "" {
 		_ = os.MkdirAll(m.transcriptDir, 0o755)
@@ -269,6 +414,22 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 	}
 	if m.bus != nil {
 		m.bus.Publish(eventbus.EvtWorkerSlotFreed, rs.sess.ID)
+	}
+
+	// Issue #22: per-execute worktree teardown.
+	//   q2=A: Blocked/Failed → immediate `git worktree remove --force`. The
+	//         user loses post-mortem `cd` access to the worktree but gains
+	//         deterministic state with no goroutine fanout. A leftover from a
+	//         transient failure is reclaimed by the next startup Prune.
+	//   q3=A: Completed → leave on disk; the 24h GC walk reclaims it later.
+	if rs.worktreeDir != "" {
+		switch rs.sess.State {
+		case types.StateBlocked, types.StateFailed:
+			if err := pcgit.Remove(rs.repoPath, rs.worktreeDir); err != nil {
+				log.Printf("worktree cleanup (terminal=%s) %s: %v",
+					rs.sess.State, rs.worktreeDir, err)
+			}
+		}
 	}
 
 	// Drop from in-process registry so Card iteration doesn't keep finding

--- a/internal/skills/bundle/skills/conductor-execute.md
+++ b/internal/skills/bundle/skills/conductor-execute.md
@@ -7,6 +7,11 @@ description: Resumes an issue from an approved plan plus answered questions. Imp
 
 Bundled by PrismConductor (PRISMCONDUCTOR_PLAN.md §15.7).
 
+> Note (issue #22): the conductor spawns this skill inside a per-execute git
+> worktree off `origin/<BASE>`. The branch is pre-created. The user's primary
+> checkout is unaffected by anything you do here. Multiple parallel execute
+> workers each run in their own worktree.
+
 ## Inputs
 
 - `--issue <number>` (required)
@@ -27,9 +32,16 @@ These steps are mandatory and must run in this order. Do **not** edit any files 
 ### 2. Branch hygiene (NON-NEGOTIABLE)
 
 4. Determine the default branch via `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` (or `git symbolic-ref refs/remotes/origin/HEAD` as fallback). Call it `BASE`.
-5. Refuse to operate on a dirty working tree. If `git status --porcelain` is non-empty:
-   - Print `BLOCKED: working tree has uncommitted changes; resolve before re-running` and exit. Do not stash, do not commit, do not delete.
-6. `git fetch origin` then `git switch -c feat/issue-<num>-<slug> origin/<BASE>`. The slug is a kebab-case truncation of the issue title (≤40 chars). If the branch already exists locally or remotely, use `feat/issue-<num>-<slug>-<short-uuid>` instead — never overwrite an existing branch.
+5. **You are running inside a conductor-managed worktree.** The conductor has
+   already fetched origin, created a fresh `feat/issue-<num>-<slug>` branch off
+   `origin/<BASE>`, and put you on it. Do NOT `git switch` to a different
+   branch. Do NOT `git stash`, do NOT `git reset` — the working tree was just
+   created clean. Sanity check ONLY:
+   ```
+   git status --short            # should be empty
+   git branch --show-current     # should start with feat/issue-<num>-
+   ```
+   If either check fails: print `BLOCKED: worktree integrity check failed — <reason>` and exit. Do not attempt to recover.
 
 ### 3. Implementation
 
@@ -65,6 +77,7 @@ These run before commit. Failures here are **stop-the-world** events: print `BLO
     - The list of files modified
     - **Verification:** lint command + result, build command + result, test command + result with pass/fail counts
     - Anything skipped or flagged for human review
+    - `Workspace mode: per-execute worktree at <pwd>` — surfaces the conductor isolation mode for reviewers (run `pwd` to fill the path).
     - The literal trailer line `Closes #<num>`
 16. Capture the PR URL from the `gh pr create` output.
 

--- a/internal/store/issues.go
+++ b/internal/store/issues.go
@@ -8,6 +8,28 @@ import (
 	"prismconductor/internal/types"
 )
 
+// LoadIssue returns the issue row for (workspaceID, number). Used by the
+// execute spawn path (issue #22) so the branch slug can be derived from the
+// issue title rather than a stub Issue{Number, WorkspaceID}.
+func (s *Store) LoadIssue(workspaceID string, number int) (types.Issue, error) {
+	if s == nil || s.DB == nil {
+		return types.Issue{}, errors.New("store unavailable")
+	}
+	var raw, col string
+	if err := s.DB.QueryRow(
+		`SELECT json, column_name FROM issues WHERE workspace_id = ? AND number = ?`,
+		workspaceID, number,
+	).Scan(&raw, &col); err != nil {
+		return types.Issue{}, err
+	}
+	var iss types.Issue
+	if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+		return types.Issue{}, err
+	}
+	iss.Column = types.BoardColumn(col)
+	return iss, nil
+}
+
 // SaveIssue upserts an issue row. Preserves the existing column_name and
 // manual_order if the row already exists (those are conductor-managed and
 // must not be overwritten by a GitHub poll).

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -3,6 +3,10 @@ package store
 import (
 	"encoding/json"
 	"errors"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 
 	"prismconductor/internal/types"
 )
@@ -65,6 +69,53 @@ func (s *Store) LoadRunningSessions() ([]types.Session, string, error) {
 		}
 	}
 	return out, firstTranscript, rows.Err()
+}
+
+// MostRecentEndedAtForWorktree resolves the most recent terminal-state session
+// for the issue whose number is encoded in the worktree directory name
+// (`<wsID>-<num>`), returning its EndedAt timestamp.
+//
+// Used by the 24h GC walk (issue #22) to decide whether a Completed worktree
+// is old enough to reclaim. Returns ok=false when:
+//   - the path does not encode an issue number,
+//   - no terminal session exists for that issue,
+//   - the matching session has no EndedAt (state set before the timestamp
+//     was persisted; the GC treats this as "unknown, leave alone").
+//
+// Sessions table has no ended_at column; the timestamp lives only inside the
+// JSON blob, so this method unmarshals the row.
+func (s *Store) MostRecentEndedAtForWorktree(workspaceID, worktreePath string) (time.Time, bool, error) {
+	if s == nil || s.DB == nil {
+		return time.Time{}, false, errors.New("store unavailable")
+	}
+	base := filepath.Base(worktreePath)
+	idx := strings.LastIndex(base, "-")
+	if idx < 0 || idx == len(base)-1 {
+		return time.Time{}, false, nil
+	}
+	num, err := strconv.Atoi(base[idx+1:])
+	if err != nil {
+		return time.Time{}, false, nil
+	}
+	var raw string
+	err = s.DB.QueryRow(
+		`SELECT json FROM sessions
+		 WHERE workspace_id = ? AND issue_number = ?
+		   AND state IN ('completed','failed','blocked')
+		 ORDER BY rowid DESC LIMIT 1`,
+		workspaceID, num,
+	).Scan(&raw)
+	if err != nil {
+		return time.Time{}, false, nil
+	}
+	var sess types.Session
+	if err := json.Unmarshal([]byte(raw), &sess); err != nil {
+		return time.Time{}, false, err
+	}
+	if sess.EndedAt == nil {
+		return time.Time{}, false, nil
+	}
+	return *sess.EndedAt, true, nil
 }
 
 // SessionTranscriptPath returns the spool path for a session id.


### PR DESCRIPTION
## Summary

Each execute-mode worker now runs inside a per-(workspace, issue) git worktree at `.prismconductor/worktrees/<wsID>-<num>`, created off `origin/<DefaultBranch>` by the session manager before `pty.Start`. The conductor — not the skill — owns the worktree's lifecycle. Dirty main checkouts no longer block execute spawns; parallel executes of different issues each get their own worktree.

## Files modified

- `internal/git/worktree.go` (new) — thin wrapper for `git worktree add/remove/prune/list` + submodule init.
- `internal/git/worktree_test.go` (new) — table test for `parseWorktreeList`.
- `internal/session/manager.go` — `SpawnExecute` now creates the worktree, mirrors plan/answers JSON, and auto-inits submodules; `runtimeSession` gains `worktreeDir/branch/repoPath`; `tailAndParse` removes the worktree on Blocked/Failed (q2=A).
- `internal/skills/bundle/skills/conductor-execute.md` — drops dirty-tree refusal + `git switch -c`; replaces with sanity check; appends `Workspace mode: …` line to the PR body.
- `internal/store/issues.go` — `LoadIssue(workspaceID, number)` so `ApprovePlan` can pass full issue (Title needed for branch slug).
- `internal/store/sessions.go` — `MostRecentEndedAtForWorktree(workspaceID, worktreePath)` for the 24h GC walk.
- `app.go` — startup `gcWorktreesAll` + 1h ticker (q3=A); `GCWorktrees(workspaceID)` Wails-bound manual recovery; `ApprovePlan` loads full issue.
- `frontend/src/components/WorkspacesPanel.tsx` — `GC worktrees` button per workspace row.
- `frontend/wailsjs/go/main/App.{d.ts,js}` — regenerated by `wails generate module`.
- `PRISMCONDUCTOR_PLAN.md` — new §10.2.1 documenting worker isolation.

## Verification

- **Lint:** `go vet ./...` → exit 0.
- **Frontend typecheck:** `cd frontend && npx tsc --noEmit` → exit 0.
- **Build:** `wails build` → succeeded; bundle written to `build/bin/prismconductor.app`.
- **Tests:** `go test ./...` → all pass (4 packages with tests, including new `prismconductor/internal/git`).

## Resolved questions

- q1=A: copy plan + answers JSON into the worktree's `.prismconductor/` at spawn.
- q2=A: immediate `git worktree remove --force` on Blocked/Failed.
- q3=A: 24h GC at startup + 1h ticker.
- q4=D: auto `git submodule update --init --recursive` when `.gitmodules` is present.
- q5: defaults — new `internal/git/` package; `runtimeSession` extended; `types.Session` not extended; PR body line documents the worktree path.

## Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
