### PR TITLE
Auto-move card to DONE on PR merge (#33)

### DIFF
--- a/app.go
+++ b/app.go
@@ -168,6 +168,7 @@ func (a *App) startup(ctx context.Context) {
 		a.bus.Subscribe(func(e eventbus.Event) {
 			_ = a.store.LogEvent(string(e.Type), e.Payload)
 			wruntime.EventsEmit(a.ctx, "bus."+string(e.Type), e.Payload)
+			a.notifyOnPRStateChange(e)
 		})
 	}
 
@@ -1074,6 +1075,39 @@ func (a *App) handlePROpened(sess types.Session, prURL string) {
 	})
 	_ = notify.Send(titleForWorkspace(a.wsReg, sess.WorkspaceID),
 		fmt.Sprintf("#%d opened PR #%d", sess.IssueNumber, n))
+}
+
+// notifyOnPRStateChange fires an OS notification when the poller publishes
+// a pr_merged or pr_closed_unmerged event (#33). The poller can't call
+// notify.Send directly without an awkward layering import; the bus.Subscribe
+// callback is the cleanest seam. Honors the same mute/quiet-hours gate as
+// session-state notifications.
+func (a *App) notifyOnPRStateChange(e eventbus.Event) {
+	if e.Type != eventbus.EvtPRMerged && e.Type != eventbus.EvtPRClosedUnmerged {
+		return
+	}
+	if a.notificationsSuppressed() {
+		return
+	}
+	payload, _ := e.Payload.(map[string]any)
+	if payload == nil {
+		return
+	}
+	wsID, _ := payload["workspace_id"].(string)
+	issNumF, _ := payload["issue_number"].(float64)
+	issNum := int(issNumF)
+	if v, ok := payload["issue_number"].(int); ok {
+		issNum = v
+	}
+	title := titleForWorkspace(a.wsReg, wsID)
+	var body string
+	switch e.Type {
+	case eventbus.EvtPRMerged:
+		body = fmt.Sprintf("#%d merged → DONE", issNum)
+	case eventbus.EvtPRClosedUnmerged:
+		body = fmt.Sprintf("#%d PR closed without merge", issNum)
+	}
+	_ = notify.Send(title, body)
 }
 
 // LatestPlan returns the highest-revision plan for an issue.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -107,6 +107,11 @@ function App() {
         refreshIssues(selectedWorkspace ?? "");
       },
     );
