### PR TITLE
test(app): pin Archive-DONE chain end-to-end (#49)

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
+	"prismconductor/internal/eventbus"
+	"prismconductor/internal/store"
 	"prismconductor/internal/types"
 )
 
@@ -120,6 +124,84 @@ func TestReconcileAutoLabels(t *testing.T) {
 					c.current, c.keep, c.priorAxis, got, c.want)
 			}
 		})
+	}
+}
+
+// Issue #49: pin the Archive-DONE chain end-to-end at the App layer. The bug
+// report claimed the 📦 Archive N button was dead; rev1's static walk showed
+// every link wired correctly. This test fails loudly if the SQL filter, the
+// bus publish, or the ListIssues exclusion ever regress.
+func TestApp_ArchiveDone_PublishesEventAndExcludesFromListIssues(t *testing.T) {
+	s, err := store.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	bus := eventbus.New()
+	a := &App{store: s, bus: bus}
+
+	seed := func(num int, col types.BoardColumn) {
+		if _, err := s.SaveIssue(types.Issue{
+			WorkspaceID: "ws1",
+			Number:      num,
+			Title:       fmt.Sprintf("#%d", num),
+			State:       "open",
+			Column:      col,
+		}); err != nil {
+			t.Fatalf("SaveIssue %d: %v", num, err)
+		}
+	}
+	seed(101, types.ColDone)
+	seed(102, types.ColDone)
+	seed(103, types.ColDone)
+	seed(200, types.ColInProgress)
+
+	captured := make(chan eventbus.Event, 4)
+	bus.Subscribe(func(e eventbus.Event) {
+		if e.Type == eventbus.EvtIssuesArchived {
+			captured <- e
+		}
+	})
+
+	n, err := a.ArchiveDone("ws1")
+	if err != nil {
+		t.Fatalf("ArchiveDone: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("count = %d, want 3", n)
+	}
+
+	select {
+	case evt := <-captured:
+		p, ok := evt.Payload.(map[string]any)
+		if !ok {
+			t.Fatalf("payload type = %T, want map[string]any", evt.Payload)
+		}
+		if p["workspace_id"] != "ws1" {
+			t.Errorf("workspace_id = %v, want ws1", p["workspace_id"])
+		}
+		if p["count"] != 3 {
+			t.Errorf("count = %v, want 3", p["count"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("EvtIssuesArchived not published within 1s")
+	}
+
+	live, err := a.ListIssues("ws1")
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(live) != 1 || live[0].Number != 200 {
+		t.Errorf("ListIssues after archive = %v, want only #200", live)
+	}
+
+	arch, err := a.ListArchivedIssues("ws1")
+	if err != nil {
+		t.Fatalf("ListArchivedIssues: %v", err)
+	}
+	if len(arch) != 3 {
+		t.Errorf("archived count = %d, want 3", len(arch))
 	}
 }
 


### PR DESCRIPTION
## Summary

Issue #49 reports the `📦 Archive N` button (shipped in #34 / PR #41) is dead. Rev1's static walk of the chain on `main` showed every link is wired correctly — `Board.tsx` → `App.ArchiveDone` → `Store.ArchiveDone` → `EvtIssuesArchived` → frontend `bus.issues_archived` listener. Per the rev1 q3 answer, this PR lands the App-level regression test that pins the chain end-to-end so any future regression in the SQL filter, the binding, or the event publish surfaces in CI.

## Files modified

- `app_test.go` — adds `TestApp_ArchiveDone_PublishesEventAndExcludesFromListIssues`

## Verification

- **Lint:** `go vet ./...` → clean (exit 0)
- **Typecheck:** `cd frontend && npx tsc --noEmit` → clean (exit 0)
- **Build:** `go build ./...` → clean (exit 0); `cd frontend && npm run build` → built `frontend/dist` (required for the `//go:embed all:frontend/dist` directive in `main.go`)
- **Tests:** `go test ./... -count=1` → all packages pass; `go test -run TestApp_ArchiveDone_PublishesEventAndExcludesFromListIssues -v .` → PASS

## ⚠ No live `wails dev` repro performed

Step 1 of the plan called for a manual `wails dev` click-test gating the optional Reality-B patch in step 3. That requires an interactive desktop session (Wails opens a native webview window) and was not run from this conductor worker. Per the rev1 q3 answer, the regression test is the locked deliverable regardless. **Reviewer should run `wails dev` locally, click `📦 Archive N` in a workspace with DONE cards, and confirm DONE drains and the `🗄 Archived (N)` chip increments.** If the button is in fact broken at HEAD, file a follow-up — this PR's test does not exercise the dnd-kit pointer-event path between the click and `App.ArchiveDone`.

Anyone rebuilding locally should re-run `wails generate module` in case stale bindings cause a false alarm.

## Out of scope (locked by rev1 answers)

- No frontend test framework added (q4).
- No refactor of the confirm prompt or `📦` glyph.
- All-workspaces (`selectedID = ""`) semantics already covered by `TestArchiveDoneEmptyWorkspaceArchivesAll` in `internal/store/issues_test.go`.

Workspace mode: per-execute worktree at `/Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-49`

Closes #49
