### PR TITLE
fix(frontend): queue plan-ready arrivals instead of hijacking open modal (#48)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,7 +30,8 @@ import { useLabelsStore } from "./stores/labelsStore";
 import { Toast } from "./components/Toast";
 import { useToastStore, type Toast as ToastT } from "./stores/toastStore";
 
-type PlanTarget = { workspace_id: string; number: number } | null;
+type PlanRef = { workspace_id: string; number: number };
+type PlanTarget = PlanRef | null;
 
 function App() {
   const appendLine = useSessionStore((s) => s.appendLine);
@@ -48,6 +49,7 @@ function App() {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [planTarget, setPlanTarget] = useState<PlanTarget>(null);
+  const [planQueue, setPlanQueue] = useState<PlanRef[]>([]);
   const planIssue = useMemo(() => {
     if (!planTarget) return null;
     return (
@@ -113,12 +115,39 @@ function App() {
     });
     const offGoalUpd = EventsOn("bus.goal_updated", () => refreshGoals());
     const offIssue = EventsOn("bus.issue_added", () => refreshIssues(selectedWorkspace ?? ""));
+    // Don't hijack an open PlanModal when a different card's plan arrives.
+    // Card glow + toast carry the signal; queue the arrival and drain on close.
+    // Any future auto-open path (bus.plan_revised, etc.) must use the same
+    // functional-setPlanTarget guard, never an unconditional set.
     const offPlanReady = EventsOn(
       "bus.plan_ready",
       (data: { workspace_id: string; issue_number: number; revision: number }) => {
         refreshIssues(selectedWorkspace ?? "");
         markPlanReady(data);
-        setPlanTarget({ workspace_id: data.workspace_id, number: data.issue_number });
+        setPlanTarget((current) => {
+          if (current === null) {
+            return { workspace_id: data.workspace_id, number: data.issue_number };
+          }
+          if (
+            current.workspace_id === data.workspace_id &&
+            current.number === data.issue_number
+          ) {
+            return current;
+          }
+          setPlanQueue((q) => {
+            if (
+              q.some(
+                (e) =>
+                  e.workspace_id === data.workspace_id &&
+                  e.number === data.issue_number,
+              )
+            ) {
+              return q;
+            }
+            return [...q, { workspace_id: data.workspace_id, number: data.issue_number }];
+          });
+          return current;
+        });
       },
     );
     const offPROpened = EventsOn(
@@ -356,8 +385,27 @@ function App() {
       <Settings open={settingsOpen} onClose={() => setSettingsOpen(false)} />
       <PlanModal
         open={planTarget !== null}
-        onClose={() => setPlanTarget(null)}
+        onClose={() => {
+          setPlanQueue((q) => {
+            if (q.length === 0) {
+              setPlanTarget(null);
+              return q;
+            }
+            const [next, ...rest] = q;
+            setPlanTarget(next);
+            return rest;
+          });
+        }}
         issue={planIssue}
+        queueDepth={planQueue.length}
+        onPopNext={() => {
+          setPlanQueue((q) => {
+            if (q.length === 0) return q;
+            const [next, ...rest] = q;
+            setPlanTarget(next);
+            return rest;
+          });
+        }}
       />
       <Toast
         onOpenCard={(wsID, num) =>

--- a/frontend/src/components/PlanModal.tsx
+++ b/frontend/src/components/PlanModal.tsx
@@ -20,10 +20,14 @@ export function PlanModal({
   open,
   onClose,
   issue,
+  queueDepth = 0,
+  onPopNext,
 }: {
   open: boolean;
   onClose: () => void;
   issue: types.Issue | null;
+  queueDepth?: number;
+  onPopNext?: () => void;
 }) {
   const refreshIssues = useIssueStore((s) => s.refresh);
   const refreshLabels = useLabelsStore((s) => s.refresh);
@@ -132,8 +136,20 @@ export function PlanModal({
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
       <div className="w-[700px] max-h-[85vh] bg-slate-900 border border-slate-700 rounded-lg flex flex-col overflow-hidden">
         <div className="flex items-center justify-between px-4 py-2 border-b border-slate-800">
-          <div className="text-slate-200">
-            Plan: #{issue.number} — <span className="text-slate-400">{issue.title}</span>
+          <div className="flex items-center gap-2 min-w-0">
+            <div className="text-slate-200 truncate">
+              Plan: #{issue.number} — <span className="text-slate-400">{issue.title}</span>
+            </div>
+            {queueDepth > 0 && onPopNext && (
+              <button
+                type="button"
+                onClick={onPopNext}
+                className="shrink-0 text-xs px-2 py-0.5 rounded-full border border-amber-700 bg-amber-950/40 text-amber-200 hover:bg-amber-900/40"
+                title="Open next plan that became ready while you were reviewing"
+              >
+                +{queueDepth} more plan{queueDepth === 1 ? "" : "s"} ready
+              </button>
+            )}
           </div>
           <button onClick={handleClose} className="text-slate-400 hover:text-slate-200">✕</button>
         </div>


### PR DESCRIPTION
## Summary

The `bus.plan_ready` handler at `frontend/src/App.tsx` unconditionally swapped the open `PlanModal` whenever a plan finished for a *different* card, dumping the user's in-flight `refineText`, scroll position, and partially-filled answers. The fix guards `setPlanTarget` with a functional updater so it only opens when nothing is open, and otherwise enqueues the arrival into a small in-session FIFO queue. A header pill in `PlanModal` shows "+N more plans ready"; clicking it pops the next queued plan, and closing the current modal auto-drains one entry at a time. Card glow + toast continue to fire as before, so discoverability is preserved while the user's focus is not.

## Files modified

- `frontend/src/App.tsx` — guarded `bus.plan_ready` handler (functional `setPlanTarget`), added `planQueue` state and `PlanRef` type alias, queue-aware `onClose`, passes `queueDepth` + `onPopNext` to `PlanModal`.
- `frontend/src/components/PlanModal.tsx` — accepts optional `queueDepth` + `onPopNext` props, renders amber header pill in the title row.

Dedupe by `(workspace_id, issue_number)` lives inside the `setPlanQueue` updater, which also makes the pattern safe under React 18 StrictMode double-invocation. Toast clicks still replace the open modal directly per the locked-in q3 decision — that path is an intentional user action.

## Verification

- **Lint / typecheck:** `cd frontend && npx tsc --noEmit` → exit 0 (clean).
- **Build:** `npx vite build` → exit 0 (built in 1.33s); `go build ./...` → exit 0.
- **Tests:** `go test ./...` → all packages pass (store, session, orchestrator, workerpool, llm, git, root). No frontend test suite exists in this repo (no vitest/jest/@testing-library), so the queue logic is verified manually per the plan rev2 q4 decision; see acceptance walk-through below.

## ⚠ No tests run for the new frontend code (no runner detected)

Repo has no frontend test framework today. Adding one was explicitly skipped on rev2 (q4) and is the right call — bringing in vitest just for this would be much larger than the change. Manual repro instructions are in the plan §Verification and were exercised against `wails dev`:

1. Open modal for `#A` → drag `#B` to PLAN → modal stays on `#A`, scroll preserved, `refineText` retained.
2. `#B`'s card glows; toast appears; pill reads "+1 more plan ready".
3. Drag `#C` → pill reads "+2 more plans ready".
4. Re-fire `bus.plan_ready` for `#B` (Re-plan path) → pill stays at +2 (dedupe).
5. Click pill → modal swaps to `#B`; pill reads "+1 more plan ready".
6. Close modal → modal auto-opens for `#C`; pill disappears.
7. Close modal → modal closes; cards still glow until approve/reject.
8. With queue non-empty, click any pending toast → modal replaces with that issue (q3).

## Workspace mode

Workspace mode: per-execute worktree at `/Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-48`

Closes #48
