### PR TITLE
Archive Done button: hide shipped cards from the board (#34)

### DIFF
--- a/PRISMCONDUCTOR_PLAN.md
+++ b/PRISMCONDUCTOR_PLAN.md
@@ -268,6 +268,7 @@ type Issue struct {
     LastError      string          `json:"last_error,omitempty"`
     PRNumber       *int            `json:"pr_number,omitempty"` // set when execute worker emits PR_OPENED:
     PRURL          string          `json:"pr_url,omitempty"`    // canonical github.com/.../pull/N
+    ArchivedAt     *time.Time      `json:"archived_at,omitempty"` // local visual archive (#34); null = visible on board
 }
 
 type BoardColumn string
@@ -766,7 +767,7 @@ SQLite database at `~/Library/Application Support/PrismConductor/conductor.db`.
 Tables:
 - `workspaces` — registry
 - `goals` — all goals with status
-- `issues` — local mirror with conductor-managed fields
+- `issues` — local mirror with conductor-managed fields. `archived_at` (INTEGER, nullable, unix seconds) is the visual archive flag (#34); rows with `archived_at IS NOT NULL` are excluded from `ListIssues` and surface only in the Archived drawer.
 - `plans` — historical plan revisions, JSON blob
 - `sessions` — session log, transcript path
 - `events` — append-only event log for debugging

--- a/app.go
+++ b/app.go
@@ -534,13 +534,81 @@ func (a *App) ActivateGoal(id string) error {
 
 // --- Issues / Board ---
 
-// ListIssues returns all issues, optionally filtered by workspace ID.
-// Empty workspaceID = all workspaces.
+// ListIssues returns all non-archived issues, optionally filtered by workspace ID.
+// Empty workspaceID = all workspaces. Archived rows (#34) are excluded; use
+// ListArchivedIssues for the drawer.
 func (a *App) ListIssues(workspaceID string) ([]types.Issue, error) {
 	if a.store == nil {
 		return nil, fmt.Errorf("store unavailable")
 	}
 	return a.store.ListIssues(workspaceID)
+}
+
+// ListArchivedIssues returns archived rows for the drawer (#34). Empty
+// workspaceID returns archived rows across every workspace.
+func (a *App) ListArchivedIssues(workspaceID string) ([]types.Issue, error) {
+	if a.store == nil {
+		return nil, fmt.Errorf("store unavailable")
+	}
+	return a.store.ListArchivedIssues(workspaceID)
+}
+
+// ArchiveDone flags every DONE row in the workspace as archived (#34). Returns
+// the count archived. Empty workspaceID archives across every workspace
+// (matches the All switcher case). Publishes EvtIssuesArchived when n > 0 so
+// the live list and the drawer's (N) badge both refresh.
+func (a *App) ArchiveDone(workspaceID string) (int, error) {
+	if a.store == nil {
+		return 0, fmt.Errorf("store unavailable")
+	}
+	n, err := a.store.ArchiveDone(workspaceID)
+	if err != nil {
+		return 0, err
+	}
+	if n > 0 && a.bus != nil {
+		a.bus.Publish(eventbus.EvtIssuesArchived, map[string]any{
+			"workspace_id": workspaceID,
+			"count":        n,
+		})
+	}
+	return n, nil
+}
+
+// UnarchiveIssue clears archived_at for a single row (#34) and publishes
+// EvtIssuesArchived so the live list and drawer both refresh.
+func (a *App) UnarchiveIssue(workspaceID string, number int) error {
+	if a.store == nil {
+		return fmt.Errorf("store unavailable")
+	}
+	if err := a.store.UnarchiveIssue(workspaceID, number); err != nil {
+		return err
+	}
+	if a.bus != nil {
+		a.bus.Publish(eventbus.EvtIssuesArchived, map[string]any{
+			"workspace_id": workspaceID,
+			"number":       number,
+			"count":        -1,
+		})
+	}
+	return nil
+}
+
+// UnarchiveAll clears archived_at across the workspace (#34). Empty
+// workspaceID restores everything across every workspace.
+func (a *App) UnarchiveAll(workspaceID string) error {
+	if a.store == nil {
+		return fmt.Errorf("store unavailable")
+	}
+	if err := a.store.UnarchiveAll(workspaceID); err != nil {
+		return err
+	}
+	if a.bus != nil {
+		a.bus.Publish(eventbus.EvtIssuesArchived, map[string]any{
+			"workspace_id": workspaceID,
+			"count":        -1,
+		})
+	}
+	return nil
 }
 
 // MoveIssueColumn moves an issue card between columns. Emits EvtCardMovedManually
@@ -837,7 +905,7 @@ func (a *App) SetIssueLabels(workspaceID string, issueNumber int, names []string
 				continue
 			}
 			iss.Labels = append([]string(nil), names...)
-			if err := a.store.SaveIssue(iss); err != nil {
+			if _, err := a.store.SaveIssue(iss); err != nil {
 				log.Printf("optimistic label save #%d: %v", issueNumber, err)
 			}
 			break
@@ -871,7 +939,7 @@ func (a *App) AddManualIssue(workspaceID string, number int, title, body string,
 		State:       "open",
 		Column:      types.BoardColumn(column),
 	}
-	if err := a.store.SaveIssue(iss); err != nil {
+	if _, err := a.store.SaveIssue(iss); err != nil {
 		return nil, err
 	}
 	a.bus.Publish(eventbus.EvtIssueAdded, map[string]any{

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { EventsOn } from "../wailsjs/runtime/runtime";
 import {
   GetAutoPullPaused,
   GetWorkerPoolStatus,
+  ListArchivedIssues,
   ListPendingPlans,
   ListSessions,
   RefreshIssuesNow,
@@ -20,8 +21,9 @@ import { WorkspaceSwitcher } from "./components/WorkspaceSwitcher";
 import { SessionDrawer } from "./components/SessionDrawer";
 import { Settings } from "./components/Settings";
 import { PlanModal } from "./components/PlanModal";
+import { ArchivedDrawer } from "./components/ArchivedDrawer";
 import { AddIssueQuick } from "./components/AddIssueQuick";
-import { useIssueStore } from "./stores/issueStore";
+import { useArchivedStore, useIssueStore } from "./stores/issueStore";
 import { useGoalStore } from "./stores/goalStore";
 import { usePlanReadyStore } from "./stores/planReadyStore";
 import { useLabelsStore } from "./stores/labelsStore";
@@ -54,6 +56,22 @@ function App() {
   }, [issues, planTarget]);
   const [busy, setBusy] = useState(false);
   const [issueInput, setIssueInput] = useState("");
+  const [archivedOpen, setArchivedOpen] = useState(false);
+  const [archivedCount, setArchivedCount] = useState(0);
+  const refreshArchived = useArchivedStore((s) => s.refresh);
+
+  const refreshArchivedCount = useCallback(async () => {
+    try {
+      const list = await ListArchivedIssues(selectedWorkspace ?? "");
+      setArchivedCount(list?.length ?? 0);
+    } catch {
+      setArchivedCount(0);
+    }
+  }, [selectedWorkspace]);
+
+  useEffect(() => {
+    refreshArchivedCount();
+  }, [refreshArchivedCount]);
 
   useEffect(() => {
     refreshWorkspaces();
@@ -147,6 +165,11 @@ function App() {
       "bus.auto_pull_paused_changed",
       (data: { paused: boolean }) => setAutoPaused(!!data?.paused),
     );
+    const offArchived = EventsOn("bus.issues_archived", () => {
+      refreshIssues(selectedWorkspace ?? "");
+      refreshArchived(selectedWorkspace ?? "");
+      refreshArchivedCount();
+    });
     return () => {
       if (typeof offLine === "function") offLine();
       if (typeof offState === "function") offState();
@@ -169,8 +192,9 @@ function App() {
       if (typeof offGhLabel === "function") offGhLabel();
       if (typeof offLabelsUpdated === "function") offLabelsUpdated();
       if (typeof offPause === "function") offPause();
+      if (typeof offArchived === "function") offArchived();
     };
-  }, [appendLine, setMeta, refreshWorkspaces, refreshGoals, refreshIssues, markPlanReady, clearPlanReady, selectedWorkspace]);
+  }, [appendLine, setMeta, refreshWorkspaces, refreshGoals, refreshIssues, markPlanReady, clearPlanReady, selectedWorkspace, refreshArchived, refreshArchivedCount]);
 
   async function spawnDemo() {
     setBusy(true);
@@ -293,7 +317,10 @@ function App() {
           </button>
         </div>
       </header>
-      <WorkspaceSwitcher />
+      <WorkspaceSwitcher
+        archivedCount={archivedCount}
+        onOpenArchived={() => setArchivedOpen(true)}
+      />
       <GoalPane />
       <div className="px-4 py-1 border-b border-slate-800 flex items-center gap-3">
         <span className="text-xs text-slate-500">+ test issue:</span>
@@ -316,6 +343,11 @@ function App() {
         open={planTarget !== null}
         onClose={() => setPlanTarget(null)}
         issue={planIssue}
+      />
+      <ArchivedDrawer
+        open={archivedOpen}
+        onClose={() => setArchivedOpen(false)}
+        workspaceID={selectedWorkspace ?? ""}
       />
     </div>
   );

--- a/frontend/src/components/ArchivedDrawer.tsx
+++ b/frontend/src/components/ArchivedDrawer.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useMemo } from "react";
+import { types } from "../../wailsjs/go/models";
+import { useArchivedStore } from "../stores/issueStore";
+import { useWorkspaceStore } from "../stores/workspaceStore";
+
+function relativeTime(input: any): string {
+  if (!input) return "";
+  const d = input instanceof Date ? input : new Date(input);
+  if (isNaN(d.getTime())) return "";
+  const diffSec = Math.max(0, Math.floor((Date.now() - d.getTime()) / 1000));
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 30) return `${diffDay}d ago`;
+  const diffMo = Math.floor(diffDay / 30);
+  if (diffMo < 12) return `${diffMo}mo ago`;
+  return `${Math.floor(diffMo / 12)}y ago`;
+}
+
+export function ArchivedDrawer({
+  open,
+  onClose,
+  workspaceID,
+}: {
+  open: boolean;
+  onClose: () => void;
+  workspaceID: string;
+}) {
+  const { archived, refresh, unarchive, unarchiveAll, loading } = useArchivedStore();
+  const workspaces = useWorkspaceStore((s) => s.workspaces);
+
+  useEffect(() => {
+    if (open) refresh(workspaceID);
+  }, [open, workspaceID, refresh]);
+
+  const wsMeta = useMemo(() => {
+    const m = new Map<string, { color: string; label: string }>();
+    workspaces.forEach((w) => m.set(w.id, { color: w.color, label: w.display_name || w.id }));
+    return m;
+  }, [workspaces]);
+
+  if (!open) return null;
+
+  const handleRestoreAll = async () => {
+    if (archived.length === 0) return;
+    if (
+      archived.length > 5 &&
+      !window.confirm(`Restore all ${archived.length} archived cards?`)
+    ) {
+      return;
+    }
+    await unarchiveAll(workspaceID);
+  };
+
+  return (
+    <div className="fixed right-0 top-0 h-full w-[420px] bg-slate-950 border-l border-slate-800 flex flex-col z-30">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-slate-800">
+        <div className="text-sm text-slate-200">
+          🗄 Archived <span className="text-slate-500">({archived.length})</span>
+        </div>
+        <button className="text-slate-400 hover:text-slate-200" onClick={onClose}>
+          ✕
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {loading && archived.length === 0 ? (
+          <div className="px-3 py-4 text-xs text-slate-500">loading…</div>
+        ) : archived.length === 0 ? (
+          <div className="px-3 py-4 text-xs text-slate-500">
+            Nothing archived in this workspace yet.
+          </div>
+        ) : (
+          <ul className="divide-y divide-slate-800">
+            {archived.map((iss) => (
+              <ArchivedRow
+                key={`${iss.workspace_id}#${iss.number}`}
+                iss={iss}
+                wsColor={wsMeta.get(iss.workspace_id)?.color}
+                wsLabel={wsMeta.get(iss.workspace_id)?.label}
+                onRestore={() => unarchive(iss.workspace_id, iss.number)}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="px-3 py-2 border-t border-slate-800">
+        <button
+          onClick={handleRestoreAll}
+          disabled={archived.length === 0}
+          className="text-xs px-2 py-1 border border-slate-700 rounded text-slate-300 hover:bg-slate-800 disabled:opacity-40"
+        >
+          🔁 Restore all ({archived.length})
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ArchivedRow({
+  iss,
+  wsColor,
+  wsLabel,
+  onRestore,
+}: {
+  iss: types.Issue;
+  wsColor?: string;
+  wsLabel?: string;
+  onRestore: () => void;
+}) {
+  return (
+    <li className="px-3 py-2 flex items-center gap-2">
+      <span
+        className="inline-block w-2 h-2 rounded-full shrink-0"
+        style={{ backgroundColor: wsColor || "#64748b" }}
+        title={wsLabel ?? iss.workspace_id}
+      />
+      <div className="flex-1 min-w-0">
+        <div className="text-xs text-slate-200 truncate">
+          <span className="text-slate-500">#{iss.number}</span> {iss.title}
+        </div>
+        <div className="text-[10px] text-slate-500">
+          archived {relativeTime((iss as any).archived_at)}
+        </div>
+      </div>
+      <button
+        onClick={onRestore}
+        title="Restore to DONE"
+        className="text-xs px-1.5 py-0.5 rounded border border-slate-700 text-slate-400 hover:text-slate-200 hover:border-slate-500"
+      >
+        🔁
+      </button>
+    </li>
+  );
+}

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { EventsOn } from "../../wailsjs/runtime/runtime";
 import {
   CollisionDetection,
@@ -14,7 +14,7 @@ import {
   useSensors,
 } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
-import { FilterIssuesByActiveGoal } from "../../wailsjs/go/main/App";
+import { ArchiveDone, FilterIssuesByActiveGoal } from "../../wailsjs/go/main/App";
 import { types } from "../../wailsjs/go/models";
 import { useIssueStore, Column as ColumnID } from "../stores/issueStore";
 import { useWorkspaceStore } from "../stores/workspaceStore";
@@ -225,6 +225,15 @@ export function Board({ onCardClick }: { onCardClick?: (issue: types.Issue) => v
 
   const activeIssue = activeId ? findIssue(activeId) : null;
 
+  const archiveDone = useCallback(async () => {
+    const items = grouped.done ?? [];
+    const count = items.length;
+    if (count === 0) return;
+    if (count > 5 && !window.confirm(`Archive ${count} cards from DONE?`)) return;
+    await ArchiveDone(selectedID ?? "");
+    refresh(selectedID ?? "");
+  }, [grouped.done, selectedID, refresh]);
+
   return (
     <DndContext
       sensors={sensors}
@@ -240,8 +249,25 @@ export function Board({ onCardClick }: { onCardClick?: (issue: types.Issue) => v
       <div className="flex gap-3 px-4 pb-4 overflow-x-auto h-full">
         {COLUMNS.map((c) => {
           const items = grouped[c.id] ?? [];
+          const headerExtra =
+            c.id === "done" && items.length > 0 ? (
+              <button
+                onClick={archiveDone}
+                title={`Archive all ${items.length} DONE card${items.length === 1 ? "" : "s"}`}
+                className="text-[10px] text-slate-500 hover:text-slate-200 px-1.5 py-0.5 rounded border border-slate-800 hover:border-slate-600"
+              >
+                📦 Archive {items.length}
+              </button>
+            ) : undefined;
           return (
-            <Column key={c.id} id={c.id} title={c.title} count={items.length} itemIDs={items.map(cardID)}>
+            <Column
+              key={c.id}
+              id={c.id}
+              title={c.title}
+              count={items.length}
+              itemIDs={items.map(cardID)}
+              headerExtra={headerExtra}
+            >
               {items.map((iss) => {
                 const meta = wsMeta.get(iss.workspace_id);
                 return (

--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -9,12 +9,14 @@ export function Column({
   count,
   itemIDs,
   children,
+  headerExtra,
 }: {
   id: string;
   title: string;
   count: number;
   itemIDs: string[];
   children?: ReactNode;
+  headerExtra?: ReactNode;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id, data: { column: id } });
 
@@ -26,8 +28,11 @@ export function Column({
         isOver ? "bg-slate-800/60 border-emerald-700" : "bg-slate-900/40 border-slate-800",
       )}
     >
-      <div className="text-xs uppercase tracking-wide text-slate-400 mb-2 px-1">
-        {title} <span className="text-slate-500">({count})</span>
+      <div className="flex items-center text-xs uppercase tracking-wide text-slate-400 mb-2 px-1">
+        <span>
+          {title} <span className="text-slate-500">({count})</span>
+        </span>
+        {headerExtra && <span className="ml-auto">{headerExtra}</span>}
       </div>
       <SortableContext items={itemIDs} strategy={verticalListSortingStrategy}>
         <div className="space-y-1 min-h-[40px]">{children}</div>

--- a/frontend/src/components/WorkspaceSwitcher.tsx
+++ b/frontend/src/components/WorkspaceSwitcher.tsx
@@ -2,7 +2,13 @@ import { useEffect, useState } from "react";
 import { useWorkspaceStore } from "../stores/workspaceStore";
 import { LabelsModal } from "./LabelsModal";
 
-export function WorkspaceSwitcher() {
+export function WorkspaceSwitcher({
+  archivedCount = 0,
+  onOpenArchived,
+}: {
+  archivedCount?: number;
+  onOpenArchived?: () => void;
+}) {
   const { workspaces, selectedID, setSelected, refresh, loading } = useWorkspaceStore();
   const [labelsOpen, setLabelsOpen] = useState(false);
   const labelsTarget = selectedID ?? workspaces[0]?.id ?? "";
@@ -50,6 +56,21 @@ export function WorkspaceSwitcher() {
           title="Manage labels for the active workspace"
         >
           🏷  Manage labels
+        </button>
+      )}
+      {onOpenArchived && (
+        <button
+          onClick={onOpenArchived}
+          className={
+            "px-2 py-0.5 rounded border text-xs " +
+            (labelsTarget ? "" : "ml-auto ") +
+            (archivedCount > 0
+              ? "border-slate-700 text-slate-300 hover:text-slate-100 hover:border-slate-500"
+              : "border-slate-800 text-slate-600 hover:text-slate-400")
+          }
+          title="Show archived issues"
+        >
+          🗄 Archived ({archivedCount})
         </button>
       )}
       <LabelsModal

--- a/frontend/src/stores/issueStore.ts
+++ b/frontend/src/stores/issueStore.ts
@@ -1,9 +1,12 @@
 import { create } from "zustand";
 import {
+  ListArchivedIssues,
   ListIssues,
   MoveIssueColumn,
   RemoveIssue,
   ReorderIssues,
+  UnarchiveAll,
+  UnarchiveIssue,
 } from "../../wailsjs/go/main/App";
 import { types } from "../../wailsjs/go/models";
 
@@ -73,4 +76,42 @@ export const useIssueStore = create<State>((set, get) => ({
       const others = s.issues.filter((i) => !(i.workspace_id === workspaceID && i.column === column));
       return { issues: [...others, ...inCol] };
     }),
+}));
+
+// Archived list lives in its own store so the live `issues` array doesn't
+// collide on set({issues}). Workspace-scoped (#34 q3): the (N) badge counts
+// every archived issue in the active workspace regardless of any active
+// IssueQuery / goal filter.
+type ArchivedState = {
+  archived: types.Issue[];
+  loading: boolean;
+  refresh: (workspaceID?: string) => Promise<void>;
+  unarchive: (workspaceID: string, number: number) => Promise<void>;
+  unarchiveAll: (workspaceID: string) => Promise<void>;
+};
+
+export const useArchivedStore = create<ArchivedState>((set) => ({
+  archived: [],
+  loading: false,
+  refresh: async (workspaceID) => {
+    set({ loading: true });
+    try {
+      const list = await ListArchivedIssues(workspaceID ?? "");
+      set({ archived: list ?? [], loading: false });
+    } catch {
+      set({ loading: false });
+    }
+  },
+  unarchive: async (workspaceID, number) => {
+    await UnarchiveIssue(workspaceID, number);
+    set((s) => ({
+      archived: s.archived.filter(
+        (i) => !(i.workspace_id === workspaceID && i.number === number),
+      ),
+    }));
+  },
+  unarchiveAll: async (workspaceID) => {
+    await UnarchiveAll(workspaceID);
+    set({ archived: [] });
+  },
 }));

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -16,6 +16,8 @@ export function AddWorkspace(arg1:types.Workspace):Promise<void>;
 
 export function ApprovePlan(arg1:string,arg2:number,arg3:number):Promise<void>;
 
+export function ArchiveDone(arg1:string):Promise<number>;
+
 export function CreateLabel(arg1:string,arg2:types.Label):Promise<types.Label>;
 
 export function DeleteGoal(arg1:string):Promise<void>;
@@ -51,6 +53,8 @@ export function InspectRepo(arg1:string):Promise<workspace.Inspection>;
 export function KillSession(arg1:string):Promise<void>;
 
 export function LatestPlan(arg1:string,arg2:number):Promise<types.Plan>;
+
+export function ListArchivedIssues(arg1:string):Promise<Array<types.Issue>>;
 
 export function ListBundledSkills():Promise<Array<main.BundledSkill>>;
 
@@ -119,6 +123,10 @@ export function SpawnDemo():Promise<types.Session>;
 export function SpawnPlanForIssue(arg1:string,arg2:number):Promise<types.Session>;
 
 export function SubmitAnswers(arg1:main.AnswerSubmission):Promise<void>;
+
+export function UnarchiveAll(arg1:string):Promise<void>;
+
+export function UnarchiveIssue(arg1:string,arg2:number):Promise<void>;
 
 export function UpdateLabel(arg1:string,arg2:string,arg3:types.Label):Promise<types.Label>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -18,6 +18,10 @@ export function ApprovePlan(arg1, arg2, arg3) {
   return window['go']['main']['App']['ApprovePlan'](arg1, arg2, arg3);
 }
 
+export function ArchiveDone(arg1) {
+  return window['go']['main']['App']['ArchiveDone'](arg1);
+}
+
 export function CreateLabel(arg1, arg2) {
   return window['go']['main']['App']['CreateLabel'](arg1, arg2);
 }
@@ -88,6 +92,10 @@ export function KillSession(arg1) {
 
 export function LatestPlan(arg1, arg2) {
   return window['go']['main']['App']['LatestPlan'](arg1, arg2);
+}
+
+export function ListArchivedIssues(arg1) {
+  return window['go']['main']['App']['ListArchivedIssues'](arg1);
 }
 
 export function ListBundledSkills() {
@@ -224,6 +232,14 @@ export function SpawnPlanForIssue(arg1, arg2) {
 
 export function SubmitAnswers(arg1) {
   return window['go']['main']['App']['SubmitAnswers'](arg1);
+}
+
+export function UnarchiveAll(arg1) {
+  return window['go']['main']['App']['UnarchiveAll'](arg1);
+}
+
+export function UnarchiveIssue(arg1, arg2) {
+  return window['go']['main']['App']['UnarchiveIssue'](arg1, arg2);
 }
 
 export function UpdateLabel(arg1, arg2, arg3) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1155,6 +1155,8 @@ export namespace types {
 	    last_error?: string;
 	    pr_number?: number;
 	    pr_url?: string;
+	    // Go type: time
+	    archived_at?: any;
 	
 	    static createFrom(source: any = {}) {
 	        return new Issue(source);
@@ -1180,6 +1182,7 @@ export namespace types {
 	        this.last_error = source["last_error"];
 	        this.pr_number = source["pr_number"];
 	        this.pr_url = source["pr_url"];
+	        this.archived_at = this.convertValues(source["archived_at"], null);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -27,6 +27,7 @@ const (
 	EvtAgentCountChanged EventType = "agent_count_changed"
 	EvtLabelsUpdated     EventType = "labels_updated"
 	EvtAutoPullPausedChanged EventType = "auto_pull_paused_changed"
+	EvtIssuesArchived        EventType = "issues_archived"
 )
 
 type Event struct {

--- a/internal/github/poll.go
+++ b/internal/github/poll.go
@@ -14,7 +14,7 @@ import (
 // Store is the slice of *store.Store the poller needs.
 type Store interface {
 	ListIssues(workspaceID string) ([]types.Issue, error)
-	SaveIssue(iss types.Issue) error
+	SaveIssue(iss types.Issue) (bool, error)
 	MarkIssueClosed(workspaceID string, number int) error
 	MarkPRMerged(workspaceID string, number int) error
 	MarkPRClosedUnmerged(workspaceID string, number int) error
@@ -154,9 +154,15 @@ func (p *Poller) pollOne(ctx context.Context, ws types.Workspace) error {
 		old, hadOld := prevByNum[fr.Number]
 		// SaveIssue preserves existing column_name + manual_order — see
 		// internal/store/issues.go. So a poll won't trample a user's drag.
-		if err := p.Store.SaveIssue(fr); err != nil {
+		// unarchived=true when an archived row was just cleared because the
+		// fresh row's state == "open" (#34 q2 auto-unarchive on reopen).
+		unarchived, err := p.Store.SaveIssue(fr)
+		if err != nil {
 			log.Printf("save issue %s#%d: %v", ws.ID, fr.Number, err)
 			continue
+		}
+		if unarchived {
+			p.publish(eventbus.EvtIssuesArchived, ws, fr)
 		}
 		if !hadOld {
 			p.publish(eventbus.EvtIssueAdded, ws, fr)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -18,7 +18,7 @@ import (
 // Store is the slice of *store.Store we need.
 type Store interface {
 	ListIssues(workspaceID string) ([]types.Issue, error)
-	SaveIssue(iss types.Issue) error
+	SaveIssue(iss types.Issue) (bool, error)
 	ListGoals() ([]types.Goal, error)
 	GetGoal(id string) (types.Goal, error)
 	DepCacheGet(workspaceID string, issueNumber int, goalID, bodyHash string) (string, bool, error)
@@ -461,7 +461,7 @@ func (o *Orchestrator) applyResult(goal types.Goal, candidates []types.Issue, re
 			updated.Dependencies = nil
 			updated.DepRationale = ""
 		}
-		if err := o.store.SaveIssue(updated); err != nil {
+		if _, err := o.store.SaveIssue(updated); err != nil {
 			return err
 		}
 
@@ -505,7 +505,7 @@ func (o *Orchestrator) recomputeBlocked() error {
 		if len(stillOpen) != len(iss.Dependencies) {
 			updated := iss
 			updated.Dependencies = stillOpen
-			_ = o.store.SaveIssue(updated)
+			_, _ = o.store.SaveIssue(updated)
 		}
 	}
 	return nil

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -20,7 +20,7 @@ func (s *stubStore) ListIssues(string) ([]types.Issue, error) {
 	s.listIssuesHits++
 	return s.issues, nil
 }
-func (s *stubStore) SaveIssue(types.Issue) error { return nil }
+func (s *stubStore) SaveIssue(types.Issue) (bool, error) { return false, nil }
 func (s *stubStore) ListGoals() ([]types.Goal, error) {
 	s.listGoalsHits++
 	return s.goals, nil

--- a/internal/store/issues.go
+++ b/internal/store/issues.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"time"
 
 	"prismconductor/internal/types"
 )
@@ -33,9 +34,14 @@ func (s *Store) LoadIssue(workspaceID string, number int) (types.Issue, error) {
 // SaveIssue upserts an issue row. Preserves the existing column_name and
 // manual_order if the row already exists (those are conductor-managed and
 // must not be overwritten by a GitHub poll).
-func (s *Store) SaveIssue(iss types.Issue) error {
+//
+// Returns (unarchived, err): unarchived is true when an existing archived row
+// was just cleared because the incoming issue's state == "open" (#34 q2:
+// reopening on GitHub auto-unarchives). The caller should publish
+// EvtIssuesArchived so the drawer's (N) badge refreshes.
+func (s *Store) SaveIssue(iss types.Issue) (bool, error) {
 	if s == nil || s.DB == nil {
-		return errors.New("store unavailable")
+		return false, errors.New("store unavailable")
 	}
 	col := iss.Column
 	if col == "" {
@@ -45,12 +51,14 @@ func (s *Store) SaveIssue(iss types.Issue) error {
 	// Look up existing column + manual_order so a poll-driven re-save doesn't
 	// nuke the user's drag-and-drop placement. Also pull the prior JSON so we
 	// can preserve conductor-managed scalars (pr_number / pr_url) that the
-	// fresh GitHub fetch knows nothing about.
+	// fresh GitHub fetch knows nothing about. archived_at lives in its own
+	// column so we read it directly to decide auto-unarchive on reopen.
 	var existingCol sql.NullString
 	var existingOrder sql.NullInt64
 	var existingJSON sql.NullString
-	row := s.DB.QueryRow(`SELECT column_name, manual_order, json FROM issues WHERE workspace_id = ? AND number = ?`, iss.WorkspaceID, iss.Number)
-	_ = row.Scan(&existingCol, &existingOrder, &existingJSON)
+	var existingArchivedAt sql.NullInt64
+	row := s.DB.QueryRow(`SELECT column_name, manual_order, json, archived_at FROM issues WHERE workspace_id = ? AND number = ?`, iss.WorkspaceID, iss.Number)
+	_ = row.Scan(&existingCol, &existingOrder, &existingJSON, &existingArchivedAt)
 	if existingCol.Valid {
 		col = types.BoardColumn(existingCol.String)
 	}
@@ -67,27 +75,51 @@ func (s *Store) SaveIssue(iss types.Issue) error {
 	}
 	iss.Column = col
 
+	// Decide new archived_at: a state=open save clears it (auto-unarchive on
+	// GitHub reopen); anything else preserves the existing value.
+	var newArchivedAt any
+	unarchived := false
+	if iss.State == "open" {
+		if existingArchivedAt.Valid {
+			unarchived = true
+		}
+		// newArchivedAt stays nil → SET clears the column.
+	} else if existingArchivedAt.Valid {
+		newArchivedAt = existingArchivedAt.Int64
+	}
+	if newArchivedAt != nil {
+		t := time.Unix(newArchivedAt.(int64), 0).UTC()
+		iss.ArchivedAt = &t
+	} else {
+		iss.ArchivedAt = nil
+	}
+
 	b, err := json.Marshal(iss)
 	if err != nil {
-		return err
+		return false, err
 	}
 	var manualOrder any
 	if existingOrder.Valid {
 		manualOrder = existingOrder.Int64
 	}
-	_, err = s.DB.Exec(`
-INSERT INTO issues (workspace_id, number, column_name, manual_order, json)
-VALUES (?, ?, ?, ?, ?)
+	if _, err := s.DB.Exec(`
+INSERT INTO issues (workspace_id, number, column_name, manual_order, json, archived_at)
+VALUES (?, ?, ?, ?, ?, ?)
 ON CONFLICT(workspace_id, number) DO UPDATE SET
     column_name = excluded.column_name,
     manual_order = excluded.manual_order,
-    json = excluded.json`,
-		iss.WorkspaceID, iss.Number, string(col), manualOrder, string(b))
-	return err
+    json = excluded.json,
+    archived_at = excluded.archived_at`,
+		iss.WorkspaceID, iss.Number, string(col), manualOrder, string(b), newArchivedAt); err != nil {
+		return false, err
+	}
+	return unarchived, nil
 }
 
-// ListIssues returns all issues, optionally filtered by workspace.
-// Empty workspaceID = all workspaces.
+// ListIssues returns all non-archived issues, optionally filtered by workspace.
+// Empty workspaceID = all workspaces. Archived rows (#34) are filtered out
+// here so Card / Column / Board never see them; use ListArchivedIssues for the
+// drawer.
 func (s *Store) ListIssues(workspaceID string) ([]types.Issue, error) {
 	if s == nil || s.DB == nil {
 		return nil, nil
@@ -97,9 +129,9 @@ func (s *Store) ListIssues(workspaceID string) ([]types.Issue, error) {
 		err  error
 	)
 	if workspaceID == "" {
-		rows, err = s.DB.Query(`SELECT json, column_name, manual_order FROM issues ORDER BY column_name, manual_order, number`)
+		rows, err = s.DB.Query(`SELECT json, column_name, manual_order, archived_at FROM issues WHERE archived_at IS NULL ORDER BY column_name, manual_order, number`)
 	} else {
-		rows, err = s.DB.Query(`SELECT json, column_name, manual_order FROM issues WHERE workspace_id = ? ORDER BY column_name, manual_order, number`, workspaceID)
+		rows, err = s.DB.Query(`SELECT json, column_name, manual_order, archived_at FROM issues WHERE workspace_id = ? AND archived_at IS NULL ORDER BY column_name, manual_order, number`, workspaceID)
 	}
 	if err != nil {
 		return nil, err
@@ -109,7 +141,8 @@ func (s *Store) ListIssues(workspaceID string) ([]types.Issue, error) {
 	for rows.Next() {
 		var raw, col string
 		var manual sql.NullInt64
-		if err := rows.Scan(&raw, &col, &manual); err != nil {
+		var archivedAt sql.NullInt64
+		if err := rows.Scan(&raw, &col, &manual, &archivedAt); err != nil {
 			return nil, err
 		}
 		var iss types.Issue
@@ -117,9 +150,99 @@ func (s *Store) ListIssues(workspaceID string) ([]types.Issue, error) {
 			continue
 		}
 		iss.Column = types.BoardColumn(col)
+		if archivedAt.Valid {
+			t := time.Unix(archivedAt.Int64, 0).UTC()
+			iss.ArchivedAt = &t
+		} else {
+			iss.ArchivedAt = nil
+		}
 		out = append(out, iss)
 	}
 	return out, rows.Err()
+}
+
+// ListArchivedIssues returns archived rows (archived_at IS NOT NULL) for the
+// given workspace, newest-archived first. Empty workspaceID = all workspaces.
+func (s *Store) ListArchivedIssues(workspaceID string) ([]types.Issue, error) {
+	if s == nil || s.DB == nil {
+		return nil, nil
+	}
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if workspaceID == "" {
+		rows, err = s.DB.Query(`SELECT json, column_name, manual_order, archived_at FROM issues WHERE archived_at IS NOT NULL ORDER BY archived_at DESC, number`)
+	} else {
+		rows, err = s.DB.Query(`SELECT json, column_name, manual_order, archived_at FROM issues WHERE workspace_id = ? AND archived_at IS NOT NULL ORDER BY archived_at DESC, number`, workspaceID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []types.Issue
+	for rows.Next() {
+		var raw, col string
+		var manual sql.NullInt64
+		var archivedAt sql.NullInt64
+		if err := rows.Scan(&raw, &col, &manual, &archivedAt); err != nil {
+			return nil, err
+		}
+		var iss types.Issue
+		if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+			continue
+		}
+		iss.Column = types.BoardColumn(col)
+		if archivedAt.Valid {
+			t := time.Unix(archivedAt.Int64, 0).UTC()
+			iss.ArchivedAt = &t
+		}
+		out = append(out, iss)
+	}
+	return out, rows.Err()
+}
+
+// ArchiveDone flags every DONE row in the workspace as archived (unix seconds
+// now) — bypasses SaveIssue so column_name / manual_order / JSON stay intact.
+// Empty workspaceID archives across every workspace (matches the All switcher
+// case). Returns the count archived.
+func (s *Store) ArchiveDone(workspaceID string) (int, error) {
+	if s == nil || s.DB == nil {
+		return 0, errors.New("store unavailable")
+	}
+	res, err := s.DB.Exec(`
+UPDATE issues
+SET archived_at = strftime('%s','now')
+WHERE column_name = 'done' AND archived_at IS NULL
+  AND (? = '' OR workspace_id = ?)`,
+		workspaceID, workspaceID)
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(n), nil
+}
+
+// UnarchiveIssue clears archived_at for a single (workspaceID, number) row.
+func (s *Store) UnarchiveIssue(workspaceID string, number int) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	_, err := s.DB.Exec(`UPDATE issues SET archived_at = NULL WHERE workspace_id = ? AND number = ?`, workspaceID, number)
+	return err
+}
+
+// UnarchiveAll clears archived_at across every archived row in the workspace.
+// Empty workspaceID restores everything across every workspace.
+func (s *Store) UnarchiveAll(workspaceID string) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	_, err := s.DB.Exec(`UPDATE issues SET archived_at = NULL WHERE archived_at IS NOT NULL AND (? = '' OR workspace_id = ?)`, workspaceID, workspaceID)
+	return err
 }
 
 // MoveIssueColumn updates the column for an issue and resets manual_order to

--- a/internal/store/issues_test.go
+++ b/internal/store/issues_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"testing"
+	"time"
 
 	"prismconductor/internal/types"
 )
@@ -18,7 +19,7 @@ func newTestStore(t *testing.T) *Store {
 
 func TestMarkPROpenedMovesCardAndPersistsFields(t *testing.T) {
 	s := newTestStore(t)
-	if err := s.SaveIssue(types.Issue{
+	if _, err := s.SaveIssue(types.Issue{
 		WorkspaceID: "ws1",
 		Number:      42,
 		Title:       "thing",
@@ -51,7 +52,7 @@ func TestMarkPROpenedMovesCardAndPersistsFields(t *testing.T) {
 func TestMarkPRMergedMovesCardToDoneClearsLastErrorKeepsPRFields(t *testing.T) {
 	s := newTestStore(t)
 	prNum := 99
-	if err := s.SaveIssue(types.Issue{
+	if _, err := s.SaveIssue(types.Issue{
 		WorkspaceID: "ws1",
 		Number:      42,
 		Title:       "thing",
@@ -93,7 +94,7 @@ func TestMarkPRMergedMovesCardToDoneClearsLastErrorKeepsPRFields(t *testing.T) {
 func TestMarkPRClosedUnmergedClearsPRFieldsAndPreservesColumn(t *testing.T) {
 	s := newTestStore(t)
 	prNum := 12
-	if err := s.SaveIssue(types.Issue{
+	if _, err := s.SaveIssue(types.Issue{
 		WorkspaceID: "ws1",
 		Number:      7,
 		Title:       "thing",
@@ -131,7 +132,7 @@ func TestMarkPRClosedUnmergedClearsPRFieldsAndPreservesColumn(t *testing.T) {
 func TestMarkPRClosedUnmergedSurvivesNextPoll(t *testing.T) {
 	s := newTestStore(t)
 	prNum := 12
-	if err := s.SaveIssue(types.Issue{
+	if _, err := s.SaveIssue(types.Issue{
 		WorkspaceID: "ws1",
 		Number:      7,
 		Title:       "thing",
@@ -145,7 +146,7 @@ func TestMarkPRClosedUnmergedSurvivesNextPoll(t *testing.T) {
 	if err := s.MarkPRClosedUnmerged("ws1", 7); err != nil {
 		t.Fatalf("MarkPRClosedUnmerged: %v", err)
 	}
-	if err := s.SaveIssue(types.Issue{
+	if _, err := s.SaveIssue(types.Issue{
 		WorkspaceID: "ws1",
 		Number:      7,
 		Title:       "thing (refreshed)",
@@ -167,7 +168,7 @@ func TestMarkPRClosedUnmergedSurvivesNextPoll(t *testing.T) {
 
 func TestSaveIssuePreservesPRFieldsAcrossPolls(t *testing.T) {
 	s := newTestStore(t)
-	if err := s.SaveIssue(types.Issue{
+	if _, err := s.SaveIssue(types.Issue{
 		WorkspaceID: "ws1",
 		Number:      7,
 		Title:       "polled",
@@ -181,7 +182,7 @@ func TestSaveIssuePreservesPRFieldsAcrossPolls(t *testing.T) {
 		t.Fatalf("MarkPROpened: %v", err)
 	}
 	// Simulate a poll-driven re-save where GitHub knows nothing about pr_number / pr_url.
-	if err := s.SaveIssue(types.Issue{
+	if _, err := s.SaveIssue(types.Issue{
 		WorkspaceID: "ws1",
 		Number:      7,
 		Title:       "polled (refreshed)",
@@ -205,5 +206,274 @@ func TestSaveIssuePreservesPRFieldsAcrossPolls(t *testing.T) {
 	}
 	if iss.Column != types.ColReview {
 		t.Errorf("column lost across poll: %q", iss.Column)
+	}
+}
+
+// --- Archive (#34) ---
+
+func seedDone(t *testing.T, s *Store, ws string, num int) {
+	t.Helper()
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID: ws,
+		Number:      num,
+		Title:       "done card",
+		State:       "closed",
+		Column:      types.ColDone,
+	}); err != nil {
+		t.Fatalf("seed SaveIssue ws=%s #%d: %v", ws, num, err)
+	}
+}
+
+func TestArchiveDoneScopedToWorkspace(t *testing.T) {
+	s := newTestStore(t)
+	seedDone(t, s, "ws1", 1)
+	seedDone(t, s, "ws1", 2)
+	seedDone(t, s, "ws2", 3)
+
+	n, err := s.ArchiveDone("ws1")
+	if err != nil {
+		t.Fatalf("ArchiveDone: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("archived count = %d, want 2", n)
+	}
+
+	live1, _ := s.ListIssues("ws1")
+	if len(live1) != 0 {
+		t.Errorf("ws1 still shows %d non-archived rows, want 0", len(live1))
+	}
+	live2, _ := s.ListIssues("ws2")
+	if len(live2) != 1 || live2[0].Number != 3 {
+		t.Errorf("ws2 should be untouched: got %+v", live2)
+	}
+	arch1, _ := s.ListArchivedIssues("ws1")
+	if len(arch1) != 2 {
+		t.Errorf("ws1 archived = %d, want 2", len(arch1))
+	}
+	for _, iss := range arch1 {
+		if iss.ArchivedAt == nil {
+			t.Errorf("archived row #%d missing ArchivedAt", iss.Number)
+		}
+	}
+}
+
+func TestArchiveDoneEmptyWorkspaceArchivesAll(t *testing.T) {
+	s := newTestStore(t)
+	seedDone(t, s, "ws1", 1)
+	seedDone(t, s, "ws2", 2)
+
+	n, err := s.ArchiveDone("")
+	if err != nil {
+		t.Fatalf("ArchiveDone: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("archived count = %d, want 2", n)
+	}
+	all, _ := s.ListIssues("")
+	if len(all) != 0 {
+		t.Errorf("expected zero non-archived rows after global archive, got %d", len(all))
+	}
+}
+
+func TestArchiveDoneSkipsNonDoneColumns(t *testing.T) {
+	s := newTestStore(t)
+	cols := []types.BoardColumn{types.ColTodo, types.ColPlan, types.ColInProgress, types.ColReview}
+	for i, c := range cols {
+		if _, err := s.SaveIssue(types.Issue{
+			WorkspaceID: "ws1",
+			Number:      i + 1,
+			Title:       "x",
+			State:       "open",
+			Column:      c,
+		}); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	n, err := s.ArchiveDone("ws1")
+	if err != nil {
+		t.Fatalf("ArchiveDone: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("archived count = %d, want 0", n)
+	}
+	live, _ := s.ListIssues("ws1")
+	if len(live) != len(cols) {
+		t.Errorf("non-DONE rows lost: got %d, want %d", len(live), len(cols))
+	}
+}
+
+func TestListIssuesHidesArchived(t *testing.T) {
+	s := newTestStore(t)
+	seedDone(t, s, "ws1", 1)
+	seedDone(t, s, "ws1", 2)
+	if _, err := s.ArchiveDone("ws1"); err != nil {
+		t.Fatalf("ArchiveDone: %v", err)
+	}
+	// Add a fresh non-archived row.
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      3,
+		Title:       "fresh",
+		State:       "open",
+		Column:      types.ColTodo,
+	}); err != nil {
+		t.Fatalf("SaveIssue: %v", err)
+	}
+	live, _ := s.ListIssues("ws1")
+	if len(live) != 1 || live[0].Number != 3 {
+		t.Errorf("ListIssues should return only #3, got %+v", live)
+	}
+}
+
+func TestListArchivedIssuesReturnsArchivedDesc(t *testing.T) {
+	s := newTestStore(t)
+	seedDone(t, s, "ws1", 1)
+	seedDone(t, s, "ws1", 2)
+	seedDone(t, s, "ws1", 3)
+	// Archive in 3 staggered batches via direct UPDATE so ordering is testable.
+	if _, err := s.DB.Exec(`UPDATE issues SET archived_at = 100 WHERE number = 1`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DB.Exec(`UPDATE issues SET archived_at = 300 WHERE number = 2`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DB.Exec(`UPDATE issues SET archived_at = 200 WHERE number = 3`); err != nil {
+		t.Fatal(err)
+	}
+	arch, err := s.ListArchivedIssues("ws1")
+	if err != nil {
+		t.Fatalf("ListArchivedIssues: %v", err)
+	}
+	if len(arch) != 3 {
+		t.Fatalf("len = %d, want 3", len(arch))
+	}
+	want := []int{2, 3, 1}
+	for i, iss := range arch {
+		if iss.Number != want[i] {
+			t.Errorf("ordering[%d] = #%d, want #%d", i, iss.Number, want[i])
+		}
+	}
+}
+
+func TestUnarchiveIssueRestoresVisibility(t *testing.T) {
+	s := newTestStore(t)
+	seedDone(t, s, "ws1", 1)
+	seedDone(t, s, "ws1", 2)
+	if _, err := s.ArchiveDone("ws1"); err != nil {
+		t.Fatalf("ArchiveDone: %v", err)
+	}
+	if err := s.UnarchiveIssue("ws1", 1); err != nil {
+		t.Fatalf("UnarchiveIssue: %v", err)
+	}
+	live, _ := s.ListIssues("ws1")
+	if len(live) != 1 || live[0].Number != 1 {
+		t.Errorf("after unarchive ListIssues = %+v, want only #1", live)
+	}
+	arch, _ := s.ListArchivedIssues("ws1")
+	if len(arch) != 1 || arch[0].Number != 2 {
+		t.Errorf("archived = %+v, want only #2", arch)
+	}
+}
+
+func TestUnarchiveAllRestoresEverything(t *testing.T) {
+	s := newTestStore(t)
+	seedDone(t, s, "ws1", 1)
+	seedDone(t, s, "ws2", 2)
+	if _, err := s.ArchiveDone(""); err != nil {
+		t.Fatalf("ArchiveDone: %v", err)
+	}
+	if err := s.UnarchiveAll(""); err != nil {
+		t.Fatalf("UnarchiveAll: %v", err)
+	}
+	arch, _ := s.ListArchivedIssues("")
+	if len(arch) != 0 {
+		t.Errorf("after UnarchiveAll archived = %d, want 0", len(arch))
+	}
+}
+
+func TestArchiveDoneIdempotent(t *testing.T) {
+	s := newTestStore(t)
+	seedDone(t, s, "ws1", 1)
+	if _, err := s.ArchiveDone("ws1"); err != nil {
+		t.Fatalf("ArchiveDone first: %v", err)
+	}
+	n, err := s.ArchiveDone("ws1")
+	if err != nil {
+		t.Fatalf("ArchiveDone second: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("second ArchiveDone returned %d, want 0", n)
+	}
+}
+
+func TestSaveIssueAutoUnarchivesOnReopen(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      42,
+		Title:       "thing",
+		State:       "closed",
+		Column:      types.ColDone,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := s.ArchiveDone("ws1"); err != nil {
+		t.Fatalf("ArchiveDone: %v", err)
+	}
+	// Now GitHub poll shows it state=open again.
+	unarchived, err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      42,
+		Title:       "thing (reopened)",
+		State:       "open",
+		UpdatedAt:   time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("SaveIssue reopen: %v", err)
+	}
+	if !unarchived {
+		t.Errorf("unarchived = false, want true")
+	}
+	live, _ := s.ListIssues("ws1")
+	if len(live) != 1 || live[0].Number != 42 {
+		t.Errorf("reopened row missing from ListIssues: %+v", live)
+	}
+	if live[0].ArchivedAt != nil {
+		t.Errorf("ArchivedAt = %v, want nil after reopen", live[0].ArchivedAt)
+	}
+}
+
+func TestSaveIssuePreservesArchivedAtOnClosedRoundtrip(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      42,
+		Title:       "thing",
+		State:       "closed",
+		Column:      types.ColDone,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := s.ArchiveDone("ws1"); err != nil {
+		t.Fatalf("ArchiveDone: %v", err)
+	}
+	// A subsequent state=closed save (e.g. a hypothetical poller pass that
+	// somehow re-sees the row as closed) must not clear archived_at.
+	unarchived, err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      42,
+		Title:       "thing again",
+		State:       "closed",
+		Column:      types.ColDone,
+	})
+	if err != nil {
+		t.Fatalf("SaveIssue: %v", err)
+	}
+	if unarchived {
+		t.Errorf("unarchived = true on state=closed save, want false")
+	}
+	arch, _ := s.ListArchivedIssues("ws1")
+	if len(arch) != 1 {
+		t.Errorf("archived row count = %d, want 1 (preserved)", len(arch))
 	}
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	_ "modernc.org/sqlite"
 )
@@ -90,5 +91,15 @@ CREATE TABLE IF NOT EXISTS labels (
     PRIMARY KEY (workspace_id, name)
 );
 `)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Idempotent additive column for issue archiving (#34). Unix seconds; NULL = not archived.
+	if _, err := s.DB.Exec(`ALTER TABLE issues ADD COLUMN archived_at INTEGER`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column name") {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -107,6 +107,7 @@ type Issue struct {
 	LastError    string      `json:"last_error,omitempty"`
 	PRNumber     *int        `json:"pr_number,omitempty"`
 	PRURL        string      `json:"pr_url,omitempty"`
+	ArchivedAt   *time.Time  `json:"archived_at,omitempty"`
 }
 
 type BoardColumn string


### PR DESCRIPTION
## Summary

Adds a `📦 Archive {N}` button to the DONE column header that flags every DONE card with `archived_at = now`. Archived rows disappear from the board and surface in a new `🗄 Archived (N)` side drawer toggled from the workspace-switcher row. Archive is purely local visual cleanup — GitHub state is untouched. Reopening an archived issue on GitHub auto-unarchives it on the next poll tick.

## Files modified

Backend
- `internal/store/sqlite.go` — idempotent `ALTER TABLE issues ADD COLUMN archived_at INTEGER`
- `internal/types/types.go` — `Issue.ArchivedAt *time.Time`
- `internal/eventbus/bus.go` — `EvtIssuesArchived`
- `internal/store/issues.go` — `SaveIssue` returns `(unarchived, err)` and clears `archived_at` on `state=open`; `ListIssues` filters `archived_at IS NULL`; new `ListArchivedIssues` / `ArchiveDone` / `UnarchiveIssue` / `UnarchiveAll`; both list paths hydrate `ArchivedAt`
- `internal/github/poll.go` — `Store.SaveIssue` interface signature updated; publishes `EvtIssuesArchived` when an auto-unarchive fires
- `internal/orchestrator/orchestrator.go` + tests — `Store.SaveIssue` interface signature updated; call sites discard the new bool
- `app.go` — `ArchiveDone`, `UnarchiveIssue`, `UnarchiveAll`, `ListArchivedIssues` bound methods; existing `SaveIssue` callers updated; `EvtIssuesArchived` published on bulk paths

Frontend
- `frontend/src/components/Column.tsx` — optional `headerExtra?: ReactNode` slot on the column header
- `frontend/src/components/Board.tsx` — passes `📦 Archive {N}` button into the DONE column's `headerExtra`; confirms when count > 5
- `frontend/src/components/ArchivedDrawer.tsx` — new right-anchored drawer; per-row 🔁 restore + footer "Restore all (N)" with confirm-when-N>5
- `frontend/src/components/WorkspaceSwitcher.tsx` — `🗄 Archived (N)` toggle button beside `🏷 Manage labels`
- `frontend/src/stores/issueStore.ts` — `useArchivedStore` slice with refresh / unarchive / unarchiveAll
- `frontend/src/App.tsx` — wires `archivedOpen`, `archivedCount`, `bus.issues_archived` subscription; mounts `<ArchivedDrawer />`
- `frontend/wailsjs/go/main/App.{d.ts,js}` + `models.ts` — regenerated via `wails generate module`

Docs
- `PRISMCONDUCTOR_PLAN.md` — §6.3 Issue gains `archived_at`; §13 Persistence notes the new column

## Verification

- Lint: `go vet ./...` — pass
- Lint: `cd frontend && npx tsc --noEmit` — pass
- Build: `wails build` — pass (built `prismconductor.app` in 6.683s; the `KnownStructs … Not found: time.Time` lines are the same Wails-generator noise present on `main` for the existing `time.Time` fields)
- Tests: `go test ./...` — pass (all packages green; new tests in `internal/store/issues_test.go`: `TestArchiveDoneScopedToWorkspace`, `TestArchiveDoneEmptyWorkspaceArchivesAll`, `TestArchiveDoneSkipsNonDoneColumns`, `TestListIssuesHidesArchived`, `TestListArchivedIssuesReturnsArchivedDesc`, `TestUnarchiveIssueRestoresVisibility`, `TestUnarchiveAllRestoresEverything`, `TestArchiveDoneIdempotent`, `TestSaveIssueAutoUnarchivesOnReopen`, `TestSaveIssuePreservesArchivedAtOnClosedRoundtrip`)

## Notes for human review

- `SaveIssue`'s signature changed from `error` to `(bool, error)`. All call sites (`internal/github/poll.go`, `internal/orchestrator/orchestrator.go`, `app.go`, tests) are updated; the bool surfaces auto-unarchive transitions so the poller can publish `EvtIssuesArchived`.
- `ListIssues` hides archived rows, so orchestrator + reconciliation paths (which all funnel through `ListIssues`) remain archive-blind by construction.
- No frontend test framework exists in this repo, so no frontend tests were added.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)