+    const offPRMerged = EventsOn("bus.pr_merged", () => refreshIssues(selectedWorkspace ?? ""));
+    const offPRClosedUnmerged = EventsOn(
+      "bus.pr_closed_unmerged",
+      () => refreshIssues(selectedWorkspace ?? ""),
+    );
     const offPlanApproved = EventsOn(
       "bus.plan_approved",
       (data: { workspace_id: string; issue_number: number }) => {
@@ -151,6 +156,8 @@ function App() {
       if (typeof offIssue === "function") offIssue();
       if (typeof offPlanReady === "function") offPlanReady();
       if (typeof offPROpened === "function") offPROpened();
+      if (typeof offPRMerged === "function") offPRMerged();
+      if (typeof offPRClosedUnmerged === "function") offPRClosedUnmerged();
       if (typeof offPlanApproved === "function") offPlanApproved();
       if (typeof offPlanRejected === "function") offPlanRejected();
       if (typeof offPoolFreed === "function") offPoolFreed();

--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -16,6 +16,8 @@ const (
 	EvtIssueLabelChanged EventType = "issue_label_changed"
 	EvtPlanReady         EventType = "plan_ready"
 	EvtPROpened          EventType = "pr_opened"
+	EvtPRMerged          EventType = "pr_merged"
+	EvtPRClosedUnmerged  EventType = "pr_closed_unmerged"
 	EvtPlanApproved      EventType = "plan_approved"
 	EvtPlanRejected      EventType = "plan_rejected"
 	EvtPlanRevised       EventType = "plan_revised"

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 
 	gh "github.com/google/go-github/v62/github"
 
@@ -177,6 +178,37 @@ func (c *Client) DeleteLabel(ctx context.Context, ws types.Workspace, name strin
 	}
 	_, err := c.api.Issues.DeleteLabel(ctx, ws.GitHubOwner, ws.GitHubRepo, name)
 	return err
+}
+
+// PRState is the slice of GitHub PR fields the poller uses to drive
+// REVIEW→DONE on merge and chip-clear on close-without-merge (issue #33).
+type PRState struct {
+	State    string
+	MergedAt *time.Time
+	ClosedAt *time.Time
+}
+
+// FetchPRState fetches the current state of a single PR. Used by the poller
+// once per REVIEW-column issue per tick (rate-bounded; ≤ board-size of REVIEW
+// cards on a typical board).
+func (c *Client) FetchPRState(ctx context.Context, ws types.Workspace, prNumber int) (*PRState, error) {
+	if ws.GitHubOwner == "" || ws.GitHubRepo == "" {
+		return nil, fmt.Errorf("workspace %q missing github_owner / github_repo", ws.ID)
+	}
+	pr, _, err := c.api.PullRequests.Get(ctx, ws.GitHubOwner, ws.GitHubRepo, prNumber)
+	if err != nil {
+		return nil, err
+	}
+	out := &PRState{State: pr.GetState()}
+	if pr.MergedAt != nil {
+		ts := pr.MergedAt.Time
+		out.MergedAt = &ts
+	}
+	if pr.ClosedAt != nil {
+		ts := pr.ClosedAt.Time
+		out.ClosedAt = &ts
+	}
+	return out, nil
 }
 
 // SetIssueLabels replaces an issue's labels with the given set.

--- a/internal/github/poll.go
+++ b/internal/github/poll.go
@@ -16,6 +16,8 @@ type Store interface {
 	ListIssues(workspaceID string) ([]types.Issue, error)
 	SaveIssue(iss types.Issue) error
 	MarkIssueClosed(workspaceID string, number int) error
+	MarkPRMerged(workspaceID string, number int) error
+	MarkPRClosedUnmerged(workspaceID string, number int) error
 	SaveLabels(workspaceID string, labels []types.Label) error
 }
 
@@ -184,6 +186,40 @@ func (p *Poller) pollOne(ctx context.Context, ws types.Workspace) error {
 		p.publish(eventbus.EvtIssueClosed, ws, old)
 	}
 
+	// PR-state probe (#33). For every REVIEW-column issue with a PR, ask
+	// GitHub whether it merged or closed-without-merge. Bounded by the size
+	// of the REVIEW column (typically ≤10), so well below the 5000/h
+	// authenticated rate limit. Walk `prev` (not `fresh`) since fresh only
+	// contains open issues — a merged PR's issue is already closed and
+	// missing from the open list.
+	for _, iss := range prev {
+		if iss.PRNumber == nil {
+			continue
+		}
+		if iss.Column != types.ColReview {
+			continue
+		}
+		pr, err := p.Client.FetchPRState(ctx, ws, *iss.PRNumber)
+		if err != nil {
+			log.Printf("pr state %s#%d: %v", ws.ID, iss.Number, err)
+			continue
+		}
+		switch {
+		case pr.MergedAt != nil:
+			if err := p.Store.MarkPRMerged(ws.ID, iss.Number); err != nil {
+				log.Printf("mark pr merged %s#%d: %v", ws.ID, iss.Number, err)
+				continue
+			}
+			p.publishPR(eventbus.EvtPRMerged, ws, iss)
+		case pr.ClosedAt != nil:
+			if err := p.Store.MarkPRClosedUnmerged(ws.ID, iss.Number); err != nil {
+				log.Printf("mark pr closed-unmerged %s#%d: %v", ws.ID, iss.Number, err)
+				continue
+			}
+			p.publishPR(eventbus.EvtPRClosedUnmerged, ws, iss)
+		}
+	}
+
 	// Piggy-back label fetch on the same tick. Failures are logged and don't
 	// abort the issue cycle (the cache stays stale until the next tick).
 	if labels, err := p.Client.ListLabels(ctx, ws); err != nil {
@@ -205,6 +241,25 @@ func (p *Poller) publish(t eventbus.EventType, ws types.Workspace, iss types.Iss
 		"number":       iss.Number,
 		"title":        iss.Title,
 	})
+}
+
+// publishPR emits a PR-related event with the same payload shape as
+// app.go's handlePROpened so frontend subscribers can read pr_number / pr_url
+// uniformly across pr_opened / pr_merged / pr_closed_unmerged.
+func (p *Poller) publishPR(t eventbus.EventType, ws types.Workspace, iss types.Issue) {
+	if p.Bus == nil {
+		return
+	}
+	payload := map[string]any{
+		"workspace_id": ws.ID,
+		"issue_number": iss.Number,
+		"title":        iss.Title,
+		"pr_url":       iss.PRURL,
+	}
+	if iss.PRNumber != nil {
+		payload["pr_number"] = *iss.PRNumber
+	}
+	p.Bus.Publish(t, payload)
 }
 
 func sameLabels(a, b []string) bool {

--- a/internal/store/issues.go
+++ b/internal/store/issues.go
@@ -278,6 +278,87 @@ func (s *Store) MarkPROpened(workspaceID string, number int, prNumber int, prURL
 	return tx.Commit()
 }
 
+// MarkPRMerged moves the card to DONE and marks the issue closed, mirroring
+// MarkIssueClosed but driven by the GitHub PR-state probe (#33). Preserves
+// pr_number / pr_url so the chip stays on the DONE card as history. Clears
+// last_error in the same tx so a stale failure string doesn't linger.
+// Idempotent: re-runs are no-ops because the column is already DONE.
+func (s *Store) MarkPRMerged(workspaceID string, number int) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	tx, err := s.DB.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var raw string
+	if err := tx.QueryRow(`SELECT json FROM issues WHERE workspace_id = ? AND number = ?`,
+		workspaceID, number).Scan(&raw); err != nil {
+		return err
+	}
+	var iss types.Issue
+	if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+		return err
+	}
+	iss.State = "closed"
+	iss.Column = types.ColDone
+	iss.LastError = ""
+	b, _ := json.Marshal(iss)
+
+	var maxOrder sql.NullInt64
+	if err := tx.QueryRow(
+		`SELECT COALESCE(MAX(manual_order), -1) FROM issues WHERE workspace_id = ? AND column_name = ?`,
+		workspaceID, string(types.ColDone),
+	).Scan(&maxOrder); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		`UPDATE issues SET column_name = ?, manual_order = ?, json = ? WHERE workspace_id = ? AND number = ?`,
+		string(types.ColDone), maxOrder.Int64+1, string(b), workspaceID, number,
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// MarkPRClosedUnmerged clears pr_number / pr_url on an issue whose PR was
+// closed without merging (#33). Leaves column_name / manual_order alone —
+// per rev2 q2, trust the user's manual placement. Bypasses SaveIssue because
+// SaveIssue's preserve-PR-fields path would resurrect the cleared values on
+// the next poll.
+func (s *Store) MarkPRClosedUnmerged(workspaceID string, number int) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	tx, err := s.DB.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var raw string
+	if err := tx.QueryRow(`SELECT json FROM issues WHERE workspace_id = ? AND number = ?`,
+		workspaceID, number).Scan(&raw); err != nil {
+		return err
+	}
+	var iss types.Issue
+	if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+		return err
+	}
+	iss.PRNumber = nil
+	iss.PRURL = ""
+	b, _ := json.Marshal(iss)
+	if _, err := tx.Exec(
+		`UPDATE issues SET json = ? WHERE workspace_id = ? AND number = ?`,
+		string(b), workspaceID, number,
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 // MarkIssueClosed forces state=closed AND column=done in a single transaction,
 // bypassing SaveIssue's column-preservation logic (which would otherwise keep
 // the closed issue stuck in whatever column the user last placed it in).

--- a/internal/store/issues_test.go
+++ b/internal/store/issues_test.go
@@ -48,6 +48,123 @@ func TestMarkPROpenedMovesCardAndPersistsFields(t *testing.T) {
 	}
 }
 
+func TestMarkPRMergedMovesCardToDoneClearsLastErrorKeepsPRFields(t *testing.T) {
+	s := newTestStore(t)
+	prNum := 99
+	if err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      42,
+		Title:       "thing",
+		State:       "open",
+		Column:      types.ColReview,
+		PRNumber:    &prNum,
+		PRURL:       "https://github.com/o/r/pull/99",
+		LastError:   "stale failure from a prior run",
+	}); err != nil {
+		t.Fatalf("SaveIssue: %v", err)
+	}
+
+	if err := s.MarkPRMerged("ws1", 42); err != nil {
+		t.Fatalf("MarkPRMerged: %v", err)
+	}
+
+	got, err := s.ListIssues("ws1")
+	if err != nil || len(got) != 1 {
+		t.Fatalf("ListIssues: %v len=%d", err, len(got))
+	}
+	iss := got[0]
+	if iss.Column != types.ColDone {
+		t.Errorf("column = %q, want %q", iss.Column, types.ColDone)
+	}
+	if iss.State != "closed" {
+		t.Errorf("state = %q, want closed", iss.State)
+	}
+	if iss.LastError != "" {
+		t.Errorf("LastError = %q, want empty", iss.LastError)
+	}
+	if iss.PRNumber == nil || *iss.PRNumber != 99 {
+		t.Errorf("PRNumber = %v, want 99 (kept as history)", iss.PRNumber)
+	}
+	if iss.PRURL != "https://github.com/o/r/pull/99" {
+		t.Errorf("PRURL = %q, want kept as history", iss.PRURL)
+	}
+}
+
+func TestMarkPRClosedUnmergedClearsPRFieldsAndPreservesColumn(t *testing.T) {
+	s := newTestStore(t)
+	prNum := 12
+	if err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      7,
+		Title:       "thing",
+		State:       "open",
+		Column:      types.ColReview,
+		PRNumber:    &prNum,
+		PRURL:       "https://github.com/o/r/pull/12",
+	}); err != nil {
+		t.Fatalf("SaveIssue: %v", err)
+	}
+
+	if err := s.MarkPRClosedUnmerged("ws1", 7); err != nil {
+		t.Fatalf("MarkPRClosedUnmerged: %v", err)
+	}
+
+	got, err := s.ListIssues("ws1")
+	if err != nil || len(got) != 1 {
+		t.Fatalf("ListIssues: %v len=%d", err, len(got))
+	}
+	iss := got[0]
+	if iss.PRNumber != nil {
+		t.Errorf("PRNumber = %v, want nil", iss.PRNumber)
+	}
+	if iss.PRURL != "" {
+		t.Errorf("PRURL = %q, want empty", iss.PRURL)
+	}
+	if iss.Column != types.ColReview {
+		t.Errorf("column = %q, want %q (column must be preserved)", iss.Column, types.ColReview)
+	}
+}
+
+// Regression: SaveIssue's preserve-PR-fields path at issues.go:57-67 would
+// resurrect the cleared values after the next poll. Ensure the cleared state
+// survives a subsequent SaveIssue call with no PR fields on the fresh row.
+func TestMarkPRClosedUnmergedSurvivesNextPoll(t *testing.T) {
+	s := newTestStore(t)
+	prNum := 12
+	if err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      7,
+		Title:       "thing",
+		State:       "open",
+		Column:      types.ColReview,
+		PRNumber:    &prNum,
+		PRURL:       "https://github.com/o/r/pull/12",
+	}); err != nil {
+		t.Fatalf("SaveIssue: %v", err)
+	}
+	if err := s.MarkPRClosedUnmerged("ws1", 7); err != nil {
+		t.Fatalf("MarkPRClosedUnmerged: %v", err)
+	}
+	if err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      7,
+		Title:       "thing (refreshed)",
+		State:       "open",
+	}); err != nil {
+		t.Fatalf("SaveIssue refresh: %v", err)
+	}
+	got, err := s.ListIssues("ws1")
+	if err != nil || len(got) != 1 {
+		t.Fatalf("ListIssues: %v len=%d", err, len(got))
+	}
+	if got[0].PRNumber != nil {
+		t.Errorf("PRNumber resurrected by SaveIssue: %v", got[0].PRNumber)
+	}
+	if got[0].PRURL != "" {
+		t.Errorf("PRURL resurrected by SaveIssue: %q", got[0].PRURL)
+	}
+}
+
 func TestSaveIssuePreservesPRFieldsAcrossPolls(t *testing.T) {
 	s := newTestStore(t)
 	if err := s.SaveIssue(types.Issue{


### PR DESCRIPTION
## Summary

When a PR opened by an execute worker is merged on GitHub, the card now moves REVIEW → DONE on the next poll cycle (≤5 min, instant on `↻ Refresh`). When the PR is closed without merging, the PR chip is cleared but the card stays in whatever column the user placed it in. Both transitions ride the existing 5-min poller — no new polling loop, in keeping with PRISMCONDUCTOR_PLAN.md §7.

Asymmetry (per rev2 answers): merged PRs keep `pr_number` / `pr_url` as a history chip on DONE; abandoned PRs clear them.

## Files modified

- `internal/github/client.go` — `PRState` struct + `FetchPRState`.
- `internal/github/poll.go` — `Store` interface widened with `MarkPRMerged` / `MarkPRClosedUnmerged`; per-REVIEW-card probe appended to `pollOne`; `publishPR` helper.
- `internal/store/issues.go` — `MarkPRMerged` (REVIEW → DONE, clears `LastError`, keeps PR fields) and `MarkPRClosedUnmerged` (clears `PRNumber` / `PRURL` only; column untouched). Both bypass `SaveIssue` so the cleared fields aren't resurrected by the preserve-PR-fields path on the next poll.
- `internal/store/issues_test.go` — three new tests covering merge transition, close-unmerged transition, and the close-unmerged-survives-next-poll regression.
- `internal/eventbus/bus.go` — `EvtPRMerged` and `EvtPRClosedUnmerged` constants.
- `app.go` — `notifyOnPRStateChange` helper wired into the existing `a.bus.Subscribe` callback; honors `notificationsSuppressed()` (mute + quiet hours).
- `frontend/src/App.tsx` — subscriptions to `bus.pr_merged` / `bus.pr_closed_unmerged` that refresh issues; cleanup wired.

## Verification

- Lint: `go vet ./...` — exit 0
- Build: `go build ./...` — exit 0
- Tests: `go test ./...` — all packages pass (full suite, including the new `TestMarkPRMergedMovesCardToDoneClearsLastErrorKeepsPRFields`, `TestMarkPRClosedUnmergedClearsPRFieldsAndPreservesColumn`, `TestMarkPRClosedUnmergedSurvivesNextPoll`)
- Frontend typecheck: `cd frontend && npx tsc --noEmit` — exit 0

## Skipped / flagged for human review

- Acceptance criterion #5 from the issue body ("With #30 landed: card_state on merge transitions to `done`, card_state_reason clears") is **deferred** — issue #30 is still open and the `card_state` field doesn't exist on `Issue` today. When #30 lands, `MarkPRMerged` / `MarkPRClosedUnmerged` are the natural place to also write `card_state` in the same tx.
- Manual end-to-end check (drive a worker through PR-open, merge on GitHub, click Refresh, confirm REVIEW→DONE) was **not** performed by the worker — only the unit tests were exercised. Reviewer should manual-test before un-drafting.
- No `FetchPRState` unit test (would need a real GitHub hit or a fake; the existing client has no test scaffolding).
- No poller integration test (no existing poller test scaffold).

Closes #33
