### PR TITLE
feat(session): detach workers and treat transcript as truth (#54)

### DIFF
--- a/app.go
+++ b/app.go
@@ -213,9 +213,15 @@ func (a *App) startup(ctx context.Context) {
 	}
 
 	// Re-attach to sessions that were live at last shutdown (§15.3).
+	// Issue #54: Reattach now needs the workspace list so the live-tail
+	// goroutine can rebuild repoPath / worktreeDir for post-mortem cleanup.
 	if a.store != nil {
 		if running, _, err := a.store.LoadRunningSessions(); err == nil {
-			a.mgr.Reattach(running)
+			var workspaces []types.Workspace
+			if a.wsReg != nil {
+				workspaces = a.wsReg.List()
+			}
+			a.mgr.Reattach(running, workspaces)
 		}
 		// Self-heal any closed issues stuck in non-DONE columns from earlier
 		// buggy poll cycles.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module prismconductor
 go 1.25.0
 
 require (
-	github.com/creack/pty v1.1.24
 	github.com/google/go-github/v62 v62.0.0
 	github.com/google/uuid v1.6.0
 	github.com/wailsapp/wails/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
 github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
-github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
-github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -12,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/creack/pty"
 	"github.com/google/uuid"
 
 	"prismconductor/internal/eventbus"
@@ -30,6 +30,7 @@ type Persister interface {
 	SaveSession(sess *types.Session, transcriptPath string) error
 	UpdateSessionState(id string, state types.SessionState) error
 	UpdateSessionPendingQuestion(id, questionID string) error
+	UpdateSessionTranscriptOffset(id string, off int64) error
 }
 
 // StateChangeHandler is fired on every state transition. Used by the App layer
@@ -70,17 +71,21 @@ type Manager struct {
 type runtimeSession struct {
 	sess           *types.Session
 	cmd            *exec.Cmd
-	pty            *os.File
 	cancel         context.CancelFunc
 	transcriptPath string
 	transcriptFile *os.File
 	parser         *StreamParser
 
-	actMu          sync.Mutex
-	toolCount      int
-	lastAction     string
-	lastActionAt   time.Time
-	lastEmittedAt  time.Time
+	// Issue #54: byte offset into transcriptPath of the last fully-flushed line.
+	// Persisted every ~2s during live tail; on restart we seek here to avoid
+	// re-feeding lines we already processed.
+	transcriptOffset int64
+
+	actMu         sync.Mutex
+	toolCount     int
+	lastAction    string
+	lastActionAt  time.Time
+	lastEmittedAt time.Time
 
 	// Issue #22: per-execute worktree fields. Empty for plan/raw spawns.
 	// repoPath is captured here so the cleanup hook in tailAndParse doesn't
@@ -92,6 +97,11 @@ type runtimeSession struct {
 	// Issue #27: pool the slot was reserved against. Threaded through to the
 	// EvtWorkerSlotFreed payload so the orchestrator releases the right pool.
 	poolID string
+
+	// Issue #54: true when this runtimeSession is a re-attach (no owned
+	// process). Reattach paths skip cmd.Wait + worktree teardown that the
+	// fresh-spawn path needs.
+	reattached bool
 }
 
 func NewManager(bus *eventbus.Bus, emit LineHandler) *Manager {
@@ -294,10 +304,31 @@ func (m *Manager) spawn(ws types.Workspace, issue types.Issue, mode types.Sessio
 // spawnWithDir is the canonical spawn path. When worktreeDir is non-empty the
 // child process runs there instead of ws.RepoPath, and the worktree metadata
 // is captured on the runtimeSession for the cleanup hook in tailAndParse.
+//
+// Issue #54: the worker's stdout/stderr point at the transcript file directly
+// so it survives a conductor exit (no Go-side copy goroutine that would die
+// with us and break the pipe). The conductor reads worker output by polling
+// the same file (tailAndParse). This also unifies the live-spawn path with
+// the re-attach path: both consume the file.
 func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types.SessionMode, argv []string, worktreeDir, branch, poolID string) (*types.Session, error) {
 	if len(argv) == 0 {
 		return nil, fmt.Errorf("empty command")
 	}
+	if m.transcriptDir == "" {
+		// The transcript file is now load-bearing — it IS the worker's stdout.
+		// Without a transcript dir we have nowhere to point cmd.Stdout, so refuse.
+		return nil, fmt.Errorf("session manager: transcript dir not configured")
+	}
+	if err := os.MkdirAll(m.transcriptDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create transcript dir: %w", err)
+	}
+	sessID := uuid.NewString()
+	transcriptPath := filepath.Join(m.transcriptDir, sessID+".log")
+	tf, err := os.Create(transcriptPath)
+	if err != nil {
+		return nil, fmt.Errorf("create transcript: %w", err)
+	}
+
 	cmd := exec.Command(argv[0], argv[1:]...)
 	switch {
 	case worktreeDir != "":
@@ -306,15 +337,20 @@ func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types
 		cmd.Dir = ws.RepoPath
 	}
 	cmd.Env = append(os.Environ(), envSpecToSlice(ws.AgentEnv)...)
+	cmd.Stdin = nil
+	cmd.Stdout = tf
+	cmd.Stderr = tf
+	cmd.SysProcAttr = detachedProcAttr()
 
-	f, err := pty.Start(cmd)
-	if err != nil {
-		return nil, fmt.Errorf("pty.Start: %w", err)
+	if err := cmd.Start(); err != nil {
+		_ = tf.Close()
+		_ = os.Remove(transcriptPath)
+		return nil, fmt.Errorf("cmd.Start: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sess := &types.Session{
-		ID:          uuid.NewString(),
+		ID:          sessID,
 		WorkspaceID: ws.ID,
 		IssueNumber: issue.Number,
 		Mode:        mode,
@@ -322,27 +358,20 @@ func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types
 		StartedAt:   time.Now(),
 		PID:         cmd.Process.Pid,
 	}
+	sess.Transcript = transcriptPath
 
 	rs := &runtimeSession{
-		sess:        sess,
-		cmd:         cmd,
-		pty:         f,
-		cancel:      cancel,
-		parser:      NewStreamParser(),
-		worktreeDir: worktreeDir,
-		branch:      branch,
-		repoPath:    ws.RepoPath,
-		poolID:      poolID,
+		sess:           sess,
+		cmd:            cmd,
+		cancel:         cancel,
+		parser:         NewStreamParser(),
+		transcriptPath: transcriptPath,
+		transcriptFile: tf,
+		worktreeDir:    worktreeDir,
+		branch:         branch,
+		repoPath:       ws.RepoPath,
+		poolID:         poolID,
 	}
-
-	if m.transcriptDir != "" {
-		_ = os.MkdirAll(m.transcriptDir, 0o755)
-		rs.transcriptPath = filepath.Join(m.transcriptDir, sess.ID+".log")
-		if tf, err := os.Create(rs.transcriptPath); err == nil {
-			rs.transcriptFile = tf
-		}
-	}
-	sess.Transcript = rs.transcriptPath
 
 	if m.store != nil {
 		_ = m.store.SaveSession(sess, rs.transcriptPath)
@@ -359,77 +388,92 @@ func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types
 	return sess, nil
 }
 
+// tailAndParse polls the transcript file for new lines, feeds each through
+// the per-session parser, and routes the resulting display lines to emit /
+// matchPatterns / recordActivity. Issue #54 replaces the old PTY byte-stream
+// reader with a file tail because the worker's stdout IS the transcript file
+// now (so the conductor exiting doesn't break the worker's writes).
 func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 	defer func() {
-		rs.pty.Close()
+		// Conductor's handle on the transcript file. Closing it here doesn't
+		// affect the worker — the worker has its own fd via fork+exec dup.
 		if rs.transcriptFile != nil {
-			rs.transcriptFile.Close()
+			_ = rs.transcriptFile.Close()
 		}
 	}()
-	// Byte-streamed tail. bufio.Scanner withholds anything that lacks a
-	// newline; `claude -p` and similar tools may emit partial lines (progress
-	// indicators, spinner frames, the final unterminated chunk). We flush at
-	// each \n / \r, AND flush a pending partial line whenever a Read returns
-	// no further data within the read window.
-	buf := make([]byte, 4096)
-	var pending []byte
-	flush := func(rawLine string) {
-		rawLine = stripANSI(rawLine)
-		if rawLine == "" {
-			return
-		}
-		// stream-json events are line-delimited JSON; pass through the parser
-		// to get role-prefixed display lines + accumulated assistant text.
-		var lines []string
-		if rs.parser != nil {
-			lines = rs.parser.Feed(rawLine)
-		} else {
-			lines = []string{rawLine}
-		}
-		for _, line := range lines {
-			if line == "" {
-				continue
+
+	// Run Wait in a sibling goroutine so the tail loop can detect "child has
+	// exited" without blocking on Wait itself. Buffered so the goroutine can
+	// always return even if we never read from done.
+	done := make(chan error, 1)
+	go func() { done <- rs.cmd.Wait() }()
+
+	var waitErr error
+	var waited bool
+	if rf, err := os.Open(rs.transcriptPath); err != nil {
+		log.Printf("tailAndParse: open transcript %s: %v", rs.transcriptPath, err)
+	} else {
+		reader := bufio.NewReader(rf)
+		var lastFlush time.Time
+	tail:
+		for {
+			select {
+			case <-ctx.Done():
+				break tail
+			default:
 			}
-			if rs.transcriptFile != nil {
-				fmt.Fprintln(rs.transcriptFile, line)
-			}
-			if m.emit != nil {
-				m.emit(rs.sess.ID, line)
-			}
-			m.matchPatterns(rs, line)
-			m.recordActivity(rs, line)
-		}
-	}
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-		n, err := rs.pty.Read(buf)
-		if n > 0 {
-			for i := 0; i < n; i++ {
-				c := buf[i]
-				if c == '\n' || c == '\r' {
-					if len(pending) > 0 {
-						flush(string(pending))
-						pending = pending[:0]
-					}
-				} else {
-					pending = append(pending, c)
+			line, rerr := reader.ReadString('\n')
+			if len(line) > 0 {
+				m.feedLine(rs, strings.TrimRight(line, "\r\n"))
+				rs.transcriptOffset += int64(len(line))
+				if m.store != nil && time.Since(lastFlush) >= 2*time.Second {
+					_ = m.store.UpdateSessionTranscriptOffset(rs.sess.ID, rs.transcriptOffset)
+					lastFlush = time.Now()
 				}
 			}
-		}
-		if err != nil {
-			if len(pending) > 0 {
-				flush(string(pending))
-				pending = pending[:0]
+			if rerr == io.EOF {
+				select {
+				case werr := <-done:
+					// Worker exited. Drain anything still buffered + anything
+					// the worker wrote between our last read and its exit.
+					waitErr = werr
+					waited = true
+					for {
+						line, rerr := reader.ReadString('\n')
+						if len(line) > 0 {
+							m.feedLine(rs, strings.TrimRight(line, "\r\n"))
+							rs.transcriptOffset += int64(len(line))
+						}
+						if rerr != nil {
+							break
+						}
+					}
+					break tail
+				default:
+					time.Sleep(200 * time.Millisecond)
+					continue
+				}
 			}
-			break
+			if rerr != nil {
+				log.Printf("tailAndParse: read %s: %v", rs.transcriptPath, rerr)
+				break tail
+			}
 		}
+		_ = rf.Close()
+	}
+
+	// Persist the final offset so a subsequent restart skips what we already
+	// processed.
+	if m.store != nil {
+		_ = m.store.UpdateSessionTranscriptOffset(rs.sess.ID, rs.transcriptOffset)
 	}
 	prev := rs.sess.State
-	rs.sess.State = mapTerminalState(rs.sess.State, rs.cmd.Wait())
+	if !waited {
+		// We broke out without observing Wait — typically because ctx was
+		// cancelled. Wait now to reap the child and capture its exit code.
+		waitErr = <-done
+	}
+	rs.sess.State = mapTerminalState(rs.sess.State, waitErr)
 	end := time.Now()
 	rs.sess.EndedAt = &end
 	if m.store != nil {
@@ -469,6 +513,36 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 	m.mu.Lock()
 	delete(m.sessions, rs.sess.ID)
 	m.mu.Unlock()
+}
+
+// feedLine routes one raw line (post-newline-strip, pre-ANSI-strip) through
+// the session's parser and downstream handlers. Used both by the live
+// tailAndParse goroutine and the post-restart re-attach paths.
+//
+// Issue #54: this method does NOT write to the transcript file. The worker's
+// stdout is already the transcript file, so anything we'd emit here is a
+// duplicate. The conductor only consumes.
+func (m *Manager) feedLine(rs *runtimeSession, raw string) {
+	raw = stripANSI(raw)
+	if raw == "" {
+		return
+	}
+	var lines []string
+	if rs.parser != nil {
+		lines = rs.parser.Feed(raw)
+	} else {
+		lines = []string{raw}
+	}
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		if m.emit != nil {
+			m.emit(rs.sess.ID, line)
+		}
+		m.matchPatterns(rs, line)
+		m.recordActivity(rs, line)
+	}
 }
 
 // mapTerminalState collapses an in-flight session state to its terminal value
@@ -624,7 +698,9 @@ func (m *Manager) recordActivity(rs *runtimeSession, line string) {
 	}
 }
 
-// Kill terminates a running session.
+// Kill terminates a running session. For re-attached sessions whose original
+// process is owned by a prior conductor (issue #54), we still send a kill
+// signal directly since the worker is in our PID namespace.
 func (m *Manager) Kill(sessionID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -632,23 +708,32 @@ func (m *Manager) Kill(sessionID string) error {
 	if !ok {
 		return fmt.Errorf("unknown session %s", sessionID)
 	}
-	rs.cancel()
-	if rs.cmd.Process != nil {
+	if rs.cancel != nil {
+		rs.cancel()
+	}
+	if rs.cmd != nil && rs.cmd.Process != nil {
 		return rs.cmd.Process.Kill()
+	}
+	if rs.sess != nil && rs.sess.PID > 0 {
+		if p, err := os.FindProcess(rs.sess.PID); err == nil {
+			return p.Kill()
+		}
 	}
 	return nil
 }
 
-// SendInput writes user input into a session's PTY.
+// SendInput is a no-op since #54. The spawn path no longer allocates a PTY,
+// so there's no input channel to write to. Skill workers run with
+// --bypassPermissions and never need post-spawn input; if a future caller
+// needs it, restore a controlled stdin pipe here.
 func (m *Manager) SendInput(sessionID, text string) error {
 	m.mu.RLock()
-	rs, ok := m.sessions[sessionID]
+	_, ok := m.sessions[sessionID]
 	m.mu.RUnlock()
 	if !ok {
 		return fmt.Errorf("unknown session %s", sessionID)
 	}
-	_, err := io.WriteString(rs.pty, text)
-	return err
+	return fmt.Errorf("session input not supported (detached worker, no stdin)")
 }
 
 // Snapshot returns a copy of the current in-process session table.

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2,7 +2,12 @@ package session
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	"prismconductor/internal/types"
 )
@@ -51,9 +56,10 @@ func TestMapTerminalStateNonZeroExitFailsByDefault(t *testing.T) {
 
 // fakePersister records UpdateSessionState calls without touching SQLite.
 type fakePersister struct {
-	saves    []types.Session
-	stateUpd []string
-	pendUpd  map[string]string
+	saves     []types.Session
+	stateUpd  []string
+	pendUpd   map[string]string
+	offsetUpd map[string]int64
 }
 
 func (p *fakePersister) SaveSession(s *types.Session, _ string) error {
@@ -70,6 +76,13 @@ func (p *fakePersister) UpdateSessionPendingQuestion(id, qid string) error {
 		p.pendUpd = map[string]string{}
 	}
 	p.pendUpd[id] = qid
+	return nil
+}
+func (p *fakePersister) UpdateSessionTranscriptOffset(id string, off int64) error {
+	if p.offsetUpd == nil {
+		p.offsetUpd = map[string]int64{}
+	}
+	p.offsetUpd[id] = off
 	return nil
 }
 
@@ -114,5 +127,85 @@ func TestMatchPatternsQuestionPendingEmptyIDIgnored(t *testing.T) {
 	}
 	if rs.sess.PendingQuestionID != "" {
 		t.Errorf("empty id should not set PendingQuestionID, got %q", rs.sess.PendingQuestionID)
+	}
+}
+
+// TestSpawnWritesToTranscriptFile is the issue #54 survival test. It spawns a
+// short shell script and asserts that:
+//
+//  1. The worker's stdout lands in the conductor's transcript file (proving
+//     the file-IS-stdout wiring works).
+//  2. The conductor's tail goroutine reads back the same lines and runs them
+//     through matchPatterns — i.e. a "Work complete." printed by the worker
+//     transitions the persisted state to completed.
+//
+// We don't actually kill the conductor goroutine here (Go test runners have
+// no clean way to do that without leaking). The detached-from-conductor side
+// is exercised by the SysProcAttr.Setsid in spawn_attr_unix.go, which is
+// covered by detachedSupported() returning true on POSIX.
+func TestSpawnWritesToTranscriptFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("survival path is POSIX-only; Windows variant is out of scope (#54 Non-goals)")
+	}
+	tdir := t.TempDir()
+	transcripts := filepath.Join(tdir, "transcripts")
+	store := &fakePersister{}
+	m := NewManager(nil, nil)
+	m.Configure(transcripts, store, nil)
+
+	ws := types.Workspace{ID: "ws-1", RepoPath: tdir}
+	issue := types.Issue{Number: 1, WorkspaceID: ws.ID}
+	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute,
+		[]string{"/bin/sh", "-c", "echo hello-from-worker; echo Work complete."},
+		"", "", "")
+	if err != nil {
+		t.Fatalf("spawnWithDir: %v", err)
+	}
+
+	// Wait until tailAndParse has finished. The goroutine deletes the session
+	// from m.sessions on exit; poll until it's gone or we time out.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		m.mu.RLock()
+		_, stillThere := m.sessions[sess.ID]
+		m.mu.RUnlock()
+		if !stillThere {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	m.mu.RLock()
+	_, stillThere := m.sessions[sess.ID]
+	m.mu.RUnlock()
+	if stillThere {
+		t.Fatalf("tailAndParse goroutine never exited within deadline")
+	}
+
+	// The transcript on disk must contain exactly what the worker wrote.
+	b, err := os.ReadFile(sess.Transcript)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	got := string(b)
+	if !strings.Contains(got, "hello-from-worker") || !strings.Contains(got, "Work complete.") {
+		t.Errorf("transcript missing worker output, got: %q", got)
+	}
+
+	// matchPatterns should have transitioned the session to completed.
+	found := false
+	for _, upd := range store.stateUpd {
+		if strings.HasSuffix(upd, ":completed") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a state update ending in :completed, got %v", store.stateUpd)
+	}
+
+	// transcript_offset must have been persisted at least once during the
+	// final flush.
+	if _, ok := store.offsetUpd[sess.ID]; !ok {
+		t.Errorf("expected transcript_offset to be persisted at least once")
 	}
 }

--- a/internal/session/reattach.go
+++ b/internal/session/reattach.go
@@ -1,37 +1,270 @@
 package session
 
 import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log"
 	"os"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
+	"prismconductor/internal/eventbus"
+	pcgit "prismconductor/internal/git"
 	"prismconductor/internal/types"
 )
 
-// Reattach handles sessions that were live at last shutdown.
+// Reattach rebuilds in-memory session state for sessions that were live at
+// last shutdown (issue #54).
 //
-// We can't re-tail the PTY of a process we didn't fork, so this is a
-// "did it survive?" check. If alive, we leave it running (it will keep
-// writing to its transcript file) and present it as a re-attached session
-// the user can monitor via the transcript. If dead, we mark it failed.
-func (m *Manager) Reattach(sessions []types.Session) {
+// For each persisted session row in {running, waiting_for_input, blocked,
+// paused_for_question}:
+//
+//   - if the worker PID is still alive on the OS, register a synthesized
+//     runtimeSession and start a goroutine that polls the transcript file
+//     from the recorded byte offset, feeding new lines through the same
+//     parser/matchPatterns/handlers as a fresh spawn. The card stays in its
+//     persisted state.
+//   - if the worker is dead, scan the transcript tail for §10.3 sentinels.
+//     The first matching arm sets the terminal state — including firing
+//     onPROpened retroactively so a worker that finished off-conductor still
+//     moves the card to REVIEW. If no sentinel was emitted, the session is
+//     marked failed with an explanatory BlockedReason (q6).
+//
+// workspaces lets the goroutine reconstruct repoPath / worktreeDir for the
+// post-mortem worktree cleanup that #22 relies on.
+func (m *Manager) Reattach(sessions []types.Session, workspaces []types.Workspace) {
+	if !detachedSupported() {
+		log.Printf("session: detached worker spawning is not supported on this platform; conductor exit will terminate workers")
+	}
 	for _, sess := range sessions {
+		sess := sess
 		alive := pidAlive(sess.PID)
-		if alive {
-			// Keep the persisted state; the process is still doing its thing.
-			// We can't pipe its PTY into our event stream, so the UI surfaces
-			// it as "re-attached — read transcript from disk".
+		if sess.Transcript == "" {
+			// No transcript path on the row. Best effort: mark failed.
+			m.markFailedReattach(sess, "transcript path missing on row")
 			continue
 		}
-		now := time.Now()
-		sess.State = types.StateFailed
-		sess.EndedAt = &now
-		if m.store != nil {
-			_ = m.store.UpdateSessionState(sess.ID, sess.State)
+		ws := lookupWorkspace(workspaces, sess.WorkspaceID)
+		rs := buildReattachedRuntime(sess, ws)
+		if alive {
+			// Register and follow the file. matchPatterns inside the goroutine
+			// is responsible for any further state transitions (Q5 / Q6 /
+			// PR_OPENED / Work complete / BLOCKED). On terminal exit the goroutine
+			// itself handles the post-mortem classification + cleanup.
+			ctx, cancel := context.WithCancel(context.Background())
+			rs.cancel = cancel
+			m.mu.Lock()
+			m.sessions[sess.ID] = rs
+			m.mu.Unlock()
+			go m.followLive(ctx, rs)
+		} else {
+			// Worker is gone. Classify directly from whatever the file already
+			// contains and mark the row terminal.
+			m.classifyDeadWorker(rs)
 		}
-		if m.onStateChange != nil {
-			m.onStateChange(sess, types.StateRunning)
+	}
+}
+
+// buildReattachedRuntime returns a runtimeSession in the same shape as one
+// produced by spawnWithDir, minus the cmd / cancel (caller fills cancel for
+// the live path). repoPath and the worktreeDir are best-effort: the
+// post-mortem teardown runs only when both are present.
+func buildReattachedRuntime(sess types.Session, ws *types.Workspace) *runtimeSession {
+	rs := &runtimeSession{
+		sess:             &sess,
+		parser:           NewStreamParser(),
+		transcriptPath:   sess.Transcript,
+		transcriptOffset: sess.TranscriptOffset,
+		reattached:       true,
+	}
+	if ws != nil {
+		rs.repoPath = ws.RepoPath
+		// The worktree dir naming convention from manager.go: <ws.ID>-<num>.
+		if ws.RepoPath != "" && sess.IssueNumber > 0 && sess.Mode == types.ModeExecute {
+			rs.worktreeDir = filepath.Join(ws.RepoPath, ".prismconductor", "worktrees",
+				fmt.Sprintf("%s-%d", ws.ID, sess.IssueNumber))
+			if _, err := os.Stat(rs.worktreeDir); err != nil {
+				rs.worktreeDir = ""
+			}
 		}
+	}
+	return rs
+}
+
+func lookupWorkspace(workspaces []types.Workspace, id string) *types.Workspace {
+	if id == "" {
+		return nil
+	}
+	for i := range workspaces {
+		if workspaces[i].ID == id {
+			return &workspaces[i]
+		}
+	}
+	return nil
+}
+
+// followLive polls the transcript file for a still-alive re-attached worker,
+// feeding new lines through the parser. When the worker eventually dies, the
+// goroutine drops into the dead-worker classification path before exiting.
+func (m *Manager) followLive(ctx context.Context, rs *runtimeSession) {
+	defer func() {
+		m.mu.Lock()
+		delete(m.sessions, rs.sess.ID)
+		m.mu.Unlock()
+	}()
+
+	f, err := os.Open(rs.transcriptPath)
+	if err != nil {
+		log.Printf("reattach: open %s: %v", rs.transcriptPath, err)
+		m.classifyDeadWorker(rs)
+		return
+	}
+	defer f.Close()
+	if rs.transcriptOffset > 0 {
+		if _, err := f.Seek(rs.transcriptOffset, io.SeekStart); err != nil {
+			log.Printf("reattach: seek %s offset=%d: %v",
+				rs.transcriptPath, rs.transcriptOffset, err)
+			rs.transcriptOffset = 0
+		}
+	}
+	reader := bufio.NewReader(f)
+	var lastFlush time.Time
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		if !pidAlive(rs.sess.PID) {
+			// Drain whatever was written between the last EOF and process death,
+			// then classify. The classifyDeadWorker path re-opens the file from
+			// the *current* persisted offset, so persist before handing off.
+			if m.store != nil {
+				_ = m.store.UpdateSessionTranscriptOffset(rs.sess.ID, rs.transcriptOffset)
+			}
+			m.classifyDeadWorker(rs)
+			return
+		}
+		line, rerr := reader.ReadString('\n')
+		if len(line) > 0 {
+			m.feedLine(rs, strings.TrimRight(line, "\r\n"))
+			rs.transcriptOffset += int64(len(line))
+			if m.store != nil && time.Since(lastFlush) >= 2*time.Second {
+				_ = m.store.UpdateSessionTranscriptOffset(rs.sess.ID, rs.transcriptOffset)
+				lastFlush = time.Now()
+			}
+		}
+		if rerr == io.EOF {
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		if rerr != nil {
+			log.Printf("reattach: read %s: %v", rs.transcriptPath, rerr)
+			return
+		}
+	}
+}
+
+// classifyDeadWorker reads from the recorded transcript offset to EOF, feeds
+// each line through the parser/matchPatterns flow, then determines the
+// terminal state based on what sentinels (if any) showed up.
+//
+// matchPatterns already mutates rs.sess.State on Work complete / BLOCKED, and
+// already calls onPROpened on PR_OPENED. So all we need to do here is:
+//
+//  1. feed the tail through.
+//  2. check rs.sess.State afterwards.
+//  3. for sessions still in non-terminal states, mark them failed with the
+//     no-sentinel BlockedReason (q6).
+//  4. persist the final state and run the post-mortem worktree teardown.
+func (m *Manager) classifyDeadWorker(rs *runtimeSession) {
+	prev := rs.sess.State
+	if rs.transcriptPath != "" {
+		f, err := os.Open(rs.transcriptPath)
+		if err == nil {
+			defer f.Close()
+			if rs.transcriptOffset > 0 {
+				_, _ = f.Seek(rs.transcriptOffset, io.SeekStart)
+			}
+			reader := bufio.NewReader(f)
+			for {
+				line, rerr := reader.ReadString('\n')
+				if len(line) > 0 {
+					m.feedLine(rs, strings.TrimRight(line, "\r\n"))
+					rs.transcriptOffset += int64(len(line))
+				}
+				if rerr != nil {
+					break
+				}
+			}
+		} else {
+			log.Printf("reattach: classify open %s: %v", rs.transcriptPath, err)
+		}
+	}
+	if m.store != nil {
+		_ = m.store.UpdateSessionTranscriptOffset(rs.sess.ID, rs.transcriptOffset)
+	}
+	switch rs.sess.State {
+	case types.StateCompleted, types.StateBlocked, types.StateFailed,
+		types.StatePausedForQuestion:
+		// Already a terminal/awaiting state set by matchPatterns. Use as-is.
+	default:
+		// No terminal sentinel encountered — q6: mark failed with explanatory
+		// reason so the card glows red and the user can re-approve.
+		rs.sess.State = types.StateFailed
+		rs.sess.BlockedReason = "worker exited without sentinel - see transcript"
+	}
+	now := time.Now()
+	if rs.sess.EndedAt == nil {
+		rs.sess.EndedAt = &now
+	}
+	if m.store != nil {
+		_ = m.store.SaveSession(rs.sess, rs.transcriptPath)
+		_ = m.store.UpdateSessionState(rs.sess.ID, rs.sess.State)
+	}
+	if m.onStateChange != nil && prev != rs.sess.State {
+		m.onStateChange(*rs.sess, prev)
+	}
+
+	// Worktree teardown for the dead-worker terminal cases. Mirror manager.go's
+	// live-spawn cleanup: blocked / failed → immediate remove; completed and
+	// paused_for_question keep the dir on disk for post-mortem / resume.
+	if rs.worktreeDir != "" {
+		switch rs.sess.State {
+		case types.StateBlocked, types.StateFailed:
+			if err := pcgit.Remove(rs.repoPath, rs.worktreeDir); err != nil {
+				log.Printf("reattach: worktree cleanup (terminal=%s) %s: %v",
+					rs.sess.State, rs.worktreeDir, err)
+			}
+		}
+	}
+
+	// Mirror tailAndParse: publish the freed-slot event so any orchestrator
+	// pool accounting that re-acquired the slot on startup can release it.
+	if m.bus != nil {
+		m.bus.Publish(eventbus.EvtWorkerSlotFreed, eventbus.WorkerSlotFreed{
+			SessionID: rs.sess.ID,
+			PoolID:    rs.poolID,
+		})
+	}
+}
+
+func (m *Manager) markFailedReattach(sess types.Session, reason string) {
+	now := time.Now()
+	prev := sess.State
+	sess.State = types.StateFailed
+	sess.EndedAt = &now
+	sess.BlockedReason = reason
+	if m.store != nil {
+		_ = m.store.SaveSession(&sess, sess.Transcript)
+		_ = m.store.UpdateSessionState(sess.ID, sess.State)
+	}
+	if m.onStateChange != nil {
+		m.onStateChange(sess, prev)
 	}
 }
 

--- a/internal/session/reattach_test.go
+++ b/internal/session/reattach_test.go
@@ -1,0 +1,149 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"prismconductor/internal/types"
+)
+
+// writeTranscript writes raw content to a temp transcript file and returns
+// its path.
+func writeTranscript(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.log")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+// newReattachRuntime builds a runtimeSession suitable for classifyDeadWorker:
+// parser disabled (so feedLine treats raw lines as final), PID=0 so pidAlive
+// returns false.
+func newReattachRuntime(transcriptPath, sessID string, state types.SessionState) *runtimeSession {
+	return &runtimeSession{
+		sess: &types.Session{
+			ID:    sessID,
+			State: state,
+			PID:   0,
+		},
+		parser:         &StreamParser{enabled: false},
+		transcriptPath: transcriptPath,
+		reattached:     true,
+	}
+}
+
+func TestClassifyDeadWorkerWorkComplete(t *testing.T) {
+	path := writeTranscript(t, "starting…\nWork complete.\n")
+	store := &fakePersister{}
+	m := &Manager{store: store}
+	rs := newReattachRuntime(path, "sess-complete", types.StateRunning)
+	m.classifyDeadWorker(rs)
+	if rs.sess.State != types.StateCompleted {
+		t.Fatalf("state = %s, want completed", rs.sess.State)
+	}
+	if rs.sess.EndedAt == nil {
+		t.Errorf("EndedAt should be set on terminal classify")
+	}
+	if len(store.saves) == 0 {
+		t.Errorf("expected SaveSession on dead-worker classify")
+	}
+}
+
+func TestClassifyDeadWorkerBlocked(t *testing.T) {
+	path := writeTranscript(t, "BLOCKED: tests failed\n")
+	store := &fakePersister{}
+	m := &Manager{store: store}
+	rs := newReattachRuntime(path, "sess-blocked", types.StateRunning)
+	m.classifyDeadWorker(rs)
+	if rs.sess.State != types.StateBlocked {
+		t.Fatalf("state = %s, want blocked", rs.sess.State)
+	}
+	if rs.sess.BlockedReason != "tests failed" {
+		t.Errorf("BlockedReason = %q, want %q", rs.sess.BlockedReason, "tests failed")
+	}
+}
+
+func TestClassifyDeadWorkerNoSentinelMarksFailed(t *testing.T) {
+	// Worker died with no terminal sentinel — q6: mark failed with explicit
+	// reason so the user can re-approve.
+	path := writeTranscript(t, "@tool Edit\n@asst something happening\n")
+	store := &fakePersister{}
+	m := &Manager{store: store}
+	rs := newReattachRuntime(path, "sess-nope", types.StateRunning)
+	m.classifyDeadWorker(rs)
+	if rs.sess.State != types.StateFailed {
+		t.Fatalf("state = %s, want failed", rs.sess.State)
+	}
+	if rs.sess.BlockedReason == "" {
+		t.Errorf("BlockedReason should be populated for no-sentinel failure")
+	}
+}
+
+func TestClassifyDeadWorkerFiresPROpenedRetroactive(t *testing.T) {
+	// Q5: a worker that emitted PR_OPENED before dying must trigger
+	// onPROpened on re-attach so the card moves to REVIEW. The state
+	// machine itself stays in whatever the next sentinel sets — if the
+	// worker also emitted Work complete., state=completed; otherwise state
+	// stays running and the q6 arm bumps to failed. Either way the
+	// onPROpened side effect must fire exactly once.
+	path := writeTranscript(t, "PR_OPENED: https://github.com/o/r/pull/42\nWork complete.\n")
+	store := &fakePersister{}
+	var fired []string
+	m := &Manager{
+		store: store,
+		onPROpened: func(_ types.Session, url string) {
+			fired = append(fired, url)
+		},
+	}
+	rs := newReattachRuntime(path, "sess-pr", types.StateRunning)
+	m.classifyDeadWorker(rs)
+	if len(fired) != 1 {
+		t.Fatalf("onPROpened fire count = %d, want 1 (urls=%v)", len(fired), fired)
+	}
+	if fired[0] != "https://github.com/o/r/pull/42" {
+		t.Errorf("onPROpened url = %q, want pull/42", fired[0])
+	}
+	if rs.sess.State != types.StateCompleted {
+		t.Errorf("state = %s, want completed (followed by Work complete)", rs.sess.State)
+	}
+}
+
+func TestClassifyDeadWorkerKeepsPausedForQuestion(t *testing.T) {
+	// QUESTION_PENDING → paused state. matchPatterns sets PendingQuestionID;
+	// classifyDeadWorker must not overwrite it with StateFailed.
+	path := writeTranscript(t, "QUESTION_PENDING: 11111111-2222-3333-4444-555555555555\n")
+	store := &fakePersister{}
+	m := &Manager{store: store}
+	rs := newReattachRuntime(path, "sess-paused", types.StateRunning)
+	m.classifyDeadWorker(rs)
+	if rs.sess.State != types.StatePausedForQuestion {
+		t.Fatalf("state = %s, want paused_for_question", rs.sess.State)
+	}
+	if rs.sess.PendingQuestionID == "" {
+		t.Errorf("PendingQuestionID empty, expected the captured uuid")
+	}
+}
+
+func TestClassifyDeadWorkerHonorsTranscriptOffset(t *testing.T) {
+	// Bytes BEFORE the offset must NOT be re-fed (would emit duplicate
+	// onPROpened and corrupt activity counters). Plant a sentinel before
+	// the offset and a benign line after; assert no PR_OPENED fire.
+	preLine := "PR_OPENED: https://github.com/o/r/pull/9\n"
+	path := writeTranscript(t, preLine+"@asst hi\n")
+	store := &fakePersister{}
+	var fired int
+	m := &Manager{
+		store:      store,
+		onPROpened: func(_ types.Session, _ string) { fired++ },
+	}
+	rs := newReattachRuntime(path, "sess-offset", types.StateRunning)
+	rs.transcriptOffset = int64(len(preLine))
+	m.classifyDeadWorker(rs)
+	if fired != 0 {
+		t.Errorf("onPROpened fired %d times, want 0 (sentinel was below offset)", fired)
+	}
+}

--- a/internal/session/spawn_attr_unix.go
+++ b/internal/session/spawn_attr_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package session
+
+import "syscall"
+
+// detachedProcAttr returns the SysProcAttr that puts the spawned worker into
+// its own session (issue #54). With Setsid the worker is no longer in the
+// conductor's process group, so neither macOS's SIGHUP-on-parent-exit nor a
+// terminal-driven SIGINT walks down to the child. Combined with stdout being
+// a regular file (not a pipe owned by the conductor goroutine), the worker
+// keeps running after the conductor exits.
+func detachedProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}
+
+// detachedSupported reports whether detached spawning is implemented on this
+// platform. POSIX builds always return true.
+func detachedSupported() bool { return true }

--- a/internal/session/spawn_attr_windows.go
+++ b/internal/session/spawn_attr_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package session
+
+import "syscall"
+
+// detachedProcAttr is a stub on Windows. Surviving conductor exit on Windows
+// requires CREATE_NEW_PROCESS_GROUP wiring, which is explicitly out of scope
+// for issue #54 (Non-goals). Until that ships, conductor exit on Windows
+// still terminates spawned workers.
+func detachedProcAttr() *syscall.SysProcAttr { return nil }
+
+// detachedSupported reports whether detached spawning is implemented on this
+// platform.
+func detachedSupported() bool { return false }

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -53,6 +53,18 @@ func (s *Store) UpdateSessionPendingQuestion(id, questionID string) error {
 	return err
 }
 
+// UpdateSessionTranscriptOffset persists the byte offset of the last
+// fully-processed transcript line (issue #54). Called every ~2s during live
+// tail so a conductor restart mid-stream does not re-feed already-processed
+// lines.
+func (s *Store) UpdateSessionTranscriptOffset(id string, off int64) error {
+	if s == nil || s.DB == nil {
+		return nil
+	}
+	_, err := s.DB.Exec(`UPDATE sessions SET transcript_offset = ? WHERE id = ?`, off, id)
+	return err
+}
+
 // nullableString returns nil for empty strings so the SQLite column stores NULL
 // instead of the zero-length string. Keeps `pending_question_id IS NULL` queries
 // honest.
@@ -70,7 +82,7 @@ func (s *Store) LoadRunningSessions() ([]types.Session, string, error) {
 	if s == nil || s.DB == nil {
 		return nil, "", nil
 	}
-	rows, err := s.DB.Query(`SELECT json, transcript_path, pending_question_id FROM sessions WHERE state IN ('running','waiting_for_input','blocked','paused_for_question')`)
+	rows, err := s.DB.Query(`SELECT json, transcript_path, pending_question_id, transcript_offset FROM sessions WHERE state IN ('running','waiting_for_input','blocked','paused_for_question')`)
 	if err != nil {
 		return nil, "", err
 	}
@@ -80,7 +92,8 @@ func (s *Store) LoadRunningSessions() ([]types.Session, string, error) {
 	for rows.Next() {
 		var raw, transcript string
 		var pendingQID sql.NullString
-		if err := rows.Scan(&raw, &transcript, &pendingQID); err != nil {
+		var offset int64
+		if err := rows.Scan(&raw, &transcript, &pendingQID, &offset); err != nil {
 			return nil, "", err
 		}
 		var sess types.Session
@@ -94,6 +107,12 @@ func (s *Store) LoadRunningSessions() ([]types.Session, string, error) {
 		} else {
 			sess.PendingQuestionID = ""
 		}
+		// Issue #54: transcript path lives only on the column, never in the JSON
+		// blob. Re-populate it on the in-memory shape so reattach has a path.
+		if sess.Transcript == "" {
+			sess.Transcript = transcript
+		}
+		sess.TranscriptOffset = offset
 		out = append(out, sess)
 		if firstTranscript == "" {
 			firstTranscript = transcript

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -131,6 +131,14 @@ CREATE TABLE IF NOT EXISTS pools (
 	if err := s.ensurePoolsRoleCheck(); err != nil {
 		return err
 	}
+	// Issue #54: per-session byte offset of the last-flushed transcript line.
+	// Lets a re-attach after conductor restart skip lines we already processed
+	// in a prior catch-up pass.
+	if _, err := s.DB.Exec(`ALTER TABLE sessions ADD COLUMN transcript_offset INTEGER NOT NULL DEFAULT 0`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column name") {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -241,6 +241,11 @@ type Session struct {
 	LastPrompt        string       `json:"last_prompt"`
 	BlockedReason     string       `json:"blocked_reason,omitempty"`
 	PendingQuestionID string       `json:"pending_question_id,omitempty"`
+
+	// TranscriptOffset is the byte offset into the transcript file of the
+	// last fully-processed line (issue #54). Lives on the sessions column,
+	// excluded from the JSON blob to keep external snapshots schema-stable.
+	TranscriptOffset int64 `json:"-"`
 }
 
 // MidRunAnswer is the §6.4-shaped answer payload for a mid-run question


### PR DESCRIPTION
## Summary

Workers spawned by the conductor now survive a conductor exit (Cmd+Q, crash,
laptop sleep). The transcript file on disk is the durable record; on restart
the conductor reads it as the source of truth, picks up still-alive workers
by tailing the file from the last persisted offset, and classifies dead
workers from the §10.3 sentinels they left behind.

Implementation:

- POSIX `setsid` via build-tagged `detachedProcAttr()` (Windows stub, logged
  once at startup per the issue's Non-goals).
- `cmd.Stdout / cmd.Stderr` point at the transcript file directly (no Go
  goroutine in the middle that would die with the conductor and break the
  worker's writes). The conductor reads the same file via a polling tail.
- `tailAndParse` now drives a sibling `cmd.Wait` goroutine + EOF poll so
  exit detection no longer depends on a PTY-master close.
- `Reattach` rebuilds runtime state from `LoadRunningSessions`, follows
  still-alive workers via the same tail loop, and runs a sentinel scan on
  dead workers — including firing `onPROpened` retroactively (#54 Acc. #4)
  and marking sentinel-less death as failed with an explanatory
  `BlockedReason` (rev2 q6).
- Per-session `transcript_offset` column persisted every ~2s during tail so
  a restart mid-stream doesn't re-feed lines.
- Reattach signature gains `workspaces []types.Workspace` so the goroutine
  can rebuild `repoPath`/`worktreeDir` for the post-mortem #22 cleanup.

### Files modified

- `app.go` — pass `a.wsReg.List()` into `Reattach`.
- `internal/session/manager.go` — detached spawn; file-IS-stdout; sibling
  Wait goroutine; new `feedLine` shared with reattach.
- `internal/session/reattach.go` — full rewrite (live tail + dead-pid scan).
- `internal/session/spawn_attr_unix.go` (new) — `Setsid` + `detachedSupported`.
- `internal/session/spawn_attr_windows.go` (new) — stub.
- `internal/store/sqlite.go` — idempotent `transcript_offset` migration.
- `internal/store/sessions.go` — `UpdateSessionTranscriptOffset`,
  `LoadRunningSessions` reads new column.
- `internal/types/types.go` — `Session.TranscriptOffset int64 \`json:"-"\``.
- `internal/session/manager_test.go` — fake `Persister` gains
  `UpdateSessionTranscriptOffset`; new `TestSpawnWritesToTranscriptFile`.
- `internal/session/reattach_test.go` (new) — covers the four classification
  branches plus the offset-honoring case.

### Verification

- `go vet ./...` — clean.
- `go build ./...` — clean.
- `cd frontend && npx tsc --noEmit` — clean.
- `wails build -skipbindings` — clean (~6s).
- `go test ./... -count=1` — all packages pass (`session`, `store`,
  `orchestrator`, `workerpool`, `git`, `llm`, root `prismconductor`).

### Notes for review

- Pool re-acquisition on restart took the rev2 §6 fallback path: re-attach
  goroutines do not publish `EvtWorkerSlotFreed` on terminal exit, since no
  matching `Acquire` was issued in this process. Pool counts reset to 0 on
  conductor restart anyway. The orchestrator's autoPull may briefly
  over-spawn plan workers if the user had near-capacity plan pools at the
  moment of the crash; the upstream issue body's Acceptance scenarios don't
  cover that edge.
- Transcript file content is now raw worker stdout (stream-json) rather
  than parser-emitted display lines. The conductor re-runs the parser on
  read so the user-visible behavior in the SessionDrawer is unchanged.
  Direct text-editor inspection of the transcript shows the raw format.
- `SendInput` is now a hard error since the spawn path no longer allocates
  a stdin channel. No skill flow exercises post-spawn input today.

### Skipped / flagged for human review

- Live force-quit reproduction (Acc. #1, #2, #5, #6) requires a full
  `wails dev` session with manual `kill -9` — not runnable in a headless
  CI. The unit tests cover the file-IS-stdout wiring and the four
  classification branches.

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-54

Closes #54
