### PR TITLE
Recommended-answer rendering + auto-seed in QuestionForm (#36)

### DIFF
--- a/frontend/src/components/PlanModal.tsx
+++ b/frontend/src/components/PlanModal.tsx
@@ -5,7 +5,7 @@ import { ApprovePlan, LatestPlan, RejectPlan, SetIssueLabels, SubmitAnswers } fr
 import { main, types } from "../../wailsjs/go/models";
 import { useIssueStore } from "../stores/issueStore";
 import { useLabelsStore, EMPTY_LABELS } from "../stores/labelsStore";
-import { AnswerState, QuestionForm, emptyAnswers, isComplete } from "./QuestionForm";
+import { AnswerState, QuestionForm, emptyAnswers, initialAnswers, isComplete } from "./QuestionForm";
 import { LabelsModal } from "./LabelsModal";
 import { getContrastText } from "../lib/contrast";
 
@@ -44,7 +44,12 @@ export function PlanModal({
     setError(null);
     setAnswers(emptyAnswers());
     LatestPlan(issue.workspace_id, issue.number)
-      .then((p) => setPlan(p ?? null))
+      .then((p) => {
+        setPlan(p ?? null);
+        if (p?.questions?.length) {
+          setAnswers(initialAnswers(p.questions));
+        }
+      })
       .catch((e) => setError(String(e?.message ?? e)))
       .finally(() => setLoading(false));
     refreshLabels(issue.workspace_id);

--- a/frontend/src/components/QuestionForm.tsx
+++ b/frontend/src/components/QuestionForm.tsx
@@ -11,6 +11,20 @@ export function emptyAnswers(): AnswerState {
   return { single: {}, multi: {} };
 }
 
+export function initialAnswers(questions: types.Question[]): AnswerState {
+  const state = emptyAnswers();
+  for (const q of questions) {
+    const def = q.default ?? null;
+    if (!def) continue;
+    if (q.type === "multi_choice") {
+      state.multi[q.id] = [def];
+    } else {
+      state.single[q.id] = def;
+    }
+  }
+  return state;
+}
+
 // Many planner outputs cram the prompt + every option into the question text
 // ("A) thing... B) other thing..."), then send `options: ["A","B","C"]` —
 // useless without the prompt. Detect that pattern and pull each option's
@@ -78,6 +92,14 @@ export function QuestionForm({
               <div className="flex-1 prose prose-sm prose-invert max-w-none prose-p:my-0 prose-code:text-amber-200 prose-code:bg-slate-950 prose-code:px-1 prose-code:rounded prose-code:before:content-[''] prose-code:after:content-['']">
                 <ReactMarkdown remarkPlugins={[remarkGfm]}>{prompt}</ReactMarkdown>
               </div>
+              {q.required && !q.default && (
+                <span
+                  className="text-[10px] uppercase tracking-wide text-amber-400 whitespace-nowrap"
+                  title="Planner did not provide a recommendation for this question"
+                >
+                  ⚠ no recommendation
+                </span>
+              )}
               {q.required && <span className="text-red-400 text-xs">*</span>}
             </div>
 
@@ -88,6 +110,7 @@ export function QuestionForm({
                     q.type === "multi_choice"
                       ? (state.multi[q.id] ?? []).includes(opt.id)
                       : state.single[q.id] === opt.id;
+                  const recommended = q.default === opt.id;
                   return (
                     <label
                       key={opt.id}
@@ -114,9 +137,19 @@ export function QuestionForm({
                         {opt.id !== opt.label && (
                           <span className="text-xs font-mono text-slate-500 mr-2">{opt.id})</span>
                         )}
-                        <span className="text-sm text-slate-200 whitespace-pre-wrap break-words">
+                        <span
+                          className={
+                            "text-sm whitespace-pre-wrap break-words " +
+                            (recommended ? "text-emerald-300 font-bold" : "text-slate-200")
+                          }
+                        >
                           {opt.label}
                         </span>
+                        {recommended && (
+                          <span className="ml-2 text-[10px] uppercase tracking-wide text-emerald-400 whitespace-nowrap">
+                            ★ recommended
+                          </span>
+                        )}
                       </div>
                     </label>
                   );
@@ -125,18 +158,30 @@ export function QuestionForm({
             )}
 
             {q.type === "free_text" && (
-              <textarea
-                value={state.single[q.id] ?? ""}
-                onChange={(e) => setSingle(q.id, e.target.value)}
-                rows={3}
-                className="w-full bg-slate-800 border border-slate-700 rounded p-2 text-sm text-slate-200 mt-2"
-              />
+              <>
+                <textarea
+                  value={state.single[q.id] ?? ""}
+                  onChange={(e) => setSingle(q.id, e.target.value)}
+                  rows={3}
+                  className="w-full bg-slate-800 border border-slate-700 rounded p-2 text-sm text-slate-200 mt-2"
+                />
+                {q.default && state.single[q.id] !== q.default && (
+                  <button
+                    type="button"
+                    onClick={() => setSingle(q.id, q.default!)}
+                    className="text-xs text-emerald-400 hover:text-emerald-300 mt-1"
+                  >
+                    ↺ recommendation
+                  </button>
+                )}
+              </>
             )}
 
             {q.type === "yes_no" && (
               <div className="flex gap-2 mt-2">
                 {["yes", "no"].map((v) => {
                   const checked = state.single[q.id] === v;
+                  const recommended = q.default === v;
                   return (
                     <label
                       key={v}
@@ -154,7 +199,10 @@ export function QuestionForm({
                         checked={checked}
                         onChange={() => setSingle(q.id, v)}
                       />
-                      {v}
+                      <span className={recommended ? "text-emerald-300 font-bold" : undefined}>{v}</span>
+                      {recommended && (
+                        <span className="ml-1 text-[10px] uppercase tracking-wide text-emerald-400">★</span>
+                      )}
                     </label>
                   );
                 })}

--- a/internal/skills/bundle/skills/conductor-plan.md
+++ b/internal/skills/bundle/skills/conductor-plan.md
@@ -35,6 +35,17 @@ Bundled by PrismConductor. Used in Bundled and Hybrid skill modes (PRISMCONDUCTO
    - Use markdown freely in `prompt` — backticks for code, bold for emphasis, inline links. The UI renders prompts as markdown.
    - Keep each option text under ~280 chars where possible. Long options (a paragraph each) signal the question should split into multiple smaller ones.
    - For yes_no questions, omit `options` (or `[]`) — the UI hardcodes "yes"/"no".
+
+   **Every question MUST set `default` to exactly one recommended answer.**
+
+   - `single_choice`: `default` is the full text of one option string — the safest / most-conventional / best-aligned-with-the-issue-body choice.
+   - `yes_no`: `default` is the literal string `"yes"` or `"no"`.
+   - `multi_choice`: `default` is the full text of **one** option (the single most-likely choice).
+   - `free_text`: `default` is a one-or-two-sentence sample answer the user can edit, accept, or replace. Never an empty string.
+
+   **One recommendation per question — always.** If you find yourself wanting to recommend more than one answer for a single question, the question's scope is too large. Split it into multiple `yes_no` questions (or smaller `single_choice` questions), each with exactly one recommendation. This applies to `multi_choice` in particular: if you'd recommend two or more options, replace the `multi_choice` question with one `yes_no` per option.
+
+   Refusing to recommend ("I'm not sure, you decide") is not allowed. If you genuinely cannot pick, the question should be split into smaller yes_no questions or removed.
 6. Write the plan to `.prismconductor/plans/<issue>-rev1.json` matching §9.1 exactly. Include the
    suggestions as the `suggested_labels` array (omit the field entirely if empty).
 7. Print `Plan written to .prismconductor/plans/<issue>-rev1.json` so the conductor's PTY parser picks it up (§10.3).

--- a/internal/skills/bundle/skills/conductor-question.md
+++ b/internal/skills/bundle/skills/conductor-question.md
@@ -13,11 +13,12 @@ Bundled by PrismConductor (PRISMCONDUCTOR_PLAN.md §15.7).
 - `--prompt <text>`
 - `--options <comma-separated>` (for choice types)
 - `--required <true|false>`
+- `--default <value>` (REQUIRED — exactly one recommended answer, same per-type rules as `conductor-plan`'s questions: full option text for choice types, `"yes"` or `"no"` for yes_no, a one-or-two-sentence sample answer for free_text)
 
 ## Behavior
 
 1. Generate a UUID for the question id.
-2. Write `.prismconductor/questions/<id>.json` matching the §6.4 Question schema.
+2. Write `.prismconductor/questions/<id>.json` matching the §6.4 Question schema. Populate `default` from the `--default` input.
 3. Print `Question: <prompt>` so the PTY parser flips state to waiting_for_input (§10.3).
 4. Block on the matching answer file `.prismconductor/answers/<id>.json` (poll every 2s).
 5. Read the answer and return it on stdout for the calling skill.


### PR DESCRIPTION
## Summary

Every plan question now carries exactly one planner-recommended answer (`Question.Default`). The QuestionForm renders it as bold-emerald text with a `★ recommended` chip, and `PlanModal` pre-seeds answer state so a user who agrees can submit in one click. Required questions arriving without a default get a `⚠ no recommendation` chip but still render and submit (graceful degradation for older plans).

## Files modified

- `internal/skills/bundle/skills/conductor-plan.md` — append "every question MUST set exactly one `default`" rule, with the "if you want multiple, split the question" guidance for `multi_choice`.
- `internal/skills/bundle/skills/conductor-question.md` — REQUIRED `--default <value>` input; populate `Question.default` from it.
- `frontend/src/components/QuestionForm.tsx` — new `initialAnswers` export; ★ + emerald-bold styling on `single_choice`/`multi_choice`/`yes_no` rows where `q.default === opt.id`; `↺ recommendation` reset link on `free_text`; `⚠ no recommendation` chip in question header for required questions without `default`.
- `frontend/src/components/PlanModal.tsx` — import `initialAnswers`, call it inside `LatestPlan().then(...)` to pre-seed `answers`.

## Verification

- **Lint / typecheck:**
  - `go vet ./...` → exit 0
  - `cd frontend && npx tsc --noEmit` → exit 0
- **Build:**
  - `go build ./...` → exit 0
- **Tests:**
  - `go test ./...` → all packages pass (`prismconductor`, `internal/git`, `internal/orchestrator`, `internal/session`, `internal/store`); other packages have no test files.
  - **Frontend:** no test runner configured (`frontend/package.json` defines no `test` script and has no vitest/jest dependency). The `add` intent in this change is a single TS helper (`initialAnswers`) inside an otherwise-modified file; the planner's `files_to_modify` lists only `modify` intents. Per the conductor-execute skill, missing test infrastructure is the noted exception. Manual coverage: typecheck passes; both seeded and non-seeded plan paths exercised by inspection of the diff against `LatestPlan(...)` call site and `QuestionForm` branches.

## Skipped / human review

- No wails binding regeneration — `Question.Default` already exists in the generated TS types, no new bound methods.
- `multi_choice` is intentionally narrow now (single-recommendation rule). Older `.prismconductor/plans/*.json` still render correctly thanks to the graceful-degradation chip.

Closes #36
