### PR TITLE
Add mid-run question reentry path for execute workers (#17)

### DIFF
--- a/app.go
+++ b/app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -52,6 +53,8 @@ type App struct {
 	poller  *pcgithub.Poller
 	logs    *logbuffer.Ring
 	cfgDir  string
+
+	answerWatcher *store.AnswerWatcher
 
 	pendingDevice *githubauth.DeviceCode
 
@@ -172,6 +175,29 @@ func (a *App) startup(ctx context.Context) {
 		})
 	}
 
+	// Issue #17: answer-file watcher. Polls each enabled workspace's
+	// .prismconductor/answers/ directory on a 1s ticker; when an answer file
+	// matches a session paused on that question, fire the resume callback. The
+	// watcher does NOT distinguish "answer arrived live" from "answer was
+	// already on disk at startup" — the first tick post-restart auto-resumes
+	// any pre-existing match (Q4=A).
+	if a.store != nil && a.wsReg != nil {
+		a.answerWatcher = store.NewAnswerWatcher(
+			time.Second,
+			func() []types.Workspace { return a.wsReg.List() },
+			func() []store.PausedSession {
+				ps, err := a.store.ListPausedForQuestionSessions()
+				if err != nil {
+					log.Printf("answer watcher: list paused sessions: %v", err)
+					return nil
+				}
+				return ps
+			},
+			a.handleMidRunAnswerArrived,
+		)
+		go a.answerWatcher.Run(a.ctx)
+	}
+
 	// Re-attach to sessions that were live at last shutdown (§15.3).
 	if a.store != nil {
 		if running, _, err := a.store.LoadRunningSessions(); err == nil {
@@ -214,7 +240,7 @@ func (a *App) handleSessionStateChange(sess types.Session, prev types.SessionSta
 		return
 	}
 	switch sess.State {
-	case types.StateWaitingForInput, types.StateBlocked, types.StateCompleted, types.StateFailed:
+	case types.StateWaitingForInput, types.StatePausedForQuestion, types.StateBlocked, types.StateCompleted, types.StateFailed:
 		// One notification per transition; dedupe identical kicks within 2s.
 		key := sess.ID + ":" + string(sess.State)
 		a.notifyMu.Lock()
@@ -329,6 +355,8 @@ func notifyBody(sess types.Session) string {
 	switch sess.State {
 	case types.StateWaitingForInput:
 		return prefix + "needs input"
+	case types.StatePausedForQuestion:
+		return prefix + "needs answer mid-run"
 	case types.StateBlocked:
 		return prefix + "is blocked"
 	case types.StateCompleted:
@@ -1203,6 +1231,119 @@ func (a *App) ListPendingPlans() ([]store.PendingPlan, error) {
 		return nil, fmt.Errorf("store unavailable")
 	}
 	return a.store.ListPendingPlans()
+}
+
+// midRunQuestionContext mirrors the sidecar the conductor-question skill writes
+// alongside `<id>.json`. The plan_path is repo-relative; the resume callback
+// uses revision to look up the plan in the store.
+type midRunQuestionContext struct {
+	IssueNumber int    `json:"issue_number"`
+	WorkspaceID string `json:"workspace_id"`
+	Revision    int    `json:"revision"`
+	Branch      string `json:"branch"`
+	PlanPath    string `json:"plan_path"`
+	Scratch     string `json:"scratch"`
+}
+
+// handleMidRunAnswerArrived is the watcher callback (#17). Loads the plan +
+// issue, spawns a resume execute worker on the same branch, and clears the
+// pending_question_id on the OLD session row so subsequent ticks don't re-fire
+// on the stale match.
+func (a *App) handleMidRunAnswerArrived(ps store.PausedSession) {
+	if a.wsReg == nil || a.store == nil || a.mgr == nil {
+		return
+	}
+	ws, ok := a.wsReg.Get(ps.WorkspaceID)
+	if !ok {
+		log.Printf("answer arrived for unknown workspace %q (session %s)", ps.WorkspaceID, ps.SessionID)
+		return
+	}
+	ctxPath := filepath.Join(ws.RepoPath, ".prismconductor", "questions", ps.QuestionID+".context.json")
+	raw, err := os.ReadFile(ctxPath)
+	if err != nil {
+		log.Printf("answer arrived but context sidecar unreadable at %s: %v", ctxPath, err)
+		return
+	}
+	var ctx midRunQuestionContext
+	if err := json.Unmarshal(raw, &ctx); err != nil {
+		log.Printf("invalid context sidecar at %s: %v", ctxPath, err)
+		return
+	}
+	plan, err := a.store.GetPlan(ws.ID, ps.IssueNumber, ctx.Revision)
+	if err != nil {
+		log.Printf("answer resume: load plan rev %d for #%d: %v", ctx.Revision, ps.IssueNumber, err)
+		return
+	}
+	issue, err := a.store.LoadIssue(ws.ID, ps.IssueNumber)
+	if err != nil {
+		log.Printf("answer resume: load issue #%d (%v); falling back to stub", ps.IssueNumber, err)
+		issue = types.Issue{Number: ps.IssueNumber, WorkspaceID: ws.ID}
+	}
+	// Clear the pending_question_id on the OLD session BEFORE spawning so the
+	// watcher's next tick doesn't see this paused row again. The new session
+	// is the source of truth from here on.
+	if err := a.store.UpdateSessionPendingQuestion(ps.SessionID, ""); err != nil {
+		log.Printf("answer resume: clear pending_question_id on %s: %v", ps.SessionID, err)
+	}
+	if _, err := a.mgr.SpawnExecuteResume(ws, issue, plan, ps.QuestionID); err != nil {
+		log.Printf("answer resume: SpawnExecuteResume #%d: %v", ps.IssueNumber, err)
+		return
+	}
+	log.Printf("answer resume: spawned execute worker for #%d on branch %s (qid=%s)",
+		ps.IssueNumber, ctx.Branch, ps.QuestionID)
+}
+
+// SubmitMidRunAnswer writes the user's answer for a mid-run question (#17).
+// One question per call; the file lives at
+// `<RepoPath>/.prismconductor/answers/<question_id>.json` (NOT keyed by issue
+// or revision — mid-run questions are indexed by their own UUID). The
+// AnswerWatcher trips the resume on its next tick.
+func (a *App) SubmitMidRunAnswer(workspaceID string, issueNumber int, answer types.MidRunAnswer) error {
+	if a.wsReg == nil {
+		return fmt.Errorf("workspace registry unavailable")
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return fmt.Errorf("unknown workspace %q", workspaceID)
+	}
+	if answer.QuestionID == "" {
+		return fmt.Errorf("question_id required")
+	}
+	dir := filepath.Join(ws.RepoPath, ".prismconductor", "answers")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(answer, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, answer.QuestionID+".json"), b, 0o644)
+}
+
+// GetMidRunQuestion reads the on-disk question definition (#17) so the
+// frontend modal can render without direct fs access. The question lives at
+// `<RepoPath>/.prismconductor/questions/<question_id>.json`.
+func (a *App) GetMidRunQuestion(workspaceID string, issueNumber int, questionID string) (types.Question, error) {
+	if a.wsReg == nil {
+		return types.Question{}, fmt.Errorf("workspace registry unavailable")
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return types.Question{}, fmt.Errorf("unknown workspace %q", workspaceID)
+	}
+	if questionID == "" {
+		return types.Question{}, fmt.Errorf("question_id required")
+	}
+	path := filepath.Join(ws.RepoPath, ".prismconductor", "questions", questionID+".json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return types.Question{}, err
+	}
+	var q types.Question
+	if err := json.Unmarshal(raw, &q); err != nil {
+		return types.Question{}, fmt.Errorf("invalid question JSON at %s: %w", path, err)
+	}
+	return q, nil
 }
 
 // AnswerSubmission is the frontend's payload for the answers form.

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -9,6 +9,7 @@ import { usePlanReadyStore } from "../stores/planReadyStore";
 import { useLabelsStore, EMPTY_LABELS } from "../stores/labelsStore";
 import { getContrastText } from "../lib/contrast";
 import { LabelManagePopover } from "./LabelManagePopover";
+import { MidRunQuestionModal } from "./MidRunQuestionModal";
 import { cn } from "../lib/cn";
 
 export type CardProps = {
@@ -33,15 +34,22 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
   // Live state: subscribe to the *whole* sessions table so we re-render when any
   // session changes.
   const allSessions = useSessionStore((s) => s.sessions);
-  const { activeSession, activity, lastFailure } = (() => {
+  const { activeSession, activity, lastFailure, pausedSession } = (() => {
     let active: types.Session | null = null;
     let activeAct: SessionActivity | null = null;
     let lastFail: types.Session | null = null;
+    let paused: types.Session | null = null;
     for (const view of Object.values(allSessions)) {
       const m = view.meta;
       if (!m) continue;
       if (m.workspace_id !== issue.workspace_id || m.issue_number !== issue.number) continue;
-      if (m.state === "running" || m.state === "waiting_for_input" || m.state === "blocked") {
+      if (m.state === "paused_for_question") {
+        // Paused for a mid-run question (#17). Track separately so it overrides
+        // both running/active and last-failure rendering.
+        if (!paused || String(m.started_at ?? "") > String(paused.started_at ?? "")) {
+          paused = m;
+        }
+      } else if (m.state === "running" || m.state === "waiting_for_input" || m.state === "blocked") {
         if (!active) {
           active = m;
           activeAct = view.activity ?? null;
@@ -53,7 +61,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
         }
       }
     }
-    return { activeSession: active, activity: activeAct, lastFailure: lastFail };
+    return { activeSession: active, activity: activeAct, lastFailure: lastFail, pausedSession: paused };
   })();
   if (activeSession) {
     // Visible in DevTools (Cmd+Opt+I in the Wails window) — confirms the
@@ -69,6 +77,8 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
   const blocked = (issue.dependencies ?? []).length > 0;
   const isPrimitive = !blocked && (issue.priority ?? 0) >= 0.7;
 
+  const [midRunOpen, setMidRunOpen] = useState(false);
+
   return (
     <div
       ref={setNodeRef}
@@ -77,14 +87,22 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
       {...listeners}
       onClick={(e) => {
         if (isDragging) return;
+        if (pausedSession) {
+          setMidRunOpen(true);
+          e.stopPropagation();
+          return;
+        }
         onClick?.();
         e.stopPropagation();
       }}
       className={cn(
         "w-full text-left rounded-md border bg-slate-800/70 hover:bg-slate-800 px-3 py-2 mb-2",
         "shadow-sm transition-colors cursor-grab active:cursor-grabbing select-none",
-        // Blocked beats mode color — failure signal must be unmistakable.
-        activeSession && activeSession.state === "blocked"
+        // Paused-for-question (#17) beats mode color so a pending question is
+        // always visually distinct from a running execute.
+        pausedSession
+          ? "border-amber-500 card-glow-ready"
+          : activeSession && activeSession.state === "blocked"
           ? "border-red-500 card-glow-blocked"
           : !activeSession && lastFailure
           ? "border-red-500 card-glow-blocked"
@@ -128,6 +146,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
         activeSession={activeSession}
         activity={activity}
         lastFailure={lastFailure}
+        pausedSession={pausedSession}
         planReady={planReady}
         blocked={blocked}
         isPrimitive={isPrimitive}
@@ -136,6 +155,15 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
         workspaceID={issue.workspace_id}
         issueNumber={issue.number}
       />
+      {pausedSession && pausedSession.pending_question_id && (
+        <MidRunQuestionModal
+          open={midRunOpen}
+          onClose={() => setMidRunOpen(false)}
+          workspaceID={issue.workspace_id}
+          issueNumber={issue.number}
+          questionID={pausedSession.pending_question_id}
+        />
+      )}
     </div>
   );
 }
@@ -153,6 +181,7 @@ function StatusRow({
   activeSession,
   activity,
   lastFailure,
+  pausedSession,
   planReady,
   blocked,
   isPrimitive,
@@ -164,6 +193,7 @@ function StatusRow({
   activeSession: types.Session | null;
   activity: SessionActivity | null;
   lastFailure: types.Session | null;
+  pausedSession: types.Session | null;
   planReady: { revision: number } | null;
   blocked: boolean;
   isPrimitive: boolean;
@@ -172,6 +202,15 @@ function StatusRow({
   workspaceID: string;
   issueNumber: number;
 }) {
+  if (pausedSession) {
+    return (
+      <div className="text-[11px] mt-1.5 flex items-center gap-1.5 flex-wrap">
+        <Pulse className="bg-amber-400" />
+        <span className="text-amber-300">❓ awaiting answer</span>
+        <span className="text-slate-500">— click to answer</span>
+      </div>
+    );
+  }
   if (activeSession) {
     const planMode = activeSession.mode === "plan";
     const isBlocked = activeSession.state === "blocked";

--- a/frontend/src/components/MidRunQuestionModal.tsx
+++ b/frontend/src/components/MidRunQuestionModal.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react";
+import { GetMidRunQuestion, SubmitMidRunAnswer } from "../../wailsjs/go/main/App";
+import { types } from "../../wailsjs/go/models";
+import { AnswerState, QuestionForm, emptyAnswers, initialAnswers, isComplete } from "./QuestionForm";
+
+// MidRunQuestionModal renders a single mid-run question (#17) that the worker
+// raised via /conductor-question. The question lives at
+// .prismconductor/questions/<id>.json on disk; the answer file (written by
+// SubmitMidRunAnswer below) trips the answer-file watcher, which spawns a
+// fresh execute worker on the same branch to continue the work.
+export function MidRunQuestionModal({
+  open,
+  onClose,
+  workspaceID,
+  issueNumber,
+  questionID,
+}: {
+  open: boolean;
+  onClose: () => void;
+  workspaceID: string;
+  issueNumber: number;
+  questionID: string;
+}) {
+  const [question, setQuestion] = useState<types.Question | null>(null);
+  const [state, setState] = useState<AnswerState>(emptyAnswers());
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !questionID) return;
+    setLoading(true);
+    setError(null);
+    GetMidRunQuestion(workspaceID, issueNumber, questionID)
+      .then((q) => {
+        setQuestion(q);
+        setState(initialAnswers([q]));
+      })
+      .catch((e) => setError(String(e?.message ?? e)))
+      .finally(() => setLoading(false));
+  }, [open, workspaceID, issueNumber, questionID]);
+
+  if (!open) return null;
+
+  const ready = question != null && isComplete([question], state);
+
+  async function submit() {
+    if (!question) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const answer =
+        question.type === "multi_choice"
+          ? ""
+          : (state.single[question.id] ?? question.default ?? "");
+      const multi = question.type === "multi_choice"
+        ? (state.multi[question.id] ?? (question.default ? [question.default] : []))
+        : undefined;
+      await SubmitMidRunAnswer(
+        workspaceID,
+        issueNumber,
+        new types.MidRunAnswer({
+          question_id: question.id,
+          answer,
+          multi,
+        }),
+      );
+      onClose();
+    } catch (e: any) {
+      setError(String(e?.message ?? e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+      <div className="w-[600px] max-h-[80vh] bg-slate-900 border border-amber-700 rounded-lg flex flex-col overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-2 border-b border-slate-800 bg-amber-950/30">
+          <div className="text-slate-200">
+            ❓ Mid-run question — <span className="text-slate-400">#{issueNumber}</span>
+          </div>
+          <button onClick={onClose} className="text-slate-400 hover:text-slate-200">✕</button>
+        </div>
+        <div className="flex-1 overflow-y-auto px-4 py-3 text-sm space-y-3">
+          {loading && <div className="text-slate-500">loading…</div>}
+          {error && <div className="text-red-400">{error}</div>}
+          {question && (
+            <QuestionForm questions={[question]} state={state} onChange={setState} />
+          )}
+        </div>
+        <div className="px-4 py-2 border-t border-slate-800 flex items-center justify-between gap-2">
+          <div className="text-xs text-slate-500">
+            Answering re-spawns the execute worker on the same branch.
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onClose}
+              disabled={busy}
+              className="px-3 py-1.5 rounded border border-slate-700 text-slate-300 hover:border-slate-500 disabled:opacity-50"
+            >
+              Dismiss
+            </button>
+            <button
+              onClick={submit}
+              disabled={busy || !ready}
+              className="px-3 py-1.5 rounded bg-amber-600 text-slate-50 hover:bg-amber-500 disabled:opacity-50"
+            >
+              {busy ? "Submitting…" : "Submit answer"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -30,6 +30,8 @@ export function GCWorktrees(arg1:string):Promise<number>;
 
 export function GetAutoPullPaused():Promise<boolean>;
 
+export function GetMidRunQuestion(arg1:string,arg2:number,arg3:string):Promise<types.Question>;
+
 export function GetNotifyPrefs():Promise<main.NotifyPrefs>;
 
 export function GetOllamaConfig():Promise<main.OllamaConfig>;
@@ -123,6 +125,8 @@ export function SpawnDemo():Promise<types.Session>;
 export function SpawnPlanForIssue(arg1:string,arg2:number):Promise<types.Session>;
 
 export function SubmitAnswers(arg1:main.AnswerSubmission):Promise<void>;
+
+export function SubmitMidRunAnswer(arg1:string,arg2:number,arg3:types.MidRunAnswer):Promise<void>;
 
 export function UnarchiveAll(arg1:string):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -46,6 +46,10 @@ export function GetAutoPullPaused() {
   return window['go']['main']['App']['GetAutoPullPaused']();
 }
 
+export function GetMidRunQuestion(arg1, arg2, arg3) {
+  return window['go']['main']['App']['GetMidRunQuestion'](arg1, arg2, arg3);
+}
+
 export function GetNotifyPrefs() {
   return window['go']['main']['App']['GetNotifyPrefs']();
 }
@@ -232,6 +236,10 @@ export function SpawnPlanForIssue(arg1, arg2) {
 
 export function SubmitAnswers(arg1) {
   return window['go']['main']['App']['SubmitAnswers'](arg1);
+}
+
+export function SubmitMidRunAnswer(arg1, arg2, arg3) {
+  return window['go']['main']['App']['SubmitMidRunAnswer'](arg1, arg2, arg3);
 }
 
 export function UnarchiveAll(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1220,6 +1220,22 @@ export namespace types {
 	        this.description = source["description"];
 	    }
 	}
+	export class MidRunAnswer {
+	    question_id: string;
+	    answer: string;
+	    multi?: string[];
+	
+	    static createFrom(source: any = {}) {
+	        return new MidRunAnswer(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.question_id = source["question_id"];
+	        this.answer = source["answer"];
+	        this.multi = source["multi"];
+	    }
+	}
 	
 	
 	export class Session {
@@ -1235,6 +1251,7 @@ export namespace types {
 	    pid: number;
 	    last_prompt: string;
 	    blocked_reason?: string;
+	    pending_question_id?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new Session(source);
@@ -1252,6 +1269,7 @@ export namespace types {
 	        this.pid = source["pid"];
 	        this.last_prompt = source["last_prompt"];
 	        this.blocked_reason = source["blocked_reason"];
+	        this.pending_question_id = source["pending_question_id"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -28,6 +28,7 @@ type LineHandler func(sessionID string, line string)
 type Persister interface {
 	SaveSession(sess *types.Session, transcriptPath string) error
 	UpdateSessionState(id string, state types.SessionState) error
+	UpdateSessionPendingQuestion(id, questionID string) error
 }
 
 // StateChangeHandler is fired on every state transition. Used by the App layer
@@ -168,6 +169,23 @@ func (m *Manager) SpawnExecute(ws types.Workspace, issue types.Issue, plan types
 		return nil, err
 	}
 	return sess, nil
+}
+
+// SpawnExecuteResume re-enters an execute worker on an existing worktree to
+// continue work after a mid-run question (#17, Q5/Q6). The branch and
+// worktree are expected to already exist on disk — this is the second leg of
+// a paused-for-question flow, NOT a fresh execute. Returns an error if the
+// worktree is missing so the caller can surface it on the OLD session row.
+func (m *Manager) SpawnExecuteResume(ws types.Workspace, issue types.Issue, plan types.Plan, questionID string) (*types.Session, error) {
+	slug := branchSlug(issue.Title)
+	branch := fmt.Sprintf("feat/issue-%d-%s", issue.Number, slug)
+	worktreeDir := filepath.Join(ws.RepoPath, ".prismconductor", "worktrees",
+		fmt.Sprintf("%s-%d", ws.ID, issue.Number))
+	if _, err := os.Stat(worktreeDir); err != nil {
+		return nil, fmt.Errorf("resume worktree missing at %s: %w", worktreeDir, err)
+	}
+	args := buildExecuteResumeCommand(ws, issue, plan, questionID)
+	return m.spawnWithDir(ws, issue, types.ModeExecute, args, worktreeDir, branch)
 }
 
 // branchSlug derives a kebab-case branch suffix from an issue title, lowering
@@ -388,22 +406,7 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 		}
 	}
 	prev := rs.sess.State
-	if err := rs.cmd.Wait(); err != nil {
-		rs.sess.State = types.StateFailed
-	} else {
-		// Worker exited cleanly. Pattern-set transient states map to terminal:
-		//   Running          → Completed (PatternComplete didn't fire but
-		//                      exit was clean — count it as done)
-		//   Blocked          → Failed (worker emitted BLOCKED: and bailed)
-		//   WaitingForInput  → Failed (worker asked Question: then exited
-		//                      before any answer arrived; -p mode does this)
-		switch rs.sess.State {
-		case types.StateRunning:
-			rs.sess.State = types.StateCompleted
-		case types.StateBlocked, types.StateWaitingForInput:
-			rs.sess.State = types.StateFailed
-		}
-	}
+	rs.sess.State = mapTerminalState(rs.sess.State, rs.cmd.Wait())
 	end := time.Now()
 	rs.sess.EndedAt = &end
 	if m.store != nil {
@@ -422,6 +425,9 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 	//         deterministic state with no goroutine fanout. A leftover from a
 	//         transient failure is reclaimed by the next startup Prune.
 	//   q3=A: Completed → leave on disk; the 24h GC walk reclaims it later.
+	// Issue #17: PausedForQuestion must also keep the worktree on disk so the
+	// resume worker can `git switch` back into it. The 24h GC reclaims if the
+	// user never answers.
 	if rs.worktreeDir != "" {
 		switch rs.sess.State {
 		case types.StateBlocked, types.StateFailed:
@@ -439,9 +445,60 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 	m.mu.Unlock()
 }
 
+// mapTerminalState collapses an in-flight session state to its terminal value
+// once the worker process exits. Pure function so it's unit-testable without a
+// real PTY. Issue #17 added the StatePausedForQuestion arm: a paused session
+// that exits cleanly stays paused (the QUESTION_PENDING sentinel already
+// committed the pause), and a paused session that exits non-zero is also kept
+// paused — the worker's exit code doesn't change the fact that the user owes
+// an answer.
+func mapTerminalState(prev types.SessionState, waitErr error) types.SessionState {
+	if prev == types.StatePausedForQuestion {
+		return types.StatePausedForQuestion
+	}
+	if waitErr != nil {
+		return types.StateFailed
+	}
+	switch prev {
+	case types.StateRunning:
+		return types.StateCompleted
+	case types.StateBlocked, types.StateWaitingForInput:
+		return types.StateFailed
+	}
+	return prev
+}
+
 func (m *Manager) matchPatterns(rs *runtimeSession, line string) {
 	prev := rs.sess.State
 	switch {
+	case strings.Contains(line, PatternQuestionPending):
+		// Mid-run question (#17). Capture the trailing UUID; flip the session
+		// to paused_for_question so the answer-file watcher can pick it up.
+		// Order matters: this arm must run BEFORE PatternQuestion (which only
+		// fires for legacy plan-mode "Question: " lines). The two prefixes
+		// don't collide on case-sensitive contains, but listing this case
+		// first is the safer ordering if either ever changes.
+		idx := strings.Index(line, PatternQuestionPending)
+		qid := strings.TrimSpace(line[idx+len(PatternQuestionPending):])
+		if qid == "" {
+			log.Printf("QUESTION_PENDING sentinel with empty id on session %s", rs.sess.ID)
+			break
+		}
+		// One-in-flight: ignore a second QUESTION_PENDING while a question is
+		// already pending. Concurrent mid-run questions on the same issue are
+		// out of scope per the issue body's Non-goals.
+		if rs.sess.PendingQuestionID != "" {
+			log.Printf("session %s: ignoring second QUESTION_PENDING %s (already pending %s)",
+				rs.sess.ID, qid, rs.sess.PendingQuestionID)
+			break
+		}
+		rs.sess.State = types.StatePausedForQuestion
+		rs.sess.PendingQuestionID = qid
+		// Persist both. UpdateSessionState only writes one column, so we save
+		// the full row to capture the new id and the JSON blob.
+		if m.store != nil {
+			_ = m.store.SaveSession(rs.sess, rs.transcriptPath)
+		}
 	case strings.Contains(line, PatternQuestion):
 		rs.sess.State = types.StateWaitingForInput
 		rs.sess.LastPrompt = line
@@ -618,6 +675,13 @@ func buildExecuteCommand(ws types.Workspace, issue types.Issue, plan types.Plan)
 	return claudeArgs(executePrompt(ws, issue, plan))
 }
 
+// buildExecuteResumeCommand mirrors buildExecuteCommand but appends the
+// `--resume-question <id>` flag so the conductor-execute skill knows to skip
+// branch creation and read the mid-run question's context sidecar (#17).
+func buildExecuteResumeCommand(ws types.Workspace, issue types.Issue, plan types.Plan, questionID string) []string {
+	return claudeArgs(executeResumePrompt(ws, issue, plan, questionID))
+}
+
 func planPrompt(ws types.Workspace, issue types.Issue) string {
 	switch ws.SkillProfile.Mode {
 	case types.SkillModeNative:
@@ -638,6 +702,15 @@ func executePrompt(ws types.Workspace, issue types.Issue, plan types.Plan) strin
 	default:
 		return fmt.Sprintf("/conductor-execute --issue %d --repo %s --revision %d", issue.Number, ws.RepoPath, plan.Revision)
 	}
+}
+
+// executeResumePrompt appends the `--resume-question <id>` flag so the
+// conductor-execute skill knows to skip branch creation and read the mid-run
+// question's context sidecar (#17). Hybrid + Native variants get the same
+// suffix; the native command is expected to forward the flag through to its
+// underlying execute skill.
+func executeResumePrompt(ws types.Workspace, issue types.Issue, plan types.Plan, questionID string) string {
+	return executePrompt(ws, issue, plan) + " --resume-question " + questionID
 }
 
 func envSpecToSlice(env types.EnvSpec) []string {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1,0 +1,118 @@
+package session
+
+import (
+	"errors"
+	"testing"
+
+	"prismconductor/internal/types"
+)
+
+func TestMapTerminalStatePausedSurvivesCleanExit(t *testing.T) {
+	got := mapTerminalState(types.StatePausedForQuestion, nil)
+	if got != types.StatePausedForQuestion {
+		t.Errorf("paused + clean exit → %s, want paused_for_question", got)
+	}
+}
+
+func TestMapTerminalStatePausedSurvivesNonZeroExit(t *testing.T) {
+	got := mapTerminalState(types.StatePausedForQuestion, errors.New("exit 1"))
+	if got != types.StatePausedForQuestion {
+		t.Errorf("paused + non-zero exit → %s, want paused_for_question", got)
+	}
+}
+
+func TestMapTerminalStateRunningCleanExitCompletes(t *testing.T) {
+	got := mapTerminalState(types.StateRunning, nil)
+	if got != types.StateCompleted {
+		t.Errorf("running + clean exit → %s, want completed", got)
+	}
+}
+
+func TestMapTerminalStateBlockedCleanExitFails(t *testing.T) {
+	got := mapTerminalState(types.StateBlocked, nil)
+	if got != types.StateFailed {
+		t.Errorf("blocked + clean exit → %s, want failed", got)
+	}
+}
+
+func TestMapTerminalStateWaitingCleanExitFails(t *testing.T) {
+	got := mapTerminalState(types.StateWaitingForInput, nil)
+	if got != types.StateFailed {
+		t.Errorf("waiting + clean exit → %s, want failed", got)
+	}
+}
+
+func TestMapTerminalStateNonZeroExitFailsByDefault(t *testing.T) {
+	got := mapTerminalState(types.StateRunning, errors.New("exit 137"))
+	if got != types.StateFailed {
+		t.Errorf("running + non-zero exit → %s, want failed", got)
+	}
+}
+
+// fakePersister records UpdateSessionState calls without touching SQLite.
+type fakePersister struct {
+	saves    []types.Session
+	stateUpd []string
+	pendUpd  map[string]string
+}
+
+func (p *fakePersister) SaveSession(s *types.Session, _ string) error {
+	cp := *s
+	p.saves = append(p.saves, cp)
+	return nil
+}
+func (p *fakePersister) UpdateSessionState(id string, state types.SessionState) error {
+	p.stateUpd = append(p.stateUpd, id+":"+string(state))
+	return nil
+}
+func (p *fakePersister) UpdateSessionPendingQuestion(id, qid string) error {
+	if p.pendUpd == nil {
+		p.pendUpd = map[string]string{}
+	}
+	p.pendUpd[id] = qid
+	return nil
+}
+
+func TestMatchPatternsQuestionPending(t *testing.T) {
+	const qid = "11111111-2222-3333-4444-555555555555"
+	store := &fakePersister{}
+	m := &Manager{store: store}
+	rs := &runtimeSession{sess: &types.Session{ID: "sess-1", State: types.StateRunning}}
+	m.matchPatterns(rs, "@asst QUESTION_PENDING: "+qid)
+	if rs.sess.State != types.StatePausedForQuestion {
+		t.Fatalf("state after QUESTION_PENDING = %s, want paused_for_question", rs.sess.State)
+	}
+	if rs.sess.PendingQuestionID != qid {
+		t.Errorf("pending question id = %q, want %q", rs.sess.PendingQuestionID, qid)
+	}
+	if len(store.saves) == 0 {
+		t.Errorf("expected SaveSession to be called once on pause-transition")
+	}
+}
+
+func TestMatchPatternsQuestionPendingIgnoresSecondInFlight(t *testing.T) {
+	store := &fakePersister{}
+	m := &Manager{store: store}
+	rs := &runtimeSession{sess: &types.Session{
+		ID:                "sess-1",
+		State:             types.StatePausedForQuestion,
+		PendingQuestionID: "first-id",
+	}}
+	m.matchPatterns(rs, "QUESTION_PENDING: second-id")
+	if rs.sess.PendingQuestionID != "first-id" {
+		t.Errorf("expected first-id to stick, got %q", rs.sess.PendingQuestionID)
+	}
+}
+
+func TestMatchPatternsQuestionPendingEmptyIDIgnored(t *testing.T) {
+	store := &fakePersister{}
+	m := &Manager{store: store}
+	rs := &runtimeSession{sess: &types.Session{ID: "sess-1", State: types.StateRunning}}
+	m.matchPatterns(rs, "QUESTION_PENDING: ")
+	if rs.sess.State != types.StateRunning {
+		t.Errorf("empty id should be ignored, state = %s", rs.sess.State)
+	}
+	if rs.sess.PendingQuestionID != "" {
+		t.Errorf("empty id should not set PendingQuestionID, got %q", rs.sess.PendingQuestionID)
+	}
+}

--- a/internal/session/patterns.go
+++ b/internal/session/patterns.go
@@ -3,9 +3,10 @@ package session
 
 // Patterns matched in PTY output (§10.3). Plain string contains, no regex.
 const (
-	PatternQuestion    = "Question: "
-	PatternPlanWritten = "Plan written to .prismconductor/plans/"
-	PatternComplete    = "Work complete."
-	PatternBlocked     = "BLOCKED:"
-	PatternPROpened    = "PR_OPENED: "
+	PatternQuestion        = "Question: "
+	PatternPlanWritten     = "Plan written to .prismconductor/plans/"
+	PatternComplete        = "Work complete."
+	PatternBlocked         = "BLOCKED:"
+	PatternPROpened        = "PR_OPENED: "
+	PatternQuestionPending = "QUESTION_PENDING: "
 )

--- a/internal/skills/bundle/skills/conductor-execute.md
+++ b/internal/skills/bundle/skills/conductor-execute.md
@@ -18,6 +18,7 @@ Bundled by PrismConductor (PRISMCONDUCTOR_PLAN.md §15.7).
 - `--revision <N>` (required — which approved plan to execute)
 - `--repo <path>` (defaults to cwd)
 - `--native-cmd <command>` (Hybrid: hands off to a repo's own execute skill, with the conductor still owning JSON I/O)
+- `--resume-question <id>` (#17 — resume mode: continue an earlier execute on the same branch after a mid-run question was answered. When set, the steps below diverge as noted under **Resume mode**.)
 
 ## Behavior
 
@@ -38,7 +39,8 @@ These steps are mandatory and must run in this order. Do **not** edit any files 
    branch. Do NOT `git stash`, do NOT `git reset` — the working tree was just
    created clean. Sanity check ONLY:
    ```
-   git status --short            # should be empty
+   git status --short            # should be empty (or contain only the prior
+                                 #   worker's edits, in resume mode)
    git branch --show-current     # should start with feat/issue-<num>-
    ```
    If either check fails: print `BLOCKED: worktree integrity check failed — <reason>` and exit. Do not attempt to recover.
@@ -47,6 +49,8 @@ These steps are mandatory and must run in this order. Do **not** edit any files 
 
 7. Implement the plan: edit files listed in `files_to_modify`, follow the conventions discovered in step 3.
 8. **For every `add` intent in the plan, write at least one test exercising the new code.** If the plan adds a Go function `Foo`, add a `TestFoo` (or table test) in the appropriate `_test.go`. If the plan adds a React component or hook, add a Vitest/Jest test (or at minimum a render-doesn't-throw smoke test). Skipping this with "no test framework yet" is only acceptable if the repo genuinely has no test infrastructure AND you note it explicitly in the PR body.
+
+If you hit a question the plan didn't cover, invoke `/conductor-question` (writes a structured question, prints `QUESTION_PENDING: <id>`, exits 0). The conductor pauses the card on `paused_for_question`, surfaces the question to the user, and re-spawns this skill with `--resume-question <id>` once they answer. **Use this BEFORE you start committing partial work** — once you've staged changes, drive the work to completion instead.
 
 ### 4. Verification gates (NON-NEGOTIABLE — block on failure)
 
@@ -69,17 +73,17 @@ These run before commit. Failures here are **stop-the-world** events: print `BLO
 
 ### 5. Commit + push + PR (NON-NEGOTIABLE)
 
-12. `git add` only the files you modified (avoid `git add -A` — never commit unrelated WIP that may be in the tree from another task).
+12. `git add` only the files you modified (avoid `git add -A` — never commit unrelated WIP that may be in the tree from another task). If `git status` shows nothing staged AND nothing modified (the prior worker already committed before pausing), skip the commit step cleanly and proceed to the PR check.
 13. `git commit -m "<short subject>\n\nCloses #<num>\n\nCo-Authored-By: PrismConductor worker <noreply@anthropic.com>"`. Subject must reference the issue number; body must include `Closes #<num>` so the PR auto-closes the issue on merge.
 14. `git push -u origin HEAD`.
-15. `gh pr create --draft --base <BASE> --title "<short subject> (#<num>)" --body-file -` — pipe a body containing:
+15. **Single-PR enforcement (#17, Q6):** before `gh pr create`, run `gh pr list --head <branch> --json number,url`. If non-empty, an earlier resume already opened the PR — append a follow-up comment via `gh pr comment <num> --body-file -` summarizing this leg's work, capture the existing URL, and SKIP `gh pr create`. Otherwise: `gh pr create --draft --base <BASE> --title "<short subject> (#<num>)" --body-file -`. The body should contain:
     - A 1-2 sentence summary
     - The list of files modified
     - **Verification:** lint command + result, build command + result, test command + result with pass/fail counts
     - Anything skipped or flagged for human review
     - `Workspace mode: per-execute worktree at <pwd>` — surfaces the conductor isolation mode for reviewers (run `pwd` to fill the path).
     - The literal trailer line `Closes #<num>`
-16. Capture the PR URL from the `gh pr create` output.
+16. Capture the PR URL from `gh pr create` (or `gh pr list` in the reuse case).
 
 ### 6. Sentinels for the conductor
 
@@ -98,6 +102,18 @@ If you cannot complete this skill for ANY reason — permission denial, command 
 
 `Work complete.` and `PR_OPENED:` are reserved for the success path only — never print them on a failure.
 
+## Resume mode (`--resume-question <id>`)
+
+Issue #17. The previous execute worker invoked `/conductor-question` and exited; the user has now answered, and you've been re-spawned to continue.
+
+- **Skip steps 1-3.** Instead read:
+  - `.prismconductor/questions/<id>.context.json` — minimal sidecar (`issue_number`, `workspace_id`, `revision`, `branch`, `plan_path`, `scratch`).
+  - `.prismconductor/answers/<id>.json` — the user's answer in `MidRunAnswer` shape: `{question_id, answer, multi}`.
+  - The plan referenced by `context.plan_path`.
+- **Branch hygiene:** the worktree already exists with the prior worker's edits. `git status --short` MAY be non-empty. Verify `git branch --show-current` matches `context.branch`; if not, print `BLOCKED: branch mismatch — expected <ctx.branch>, got <current>` and exit. Do NOT create a new branch and do NOT discard existing changes.
+- **Continue the work** that the prior worker paused on, using the user's answer as guidance. The `scratch` field in the context sidecar is your prior self's note about what to do next.
+- The rest of the flow (verification, commit, push, PR) is identical — except the single-PR enforcement at step 15 is the load-bearing rule that keeps a multi-pause issue from opening multiple draft PRs.
+
 ## Mid-execution questions
 
-If the agent gets stuck on something the plan didn't cover, invoke `/conductor-question` (writes a structured question, pauses for answer). Do this before step 4 if possible — once a feature branch exists, you should drive the work to completion.
+If the agent gets stuck on something the plan didn't cover, invoke `/conductor-question` (writes a structured question, pauses for answer). Do this before staging changes if possible — once edits are queued, you should drive the work to completion or commit a partial WIP first.

--- a/internal/skills/bundle/skills/conductor-question.md
+++ b/internal/skills/bundle/skills/conductor-question.md
@@ -5,7 +5,7 @@ description: Helper invoked inline when a worker needs to ask the user a structu
 
 # conductor-question
 
-Bundled by PrismConductor (PRISMCONDUCTOR_PLAN.md §15.7).
+Bundled by PrismConductor (PRISMCONDUCTOR_PLAN.md §15.7, issue #17).
 
 ## Inputs
 
@@ -17,8 +17,34 @@ Bundled by PrismConductor (PRISMCONDUCTOR_PLAN.md §15.7).
 
 ## Behavior
 
-1. Generate a UUID for the question id.
-2. Write `.prismconductor/questions/<id>.json` matching the §6.4 Question schema. Populate `default` from the `--default` input.
-3. Print `Question: <prompt>` so the PTY parser flips state to waiting_for_input (§10.3).
-4. Block on the matching answer file `.prismconductor/answers/<id>.json` (poll every 2s).
-5. Read the answer and return it on stdout for the calling skill.
+The execute worker runs in `claude -p` (one-shot) mode and cannot block on user input. Mid-run questions are persisted to disk; the conductor pauses the session, surfaces the question to the user, and re-spawns a fresh execute worker on the same branch once the answer arrives. This skill writes the question + sidecar and exits.
+
+1. Generate a UUID `<id>` for the question.
+2. Write `.prismconductor/questions/<id>.json` matching the §6.4 Question schema:
+   ```json
+   {
+     "id": "<id>",
+     "type": "<type>",
+     "prompt": "<prompt>",
+     "options": ["<opt1>", "..."],
+     "default": "<default>",
+     "required": true
+   }
+   ```
+3. Write `.prismconductor/questions/<id>.context.json` with the minimal sidecar the resume worker needs:
+   ```json
+   {
+     "issue_number": <num>,
+     "workspace_id": "<wsID>",
+     "revision": <N>,
+     "branch": "<feat/issue-<num>-<slug>>",
+     "plan_path": ".prismconductor/plans/<num>-rev<N>.json",
+     "scratch": "<free-text notes for your future self — what you were doing, why you're stuck>"
+   }
+   ```
+4. Print exactly `QUESTION_PENDING: <id>` on its own line. The conductor's PTY parser flips the session state to `paused_for_question` (NOT `failed`).
+5. Exit 0.
+
+**Do NOT** poll for the answer file (the parent worker is `claude -p` and exits with you). **Do NOT** print `BLOCKED:` (this is not a failure — it's a pause). **Do NOT** print `Question:` (that sentinel is reserved for plan-mode and would double-fire the wrong UI path).
+
+After the user answers via the conductor UI, a fresh execute worker is spawned with `/conductor-execute --resume-question <id>`. That worker reads the context sidecar, switches back to the same branch, and continues.

--- a/internal/store/answers_watch.go
+++ b/internal/store/answers_watch.go
@@ -1,0 +1,137 @@
+package store
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"prismconductor/internal/types"
+)
+
+// PausedSession is the watcher's view of a session that's currently waiting on
+// a mid-run question. Returned from the PausedFn callback.
+type PausedSession struct {
+	SessionID   string
+	WorkspaceID string
+	IssueNumber int
+	QuestionID  string
+}
+
+// AnswerWatcher polls each enabled workspace's `.prismconductor/answers/` dir
+// on a 1s ticker (issue #17, Q1=A) and fires OnAnswer when an answer file
+// matches a session that's paused on that question.
+//
+// The watcher does NOT distinguish "answer arrived live" from "answer was
+// already on disk at startup" (Q4=A) — first tick after startup will auto-
+// resume any pre-existing match.
+//
+// Idempotency: each (sessionID, questionID) pair fires at most once for the
+// watcher's lifetime; the resume path is expected to clear pending_question_id
+// on the old session row so subsequent paused-session lookups won't surface
+// the stale match.
+type AnswerWatcher struct {
+	interval     time.Duration
+	workspacesFn func() []types.Workspace
+	pausedFn     func() []PausedSession
+	onAnswer     func(PausedSession)
+
+	mu    sync.Mutex
+	fired map[string]bool
+}
+
+func NewAnswerWatcher(
+	interval time.Duration,
+	workspacesFn func() []types.Workspace,
+	pausedFn func() []PausedSession,
+	onAnswer func(PausedSession),
+) *AnswerWatcher {
+	if interval <= 0 {
+		interval = time.Second
+	}
+	return &AnswerWatcher{
+		interval:     interval,
+		workspacesFn: workspacesFn,
+		pausedFn:     pausedFn,
+		onAnswer:     onAnswer,
+		fired:        map[string]bool{},
+	}
+}
+
+// Run blocks until ctx is done, ticking every interval. Spawn in a goroutine.
+func (w *AnswerWatcher) Run(ctx context.Context) {
+	if w == nil {
+		return
+	}
+	t := time.NewTicker(w.interval)
+	defer t.Stop()
+	w.Tick()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			w.Tick()
+		}
+	}
+}
+
+// Tick runs one watcher pass. Exposed for tests.
+func (w *AnswerWatcher) Tick() {
+	if w == nil || w.workspacesFn == nil || w.pausedFn == nil || w.onAnswer == nil {
+		return
+	}
+	paused := w.pausedFn()
+	if len(paused) == 0 {
+		return
+	}
+	// Index paused sessions by (workspaceID, questionID) so each answer file
+	// lookup is O(1).
+	idx := make(map[string]PausedSession, len(paused))
+	for _, p := range paused {
+		idx[p.WorkspaceID+"|"+p.QuestionID] = p
+	}
+	for _, ws := range w.workspacesFn() {
+		if !ws.Enabled || ws.RepoPath == "" {
+			continue
+		}
+		dir := filepath.Join(ws.RepoPath, ".prismconductor", "answers")
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if !strings.HasSuffix(name, ".json") {
+				continue
+			}
+			// Mid-run answer files are named "<question-uuid>.json" — distinct
+			// from the rev-keyed plan-mode answers ("<num>-rev<N>.json"). The
+			// rev-keyed ones contain a "-" before "rev"; question UUIDs are
+			// "8-4-4-4-12" hex with no "rev" segment. Skip anything that
+			// matches the rev pattern so SubmitAnswers files don't trigger.
+			id := strings.TrimSuffix(name, ".json")
+			if strings.Contains(id, "-rev") {
+				continue
+			}
+			ps, ok := idx[ws.ID+"|"+id]
+			if !ok {
+				continue
+			}
+			key := ps.SessionID + ":" + ps.QuestionID
+			w.mu.Lock()
+			if w.fired[key] {
+				w.mu.Unlock()
+				continue
+			}
+			w.fired[key] = true
+			w.mu.Unlock()
+			w.onAnswer(ps)
+		}
+	}
+}

--- a/internal/store/answers_watch_test.go
+++ b/internal/store/answers_watch_test.go
@@ -1,0 +1,150 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"prismconductor/internal/types"
+)
+
+func writeAnswerFile(t *testing.T, repoPath, questionID, body string) {
+	t.Helper()
+	dir := filepath.Join(repoPath, ".prismconductor", "answers")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir answers: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, questionID+".json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write answer: %v", err)
+	}
+}
+
+func newWS(t *testing.T, id string) types.Workspace {
+	t.Helper()
+	return types.Workspace{
+		ID:       id,
+		RepoPath: t.TempDir(),
+		Enabled:  true,
+	}
+}
+
+func TestAnswerWatcherFiresForMatchingPausedSession(t *testing.T) {
+	ws := newWS(t, "ws1")
+	const qid = "11111111-2222-3333-4444-555555555555"
+	writeAnswerFile(t, ws.RepoPath, qid, `{"question_id":"`+qid+`","answer":"yes"}`)
+
+	paused := []PausedSession{{
+		SessionID:   "sess-1",
+		WorkspaceID: ws.ID,
+		IssueNumber: 42,
+		QuestionID:  qid,
+	}}
+
+	var fired []PausedSession
+	w := NewAnswerWatcher(0,
+		func() []types.Workspace { return []types.Workspace{ws} },
+		func() []PausedSession { return paused },
+		func(ps PausedSession) { fired = append(fired, ps) },
+	)
+	w.Tick()
+	if len(fired) != 1 {
+		t.Fatalf("expected 1 callback, got %d", len(fired))
+	}
+	if fired[0].SessionID != "sess-1" || fired[0].IssueNumber != 42 || fired[0].QuestionID != qid {
+		t.Errorf("callback payload mismatch: %+v", fired[0])
+	}
+}
+
+func TestAnswerWatcherIgnoresUnmatchedAnswers(t *testing.T) {
+	ws := newWS(t, "ws1")
+	const qid = "11111111-2222-3333-4444-555555555555"
+	writeAnswerFile(t, ws.RepoPath, qid, `{}`)
+
+	// No matching paused session.
+	paused := []PausedSession{}
+	var fired []PausedSession
+	w := NewAnswerWatcher(0,
+		func() []types.Workspace { return []types.Workspace{ws} },
+		func() []PausedSession { return paused },
+		func(ps PausedSession) { fired = append(fired, ps) },
+	)
+	w.Tick()
+	if len(fired) != 0 {
+		t.Errorf("expected no callbacks, got %d", len(fired))
+	}
+}
+
+func TestAnswerWatcherIdempotent(t *testing.T) {
+	ws := newWS(t, "ws1")
+	const qid = "11111111-2222-3333-4444-555555555555"
+	writeAnswerFile(t, ws.RepoPath, qid, `{}`)
+
+	paused := []PausedSession{{
+		SessionID:   "sess-1",
+		WorkspaceID: ws.ID,
+		IssueNumber: 42,
+		QuestionID:  qid,
+	}}
+
+	var fired []PausedSession
+	w := NewAnswerWatcher(0,
+		func() []types.Workspace { return []types.Workspace{ws} },
+		func() []PausedSession { return paused },
+		func(ps PausedSession) { fired = append(fired, ps) },
+	)
+	w.Tick()
+	w.Tick()
+	w.Tick()
+	if len(fired) != 1 {
+		t.Errorf("expected exactly one callback across multiple ticks, got %d", len(fired))
+	}
+}
+
+func TestAnswerWatcherSkipsRevKeyedAnswers(t *testing.T) {
+	ws := newWS(t, "ws1")
+	// Plan-mode answer file (rev-keyed) — must be skipped.
+	writeAnswerFile(t, ws.RepoPath, "42-rev2", `{}`)
+
+	paused := []PausedSession{{
+		SessionID:   "sess-1",
+		WorkspaceID: ws.ID,
+		IssueNumber: 42,
+		QuestionID:  "42-rev2",
+	}}
+
+	var fired []PausedSession
+	w := NewAnswerWatcher(0,
+		func() []types.Workspace { return []types.Workspace{ws} },
+		func() []PausedSession { return paused },
+		func(ps PausedSession) { fired = append(fired, ps) },
+	)
+	w.Tick()
+	if len(fired) != 0 {
+		t.Errorf("expected no callbacks for rev-keyed answer file, got %d", len(fired))
+	}
+}
+
+func TestAnswerWatcherSkipsDisabledWorkspace(t *testing.T) {
+	ws := newWS(t, "ws1")
+	ws.Enabled = false
+	const qid = "11111111-2222-3333-4444-555555555555"
+	writeAnswerFile(t, ws.RepoPath, qid, `{}`)
+
+	paused := []PausedSession{{
+		SessionID:   "sess-1",
+		WorkspaceID: ws.ID,
+		IssueNumber: 42,
+		QuestionID:  qid,
+	}}
+
+	var fired []PausedSession
+	w := NewAnswerWatcher(0,
+		func() []types.Workspace { return []types.Workspace{ws} },
+		func() []PausedSession { return paused },
+		func(ps PausedSession) { fired = append(fired, ps) },
+	)
+	w.Tick()
+	if len(fired) != 0 {
+		t.Errorf("expected no callbacks for disabled workspace, got %d", len(fired))
+	}
+}

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"path/filepath"
@@ -21,14 +22,15 @@ func (s *Store) SaveSession(sess *types.Session, transcriptPath string) error {
 		return err
 	}
 	_, err = s.DB.Exec(`
-INSERT INTO sessions (id, workspace_id, issue_number, pid, state, transcript_path, json)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+INSERT INTO sessions (id, workspace_id, issue_number, pid, state, transcript_path, pending_question_id, json)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     pid = excluded.pid,
     state = excluded.state,
     transcript_path = excluded.transcript_path,
+    pending_question_id = excluded.pending_question_id,
     json = excluded.json`,
-		sess.ID, sess.WorkspaceID, sess.IssueNumber, sess.PID, string(sess.State), transcriptPath, string(b))
+		sess.ID, sess.WorkspaceID, sess.IssueNumber, sess.PID, string(sess.State), transcriptPath, nullableString(sess.PendingQuestionID), string(b))
 	return err
 }
 
@@ -41,13 +43,34 @@ func (s *Store) UpdateSessionState(id string, state types.SessionState) error {
 	return err
 }
 
+// UpdateSessionPendingQuestion writes the pending_question_id column without
+// rewriting the JSON blob. Pass an empty string to clear.
+func (s *Store) UpdateSessionPendingQuestion(id, questionID string) error {
+	if s == nil || s.DB == nil {
+		return nil
+	}
+	_, err := s.DB.Exec(`UPDATE sessions SET pending_question_id = ? WHERE id = ?`, nullableString(questionID), id)
+	return err
+}
+
+// nullableString returns nil for empty strings so the SQLite column stores NULL
+// instead of the zero-length string. Keeps `pending_question_id IS NULL` queries
+// honest.
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
 // LoadRunningSessions returns sessions that were running at last shutdown.
-// Used for re-attach on startup (§15.3).
+// Used for re-attach on startup (§15.3). Includes paused_for_question rows so
+// the answer-file watcher can pick them up post-restart (#17).
 func (s *Store) LoadRunningSessions() ([]types.Session, string, error) {
 	if s == nil || s.DB == nil {
 		return nil, "", nil
 	}
-	rows, err := s.DB.Query(`SELECT json, transcript_path FROM sessions WHERE state IN ('running','waiting_for_input','blocked')`)
+	rows, err := s.DB.Query(`SELECT json, transcript_path, pending_question_id FROM sessions WHERE state IN ('running','waiting_for_input','blocked','paused_for_question')`)
 	if err != nil {
 		return nil, "", err
 	}
@@ -56,12 +79,20 @@ func (s *Store) LoadRunningSessions() ([]types.Session, string, error) {
 	var firstTranscript string
 	for rows.Next() {
 		var raw, transcript string
-		if err := rows.Scan(&raw, &transcript); err != nil {
+		var pendingQID sql.NullString
+		if err := rows.Scan(&raw, &transcript, &pendingQID); err != nil {
 			return nil, "", err
 		}
 		var sess types.Session
 		if err := json.Unmarshal([]byte(raw), &sess); err != nil {
 			continue
+		}
+		// The pending_question_id column is the source of truth — the JSON blob
+		// may be older than the most recent UpdateSessionPendingQuestion call.
+		if pendingQID.Valid {
+			sess.PendingQuestionID = pendingQID.String
+		} else {
+			sess.PendingQuestionID = ""
 		}
 		out = append(out, sess)
 		if firstTranscript == "" {
@@ -69,6 +100,34 @@ func (s *Store) LoadRunningSessions() ([]types.Session, string, error) {
 		}
 	}
 	return out, firstTranscript, rows.Err()
+}
+
+// ListPausedForQuestionSessions returns every session row whose state is
+// paused_for_question and whose pending_question_id is non-empty (#17). Used
+// by the answer-file watcher to find which session a given answer file unlocks.
+func (s *Store) ListPausedForQuestionSessions() ([]PausedSession, error) {
+	if s == nil || s.DB == nil {
+		return nil, nil
+	}
+	rows, err := s.DB.Query(`
+		SELECT id, workspace_id, issue_number, pending_question_id
+		FROM sessions
+		WHERE state = 'paused_for_question'
+		  AND pending_question_id IS NOT NULL
+		  AND pending_question_id != ''`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PausedSession
+	for rows.Next() {
+		var p PausedSession
+		if err := rows.Scan(&p.SessionID, &p.WorkspaceID, &p.IssueNumber, &p.QuestionID); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
 }
 
 // MostRecentEndedAtForWorktree resolves the most recent terminal-state session

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -71,6 +71,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     pid INTEGER,
     state TEXT NOT NULL,
     transcript_path TEXT,
+    pending_question_id TEXT,
     json TEXT NOT NULL
 );
 CREATE TABLE IF NOT EXISTS events (
@@ -97,6 +98,13 @@ CREATE TABLE IF NOT EXISTS labels (
 
 	// Idempotent additive column for issue archiving (#34). Unix seconds; NULL = not archived.
 	if _, err := s.DB.Exec(`ALTER TABLE issues ADD COLUMN archived_at INTEGER`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column name") {
+			return err
+		}
+	}
+	// Idempotent additive column for mid-run question pause (#17). NULL when no
+	// question is in flight; UUID of the pending question otherwise.
+	if _, err := s.DB.Exec(`ALTER TABLE sessions ADD COLUMN pending_question_id TEXT`); err != nil {
 		if !strings.Contains(err.Error(), "duplicate column name") {
 			return err
 		}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -171,17 +171,27 @@ const (
 // --- Session (§6.5) ---
 
 type Session struct {
-	ID            string       `json:"id"`
-	WorkspaceID   string       `json:"workspace_id"`
-	IssueNumber   int          `json:"issue_number"`
-	Mode          SessionMode  `json:"mode"`
-	State         SessionState `json:"state"`
-	StartedAt     time.Time    `json:"started_at"`
-	EndedAt       *time.Time   `json:"ended_at,omitempty"`
-	PID           int          `json:"pid"`
-	Transcript    string       `json:"-"`
-	LastPrompt    string       `json:"last_prompt"`
-	BlockedReason string       `json:"blocked_reason,omitempty"`
+	ID                string       `json:"id"`
+	WorkspaceID       string       `json:"workspace_id"`
+	IssueNumber       int          `json:"issue_number"`
+	Mode              SessionMode  `json:"mode"`
+	State             SessionState `json:"state"`
+	StartedAt         time.Time    `json:"started_at"`
+	EndedAt           *time.Time   `json:"ended_at,omitempty"`
+	PID               int          `json:"pid"`
+	Transcript        string       `json:"-"`
+	LastPrompt        string       `json:"last_prompt"`
+	BlockedReason     string       `json:"blocked_reason,omitempty"`
+	PendingQuestionID string       `json:"pending_question_id,omitempty"`
+}
+
+// MidRunAnswer is the §6.4-shaped answer payload for a mid-run question
+// (issue #17). One question per call; symmetry with the multi-question
+// AnswerSubmission shape is intentionally not preserved.
+type MidRunAnswer struct {
+	QuestionID string   `json:"question_id"`
+	Answer     string   `json:"answer"`
+	Multi      []string `json:"multi,omitempty"`
 }
 
 // SessionActivity is the per-tick liveness payload emitted on the
@@ -206,9 +216,10 @@ const (
 type SessionState string
 
 const (
-	StateRunning         SessionState = "running"
-	StateWaitingForInput SessionState = "waiting_for_input"
-	StateBlocked         SessionState = "blocked"
-	StateCompleted       SessionState = "completed"
-	StateFailed          SessionState = "failed"
+	StateRunning            SessionState = "running"
+	StateWaitingForInput    SessionState = "waiting_for_input"
+	StateBlocked            SessionState = "blocked"
+	StateCompleted          SessionState = "completed"
+	StateFailed             SessionState = "failed"
+	StatePausedForQuestion  SessionState = "paused_for_question"
 )


### PR DESCRIPTION
## Summary

Wires mid-run questions into the conductor via Option A from the issue body — file-watcher reentry. The execute worker stays one-shot (`claude -p`); a `/conductor-question` invocation pauses the run cleanly without flipping to `failed`; the answer-file watcher then re-spawns a fresh `claude -p` worker with `--resume-question <id>` that continues on the same feature branch and reuses the original draft PR.

## Files modified

- `internal/types/types.go` — `Session.PendingQuestionID`, new `StatePausedForQuestion`, `MidRunAnswer` struct.
- `internal/session/patterns.go` — new `PatternQuestionPending = "QUESTION_PENDING: "`.
- `internal/session/manager.go` — new `matchPatterns` arm for the sentinel; `mapTerminalState` helper extracted (paused state survives clean exit + non-zero exit); worktree teardown leaves paused worktrees on disk; new `SpawnExecuteResume` + `executeResumePrompt`.
- `internal/session/manager_test.go` (new) — `mapTerminalState` table-test, `matchPatterns` QUESTION_PENDING tests including one-in-flight + empty-id guards.
- `internal/store/sqlite.go` — `pending_question_id TEXT` column on `sessions`, idempotent `ALTER TABLE` so existing dev DBs upgrade cleanly.
- `internal/store/sessions.go` — `SaveSession` upserts the new column; new `UpdateSessionPendingQuestion`; `LoadRunningSessions` includes `paused_for_question` rows; new `ListPausedForQuestionSessions` for the watcher.
- `internal/store/answers_watch.go` (new) + tests — 1s ticker watcher; rev-keyed answer files (plan-mode) are excluded so they don't trip mid-run resume; idempotent per (session, question) pair.
- `internal/skills/bundle/skills/conductor-question.md` — replaced the polling-loop body with the write-and-exit-clean contract; sidecar (`<id>.context.json`) documented.
- `internal/skills/bundle/skills/conductor-execute.md` — added `--resume-question <id>` flag; resume mode reads sidecar, skips branch creation, single-PR enforcement via `gh pr list --head`.
- `app.go` — instantiates `AnswerWatcher` at startup, wires resume callback (loads plan, spawns resume worker, clears stale `pending_question_id`); new `SubmitMidRunAnswer` and `GetMidRunQuestion` Wails-bound methods; `notifyBody` distinguishes mid-run pause from plan-mode wait.
- `frontend/wailsjs/go/{main,models}` — regenerated bindings (`wails generate module`).
- `frontend/src/components/MidRunQuestionModal.tsx` (new) — single-question wrapper around `QuestionForm`; submits a `MidRunAnswer`.
- `frontend/src/components/Card.tsx` — surfaces `paused_for_question` with amber pulse + `❓ awaiting answer`; click opens the modal.

## Verification

- Lint: `go vet ./...` → clean.
- Build: `wails build` → built `prismconductor.app` cleanly.
- Tests: `go test ./...` → all packages pass (`internal/session`, `internal/store`, `internal/git`, `internal/orchestrator`, `prismconductor` root all green); frontend has no test runner today.
- Frontend typecheck: `npx tsc --noEmit` → clean.

## Acceptance (mirrors issue body)

1. Execute worker hits `/conductor-question` → exits 0 → card flips amber `paused_for_question`, NOT `failed`. ✓ (PTY arm + `mapTerminalState` covered by `manager_test.go`.)
2. User answers → fresh worker spawns automatically → continues on the same branch → ends in the same draft PR. ✓ (`AnswerWatcher` → `SpawnExecuteResume` + `gh pr list --head` enforcement in skill.)
3. Modal dismissal leaves card amber until answered. ✓ (Dismiss closes the modal but does NOT write the answer file; the watcher only fires when the answer file lands.)
4. Conductor restart with a pending question + possibly a pre-existing answer file → first watcher tick auto-resumes. ✓ (`LoadRunningSessions` includes `paused_for_question`; watcher does not distinguish "live" from "already on disk".)

## Test plan

- [ ] Approve a plan, watch the execute worker spawn, then have it invoke `/conductor-question` mid-run. Confirm card flips to amber (not red), and the worker process exits 0.
- [ ] Click the amber card → confirm `MidRunQuestionModal` renders the question, recommendation pre-selected.
- [ ] Submit answer → confirm a fresh execute session spawns within ~1s, on the same branch, in the same worktree.
- [ ] Confirm only ONE draft PR exists for the issue at the end (`gh pr list --head feat/issue-...`).
- [ ] Quit the conductor while a card is paused, relaunch — card should still be amber and the modal should still open.
- [ ] Pre-write an answer file before the conductor restarts → on relaunch, watcher's first tick should auto-resume without UI interaction.

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-17

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)
