### PR TITLE
Auto-apply planner-suggested labels from plan ready (#24)

### DIFF
--- a/PRISMCONDUCTOR_PLAN.md
+++ b/PRISMCONDUCTOR_PLAN.md
@@ -179,6 +179,7 @@ type SkillProfile struct {
     NativeExecuteCommand string    `json:"native_execute_command"` // e.g. "/start-issue --resume-from-approved-plan"
     NativeCloseCommand   string    `json:"native_close_command"`   // e.g. "/check-and-close"
     ExtraContextFiles    []string  `json:"extra_context_files"`    // optional repo-local files to preload
+    AutoApplyLabels      *bool     `json:"auto_apply_labels,omitempty"` // nil = enabled (issue #24)
 }
 
 type SkillMode string
@@ -399,7 +400,7 @@ const (
 | `issue_added` (new GH issue matching filter) | Run rank+deps for the single new issue + neighbors. Insert into TODO at correct position. |
 | `issue_closed` | Remove from board (move to DONE column visually). Recompute unblocked status of dependents. Reorder TODO. |
 | `issue_label_changed` | Re-evaluate goal membership. Add/remove from candidate set if needed. |
-| `plan_ready` | Mark card "Plan Ready (rev N, K questions)". Notify user. **Do not auto-pull next** — wait for user approval first. |
+| `plan_ready` | Mark card "Plan Ready (rev N, K questions)". Notify user. **Do not auto-pull next** — wait for user approval first. If `SkillProfile.AutoApplyLabelsEnabled()` and `plan.SuggestedLabels` is non-empty, the orchestrator intersects with the workspace label cache and applies the union via `SetIssueLabels` (replacing the prior plan revision's axis label — issue #24). The resulting `EvtIssueLabelChanged` is the only side effect. |
 | `plan_approved` | Move card to IN_PROGRESS. Resume worker session in execute mode. |
 | `plan_rejected` | Move card back to TODO. Free worker slot. |
 | `plan_revised` | Mark card "Plan Ready (rev N+1)". Notify user. |
@@ -448,11 +449,17 @@ When a worker finishes plan mode, it MUST emit a JSON file at `<repo>/.prismcond
 
 `ready_to_execute` is `true` only when `questions` is empty (or all answered in a revision).
 
-`suggested_labels` is optional (`omitempty`). Populated by `conductor-plan` from `gh label list`
-plus a semantic match against the issue title/body. Plans without it deserialize cleanly — older
-revisions on disk and native-mode skills are unaffected. The UI renders each entry as a click-to-apply
-chip in the PlanModal; if the suggested label doesn't yet exist on GitHub, the chip opens the
-LabelsModal pre-filled rather than auto-creating.
+`suggested_labels` is optional (`omitempty`). Populated by `conductor-plan` with one **axis** label
+at index 0 (`enhancement` / `bug` / `refactor` / `documentation` / `test` — mapped from the issue
+type to whatever the repo's existing vocabulary calls it) followed by up to 4 **topical** labels
+naming the components/areas the plan touches (`frontend`, `backend`, `worker`, etc.). Topicals MAY
+be names the repo doesn't have yet; the conductor's auto-apply path (issue #24) drops missing names
+with a log line, and the PlanModal renders them as `(create)` chips so the user can opt to create
+them. Plans without `suggested_labels` deserialize cleanly — older revisions on disk and native-mode
+skills are unaffected. When the workspace's `SkillProfile.AutoApplyLabelsEnabled()` is true (the
+default), labels matching the cache are applied automatically on `plan_ready`; the modal still
+renders click-to-toggle chips for every entry, with an `(auto-applied)` badge on the ones already
+on the issue.
 
 ### 9.2 AskUserQuestion Schema (UI-rendered)
 
@@ -922,7 +929,7 @@ The conductor ships four universal skills with the binary:
 
 | Skill | Purpose |
 |---|---|
-| `conductor-plan` | Universal `/start-issue` analogue. Reads issue, greps repo, reads any `CLAUDE.md` + `.claude/rules/` present, emits plan JSON, stops. No code mutation. |
+| `conductor-plan` | Universal `/start-issue` analogue. Reads issue, greps repo, reads any `CLAUDE.md` + `.claude/rules/` present, classifies the issue (axis label at index 0 + up to 4 topical labels — issue #24), emits plan JSON, stops. No code mutation. |
 | `conductor-execute` | Resumes from approved plan + answered questions. Reads repo conventions from `ConventionHints` for test/build commands. Implements per plan. Opens draft PR. |
 | `conductor-close` | Universal `/check-and-close` analogue. Posts completion summary, closes issue. No commit/push beyond what was already done. |
 | `conductor-question` | Helper invoked inline when a worker needs to emit a structured question mid-execution. Writes to `<repo>/.prismconductor/questions/<id>.json`. |

--- a/app.go
+++ b/app.go
@@ -921,6 +921,126 @@ func (a *App) SetIssueLabels(workspaceID string, issueNumber int, names []string
 	return nil
 }
 
+// autoApplyPlanLabels intersects plan.SuggestedLabels with the workspace label
+// cache, drops missing names (logged, never invented — issue #24 q3 C),
+// reconciles the prior plan revision's axis label (q2 A), and pushes the
+// union via SetIssueLabels (which fires EvtIssueLabelChanged — q4 A).
+func (a *App) autoApplyPlanLabels(ws types.Workspace, issueNumber int, plan *types.Plan) {
+	if a.store == nil {
+		return
+	}
+	cache, err := a.store.ListLabels(ws.ID)
+	if err != nil {
+		log.Printf("auto-apply labels #%d: list cache: %v", issueNumber, err)
+		return
+	}
+	inCache := make(map[string]struct{}, len(cache))
+	for _, l := range cache {
+		inCache[l.Name] = struct{}{}
+	}
+
+	var keep []string
+	for _, name := range plan.SuggestedLabels {
+		if _, ok := inCache[name]; ok {
+			keep = append(keep, name)
+		} else {
+			log.Printf("auto-apply #%d: dropped suggestion %q (not in repo)", issueNumber, name)
+		}
+	}
+
+	issue, ok := a.findIssue(ws.ID, issueNumber)
+	if !ok {
+		return
+	}
+	priorAxis := a.priorAxisLabel(ws.ID, issueNumber, plan.Revision)
+	next := reconcileAutoLabels(issue.Labels, keep, priorAxis)
+	if labelSetEqual(issue.Labels, next) {
+		return
+	}
+	if err := a.SetIssueLabels(ws.ID, issueNumber, next); err != nil {
+		log.Printf("auto-apply #%d: SetIssueLabels: %v", issueNumber, err)
+	}
+}
+
+// priorAxisLabel returns the first label of the issue's previous plan revision
+// (if any). Used to decide whether to drop the obsolete axis on re-plan.
+func (a *App) priorAxisLabel(workspaceID string, issueNumber, revision int) string {
+	if a.store == nil || revision <= 1 {
+		return ""
+	}
+	prior, err := a.store.GetPlan(workspaceID, issueNumber, revision-1)
+	if err != nil || len(prior.SuggestedLabels) == 0 {
+		return ""
+	}
+	return prior.SuggestedLabels[0]
+}
+
+// reconcileAutoLabels implements issue #24 q2 A:
+//   - start from current
+//   - if priorAxis is on current AND not in keep, drop it
+//   - union with keep
+//   - preserve original ordering of current (minus dropped axis), then append new
+func reconcileAutoLabels(current, keep []string, priorAxis string) []string {
+	keepSet := make(map[string]struct{}, len(keep))
+	for _, k := range keep {
+		keepSet[k] = struct{}{}
+	}
+	have := make(map[string]struct{}, len(current))
+	out := make([]string, 0, len(current)+len(keep))
+	for _, c := range current {
+		if priorAxis != "" && c == priorAxis {
+			if _, stillSuggested := keepSet[c]; !stillSuggested {
+				continue
+			}
+		}
+		if _, dup := have[c]; dup {
+			continue
+		}
+		have[c] = struct{}{}
+		out = append(out, c)
+	}
+	for _, k := range keep {
+		if _, dup := have[k]; dup {
+			continue
+		}
+		have[k] = struct{}{}
+		out = append(out, k)
+	}
+	return out
+}
+
+func labelSetEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(a))
+	for _, x := range a {
+		seen[x] = struct{}{}
+	}
+	for _, x := range b {
+		if _, ok := seen[x]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *App) findIssue(workspaceID string, issueNumber int) (types.Issue, bool) {
+	if a.store == nil {
+		return types.Issue{}, false
+	}
+	rows, err := a.store.ListIssues(workspaceID)
+	if err != nil {
+		return types.Issue{}, false
+	}
+	for _, iss := range rows {
+		if iss.Number == issueNumber {
+			return iss, true
+		}
+	}
+	return types.Issue{}, false
+}
+
 // AddManualIssue lets the user create a fake issue card in any column. Used to
 // drive the board UI before #2 lands the real GitHub fetch loop.
 func (a *App) AddManualIssue(workspaceID string, number int, title, body string, labels []string, column string) (*types.Issue, error) {
@@ -1082,6 +1202,11 @@ func (a *App) handlePlanReady(sess types.Session, relPath string) {
 	if err := a.store.SavePlan(*plan); err != nil {
 		log.Printf("plan save failed: %v\n", err)
 		return
+	}
+	// Issue #24: auto-apply planner-suggested labels before announcing plan_ready
+	// so the modal opens with the chips already in their final state.
+	if ws.SkillProfile.AutoApplyLabelsEnabled() && len(plan.SuggestedLabels) > 0 {
+		a.autoApplyPlanLabels(ws, sess.IssueNumber, plan)
 	}
 	a.bus.Publish(eventbus.EvtPlanReady, map[string]any{
 		"workspace_id": sess.WorkspaceID,

--- a/app_test.go
+++ b/app_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+
+	"prismconductor/internal/types"
+)
 
 func TestPullNumberFromURL(t *testing.T) {
 	cases := []struct {
@@ -19,6 +24,120 @@ func TestPullNumberFromURL(t *testing.T) {
 		got, ok := pullNumberFromURL(c.in)
 		if ok != c.wantOK || got != c.want {
 			t.Errorf("pullNumberFromURL(%q) = (%d,%v), want (%d,%v)", c.in, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+// Issue #24: AutoApplyLabelsEnabled defaults to true when the field is absent
+// (nil) so legacy workspace JSON keeps the new behavior without a migration.
+func TestAutoApplyLabelsEnabled(t *testing.T) {
+	tt := true
+	ff := false
+	cases := []struct {
+		name string
+		ptr  *bool
+		want bool
+	}{
+		{"nil defaults to true (legacy JSON)", nil, true},
+		{"explicit true", &tt, true},
+		{"explicit false disables", &ff, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sp := types.SkillProfile{AutoApplyLabels: c.ptr}
+			if got := sp.AutoApplyLabelsEnabled(); got != c.want {
+				t.Fatalf("AutoApplyLabelsEnabled() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// Issue #24 q2 A: re-plan reconciliation drops the prior axis label only,
+// preserves topical/manual labels, and unions the new suggestions.
+func TestReconcileAutoLabels(t *testing.T) {
+	cases := []struct {
+		name      string
+		current   []string
+		keep      []string
+		priorAxis string
+		want      []string
+	}{
+		{
+			name:      "first plan: union with empty current",
+			current:   nil,
+			keep:      []string{"enhancement", "frontend"},
+			priorAxis: "",
+			want:      []string{"enhancement", "frontend"},
+		},
+		{
+			name:      "no-op when keep already on issue",
+			current:   []string{"enhancement", "frontend"},
+			keep:      []string{"enhancement", "frontend"},
+			priorAxis: "",
+			want:      []string{"enhancement", "frontend"},
+		},
+		{
+			name:      "first plan: preserves manual labels",
+			current:   []string{"manual-tag"},
+			keep:      []string{"enhancement"},
+			priorAxis: "",
+			want:      []string{"manual-tag", "enhancement"},
+		},
+		{
+			name:      "re-plan axis swap: drops prior axis, keeps topical+manual, adds new axis",
+			current:   []string{"enhancement", "frontend", "manual-tag"},
+			keep:      []string{"bug"},
+			priorAxis: "enhancement",
+			want:      []string{"frontend", "manual-tag", "bug"},
+		},
+		{
+			name:      "re-plan: prior axis still suggested, do not drop",
+			current:   []string{"enhancement", "frontend"},
+			keep:      []string{"enhancement", "backend"},
+			priorAxis: "enhancement",
+			want:      []string{"enhancement", "frontend", "backend"},
+		},
+		{
+			name:      "re-plan: prior axis missing from issue (already removed manually) is a no-op for drop",
+			current:   []string{"frontend"},
+			keep:      []string{"bug"},
+			priorAxis: "enhancement",
+			want:      []string{"frontend", "bug"},
+		},
+		{
+			name:      "duplicate suggestions and labels are deduped",
+			current:   []string{"frontend", "frontend"},
+			keep:      []string{"frontend", "bug", "bug"},
+			priorAxis: "",
+			want:      []string{"frontend", "bug"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := reconcileAutoLabels(c.current, c.keep, c.priorAxis)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("reconcileAutoLabels(%v, %v, %q)\n  got:  %v\n  want: %v",
+					c.current, c.keep, c.priorAxis, got, c.want)
+			}
+		})
+	}
+}
+
+func TestLabelSetEqual(t *testing.T) {
+	cases := []struct {
+		a, b []string
+		want bool
+	}{
+		{nil, nil, true},
+		{[]string{}, nil, true},
+		{[]string{"a"}, []string{"a"}, true},
+		{[]string{"a", "b"}, []string{"b", "a"}, true},
+		{[]string{"a"}, []string{"a", "b"}, false},
+		{[]string{"a", "b"}, []string{"a", "c"}, false},
+	}
+	for _, c := range cases {
+		if got := labelSetEqual(c.a, c.b); got != c.want {
+			t.Errorf("labelSetEqual(%v, %v) = %v, want %v", c.a, c.b, got, c.want)
 		}
 	}
 }

--- a/frontend/src/components/PlanModal.tsx
+++ b/frontend/src/components/PlanModal.tsx
@@ -276,7 +276,20 @@ function LabelsSection({
   }, [cache]);
 
   const current = issue.labels ?? [];
-  const suggestions = (plan.suggested_labels ?? []).filter((n) => !current.includes(n));
+  // Issue #24: keep ALL planner suggestions rendered. Applied ones get an
+  // (auto-applied) badge; unapplied ones keep the dashed Apply chip.
+  const suggestions = plan.suggested_labels ?? [];
+
+  async function removeApplied(name: string) {
+    onError(null);
+    const next = current.filter((n) => n !== name);
+    try {
+      await SetIssueLabels(issue.workspace_id, issue.number, next);
+      await onIssueRefresh();
+    } catch (e: any) {
+      onError(String(e?.message ?? e));
+    }
+  }
 
   async function applySuggestion(name: string) {
     const exists = cacheByName.has(name);
@@ -331,8 +344,23 @@ function LabelsSection({
           <div className="flex flex-wrap items-center gap-1.5">
             {suggestions.map((name) => {
               const exists = cacheByName.has(name);
+              const applied = current.includes(name);
               const color = cacheByName.get(name)?.color ?? "475569";
               const fg = getContrastText(color);
+              if (applied) {
+                return (
+                  <button
+                    key={name}
+                    onClick={() => removeApplied(name)}
+                    className="px-1.5 py-0.5 rounded text-[11px] font-medium hover:opacity-80"
+                    style={{ backgroundColor: `#${color}`, color: fg }}
+                    title="Auto-applied by planner — click to remove"
+                  >
+                    {name}
+                    <span className="ml-1 opacity-70">(auto-applied)</span>
+                  </button>
+                );
+              }
               return (
                 <button
                   key={name}

--- a/frontend/src/components/SkillProfileEditor.tsx
+++ b/frontend/src/components/SkillProfileEditor.tsx
@@ -91,6 +91,21 @@ export function SkillProfileEditor({ workspace }: { workspace: types.Workspace }
           </div>
         </div>
       )}
+
+      <div className="flex items-start justify-between border-t border-slate-800 pt-3">
+        <div className="flex-1 mr-3">
+          <div className="text-sm text-slate-200">Auto-apply planner label suggestions</div>
+          <div className="text-[11px] text-slate-500 mt-0.5">
+            When a plan is ready, apply each <code>suggested_labels</code> entry that exists in
+            the repo's label cache. Missing labels are surfaced in the plan modal with a (create) chip.
+          </div>
+        </div>
+        <Toggle
+          label=""
+          checked={sp.auto_apply_labels !== false}
+          onChange={(v) => update({ auto_apply_labels: v })}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1281,6 +1281,7 @@ export namespace types {
 	    native_execute_command: string;
 	    native_close_command: string;
 	    extra_context_files: string[];
+	    auto_apply_labels?: boolean;
 	
 	    static createFrom(source: any = {}) {
 	        return new SkillProfile(source);
@@ -1296,6 +1297,7 @@ export namespace types {
 	        this.native_execute_command = source["native_execute_command"];
 	        this.native_close_command = source["native_close_command"];
 	        this.extra_context_files = source["extra_context_files"];
+	        this.auto_apply_labels = source["auto_apply_labels"];
 	    }
 	}
 	export class Workspace {

--- a/internal/skills/bundle/skills/conductor-plan.md
+++ b/internal/skills/bundle/skills/conductor-plan.md
@@ -18,10 +18,29 @@ Bundled by PrismConductor. Used in Bundled and Hybrid skill modes (PRISMCONDUCTO
 1. Fetch the issue body via `gh issue view <number> --json title,body,labels`.
 2. Read `CLAUDE.md` and `.claude/rules/*.md` if present (silently skip if absent — see §15.8).
 3. Grep the repo for terms in the issue title and body that name files/symbols.
-4. Run `gh label list -R <owner>/<repo> --json name,color,description --limit 200` to see the repo's
-   label vocabulary. From the issue title + body + the file paths picked above, suggest the labels
-   whose name or description plausibly applies to this issue. Err on the side of restraint
-   (max 5 suggestions). Never invent labels that don't already exist on GitHub.
+4. Run `gh label list -R <owner>/<repo> --json name,color,description --limit 200` to see the
+   repo's label vocabulary. Then classify the issue (NON-NEGOTIABLE):
+
+   - **Axis** (pick exactly one — never multi-axis):
+     - `feature` (new capability) → map to existing `enhancement` / `feature` / `feat` (in
+       that priority order). If none of those exist in the repo, omit the axis label.
+     - `bug` (defect fix) → map to `bug` / `defect` / `fix`.
+     - `refactor` (no behavior change) → map to `refactor` / `cleanup` / `chore`.
+     - `docs` (markdown-only) → map to `documentation` / `docs`.
+     - `test` (test-only) → map to `test` / `tests` / `testing`.
+   - **Topical** (up to 4): include component, area, or module names suggested by the file
+     paths the plan modifies (e.g. `frontend`, `backend`, `worker`, `orchestrator`,
+     `eventbus`). **Suggest these even when they don't exist in the repo's label list yet** —
+     the conductor drops them on auto-apply (logging the drop), and the PlanModal renders
+     them with a `(create)` chip so the user can opt to create the missing label. This
+     surfaces gaps in the repo's label vocabulary.
+   - **Cap**: 5 entries total.
+   - **Order**: axis FIRST (index 0), then topicals. The conductor's auto-apply reconciler
+     reads index 0 as the axis on re-plan to decide whether to drop the prior axis label.
+     Any deviation from this ordering breaks re-plan reconciliation.
+
+   Axis names MUST map to existing repo labels via the priority lists above — do not invent
+   axis names. The "suggest even if missing" rule applies to topicals only.
 5. Compose a plan that lists:
    - What to do (markdown)
    - Files to add/modify/delete

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -34,6 +34,14 @@ type SkillProfile struct {
 	NativeExecuteCommand string    `json:"native_execute_command"`
 	NativeCloseCommand   string    `json:"native_close_command"`
 	ExtraContextFiles    []string  `json:"extra_context_files"`
+	AutoApplyLabels      *bool     `json:"auto_apply_labels,omitempty"`
+}
+
+// AutoApplyLabelsEnabled returns true when the workspace opts in to auto-apply
+// of planner-suggested labels. Absent (nil) means enabled — legacy workspace
+// JSON keeps the new behavior without a migration.
+func (sp SkillProfile) AutoApplyLabelsEnabled() bool {
+	return sp.AutoApplyLabels == nil || *sp.AutoApplyLabels
 }
 
 type SkillMode string


### PR DESCRIPTION
## Summary

Auto-apply planner-suggested labels when a plan is ready, intersected against the workspace's cached repo label vocabulary. Adds an opt-out toggle to `SkillProfileEditor` (default ON via `SkillProfile.AutoApplyLabels *bool`, nil = enabled, no DB migration). Re-plan reconciliation drops the prior plan revision's axis label (the suggestion at index 0) when it's no longer suggested, preserving topical and manual labels. PlanModal now renders three chip states: `+ name` (apply), `+ name (create)` (label missing in repo), and `name (auto-applied)` (already applied — click to remove).

The bundled `conductor-plan` skill is updated to classify the issue as one **axis** label (mapped to existing `enhancement`/`bug`/`refactor`/`documentation`/`test` vocab) at index 0 plus up to 4 **topical** labels — topicals MAY include names the repo doesn't have yet (`frontend`, `backend`, etc.); the conductor logs and drops missing names so the modal can surface them via the `(create)` chip.

## Files modified

- `internal/types/types.go` — `SkillProfile.AutoApplyLabels *bool` + `AutoApplyLabelsEnabled()` helper
- `app.go` — `autoApplyPlanLabels`, `priorAxisLabel`, `reconcileAutoLabels`, `labelSetEqual`, `findIssue`; `handlePlanReady` calls auto-apply between `SavePlan` and `EvtPlanReady`
- `app_test.go` — table tests for `AutoApplyLabelsEnabled`, `reconcileAutoLabels` (6 cases incl. axis swap, manual-label preservation, dedupe), and `labelSetEqual`
- `internal/skills/bundle/skills/conductor-plan.md` — axis/topical classification rules with axis-at-index-0 ordering
- `frontend/src/components/SkillProfileEditor.tsx` — auto-apply toggle row
- `frontend/src/components/PlanModal.tsx` — three-state chip rendering with `removeApplied` handler
- `frontend/wailsjs/go/models.ts` — regenerated by `wails build`; adds `auto_apply_labels?: boolean`
- `PRISMCONDUCTOR_PLAN.md` — §6.1.1 struct field, §8 plan_ready row, §9.1 suggested_labels prose, §15.7 conductor-plan row

## Verification

- **Lint:** `go vet ./...` → ✅ clean
- **Frontend typecheck:** `npx tsc --noEmit` (from `frontend/`) → ✅ clean
- **Build:** `go build ./...` → ✅; `wails build` → ✅ packaged `prismconductor.app`
- **Tests:** `go test ./...` → ✅ all packages pass; the new `TestAutoApplyLabelsEnabled`, `TestReconcileAutoLabels` (7 sub-cases), and `TestLabelSetEqual` are in `prismconductor` package output (`ok prismconductor 0.547s`)

## Notes for reviewers

- The integration path (`autoApplyPlanLabels` → `SetIssueLabels` → GitHub round-trip) is covered by the manual smoke test in the locked plan, not by Go tests, because `app_test.go` has no `gh` client mock infrastructure today. The pure logic (`reconcileAutoLabels`) carries the new behavior and is unit-tested with the three acceptance scenarios called out in the issue body (first-plan apply, axis swap on re-plan, dedupe).
- Auto-apply is wired BEFORE `EvtPlanReady` is published, so the modal opens with the chips already reflecting the post-apply state. If the apply call fails, the error is logged and the plan_ready event still fires; the user can always apply manually from the modal.
- This repo's GitHub label set today only has the stock GH labels (no `frontend`/`backend`/`worker`). With the new q3 C behavior, planner suggestions for those topicals WILL be logged as dropped on auto-apply — that's by design and surfaces the gap via `(create)` chips in the modal.
- Workspace mode: per-execute worktree at `/Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-24`

Closes #24
