### PR TITLE
feat(harness): provider-agnostic agent loop for non-Claude pools (#58)

### DIFF
--- a/PRISMCONDUCTOR_PLAN.md
+++ b/PRISMCONDUCTOR_PLAN.md
@@ -408,7 +408,7 @@ const (
 - `Registry.AcquireForWork(ws)` — strict `role=work` selection (no fallback to plan pools).
 - `Registry.OrchestratorPool()` — returns the at-most-one enabled `role=orchestrator` pool, or false. Used by the orchestrator's rank pass on each call so UI changes take effect on the next event tick.
 
-Per-workspace pinning lives in `SkillProfile.PreferredPlanPoolID` and `PreferredWorkPoolID`; selection falls back to round-robin among enabled role pools when unset. Roles do not gate providers — saving e.g. an OpenAI `role=plan` pool is allowed; spawn returns `llm.ErrNotSupported` until harness-v1 ships, surfaced as a runtime toast and an "Awaiting harness-v1" pool-row badge.
+Per-workspace pinning lives in `SkillProfile.PreferredPlanPoolID` and `PreferredWorkPoolID`; selection falls back to round-robin among enabled role pools when unset. Roles do not gate providers — issue #58 ships harness-v1, so all five providers (Claude + OpenAI / Ollama / LM Studio / LiteLLM) are spawnable: Claude via the subprocess strategy, the four OpenAI-compat providers via the in-process harness loop (§10.5).
 
 `api_key` is plaintext SQLite — same trust model as `~/.claude/.credentials.json`; no keychain integration. Empty `api_key` falls back to the per-provider env var (`OPENAI_API_KEY`, `LITELLM_API_KEY`, `ANTHROPIC_API_KEY`).
 
@@ -660,6 +660,22 @@ Bundled mode passes `CLAUDE_SKILLS_PATH=~/.prismconductor/skills/` (or the platf
 
 `buildExecuteCommand` and `buildCloseCommand` follow the same dispatch pattern with `NativeExecuteCommand` and `NativeCloseCommand` respectively.
 
+### 10.5 Harness-v1 (provider-agnostic spawn, issue #58)
+
+Claude pools spawn a `claude` CLI subprocess. The four OpenAI-compat providers (OpenAI, Ollama, LM Studio, LiteLLM) have no equivalent CLI binary, so the conductor drives the agent loop itself in-process — that's the harness. From the perspective of `tailAndParse`, `StreamParser`, and `matchPatterns`, the two strategies are indistinguishable: both feed line-delimited stream-json into the transcript file with the same role-prefix conventions.
+
+**The dispatch seam is a single `errors.Is(err, llm.ErrNotSupported)` check on `Provider.SpawnArgs`.** Claude's `SpawnArgs` returns `(argv, nil)` → subprocess strategy. The four OpenAI-compat providers return `(nil, ErrNotSupported)` → harness strategy. The session manager has no `ProviderClaude` literal in its dispatch — adding a sixth provider never edits `internal/session`.
+
+**Tool surface (seven tools).** The harness exposes a fixed tool set to the model: `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`, `TodoWrite`. Each is path-scoped to the worker's cwd (the worktree for execute, the repo root for plan). Tool errors are returned to the model as `is_error: true` tool results so it can recover; the harness never auto-emits `BLOCKED:` for a tool failure — only the model itself does.
+
+**Skill mode.** Bundled-only for v1. Hybrid and Native modes rely on a repo-side CLI that non-Claude providers don't have today; the harness emits `BLOCKED: harness-v1 supports SkillModeBundled only` and exits cleanly when asked.
+
+**Budgets.** Defaults: 60 turns, 200 K cumulative input tokens, 5-minute Bash timeout, 50 KB Bash output cap. Exhaustion of either turns or tokens emits the corresponding `BLOCKED: <reason>` sentinel; the existing `matchPatterns` flips state to `StateBlocked` cleanly. The model decides whether to retry on a tool failure.
+
+**Cancellation.** `Manager.Kill` calls `synthCmd.cancel()` → harness ctx cancels → in-flight HTTP/Bash returns → loop exits → `synthCmd.Wait()` returns `context.Canceled` → `mapTerminalState` lands on `Failed`. Worktree teardown runs identically to a Claude failure.
+
+The harness package (`internal/harness/`) is the only new package introduced in this phase. Provider extension: a new `ToolChat(ctx, pool, ChatRequest) (ChatResponse, error)` method on the `Provider` interface; Claude returns `ErrNotSupported`, the four OpenAI-compat providers delegate to a shared `openAIToolChat` helper that serializes `tools[]` / `tool_choice:"auto"` and decodes `choices[0].message.tool_calls[]`.
+
 ---
 
 ## 11. Local LLM (Orchestrator) Integration
@@ -669,6 +685,8 @@ Bundled mode passes `CLAUDE_SKILLS_PATH=~/.prismconductor/skills/` (or the platf
 Issue #39 moves the orchestrator's LLM client into the pool table. The user adds a single `role=orchestrator` row in **Settings → Pools** (no separate Ollama tab). The pool's provider can be Ollama, LM Studio, OpenAI, LiteLLM, or even Claude — the rank+deps call is a one-shot HTTP request through the `Provider.ChatJSON` method, not a tool-using session, so any provider works.
 
 The orchestrator resolves the pool on every `runRank` call (`Registry.OrchestratorPool()`), so changes via the UI take effect on the next event tick without an app restart. When no enabled `role=orchestrator` pool exists, `runRank` no-ops cleanly — same degraded behavior the user sees today when Ollama is unconfigured. **Strict routing contract (rev2):** there is no plan→work fallback; auto-pull pauses cleanly when no `role=plan` pool is enabled, with the Pools panel showing an informational banner.
+
+The session manager's spawn dispatch is now provider-literal-free, mirroring the §17 / #27 commitment for the workerpool/orchestrator: routing and dispatch decisions key on per-provider behavior (`SpawnArgs` returning argv vs. `ErrNotSupported`), not on `Kind() == ProviderClaude` comparisons. Adding a sixth provider doesn't touch `internal/session`. See §10.5 for the harness strategy that picks up the `ErrNotSupported` arm.
 
 Temperature is hardcoded to `0.0` for determinism. The Anthropic Messages call falls back to `claude -p --output-format json` when `ANTHROPIC_API_KEY` is unset, so a developer with only `claude` CLI auth can still run the orchestrator on a Claude pool.
 

--- a/frontend/src/components/PoolEditModal.tsx
+++ b/frontend/src/components/PoolEditModal.tsx
@@ -80,9 +80,6 @@ export function PoolEditModal({
     );
   }, [role, existingPools, initial]);
 
-  const harnessPending =
-    (role === "plan" || role === "work") && providerInfo && !providerInfo.can_spawn;
-
   useEffect(() => {
     if (initial) return;
     if (!providerInfo) return;
@@ -217,12 +214,6 @@ export function PoolEditModal({
                 </option>
               ))}
             </select>
-            {harnessPending && (
-              <div className="text-[11px] text-amber-300 mt-1">
-                Pools with this provider can be saved now but will return an
-                error on spawn until harness-v1 ships.
-              </div>
-            )}
           </div>
 
           {providerInfo && providerKind !== "claude" && (

--- a/frontend/src/components/PoolsPanel.tsx
+++ b/frontend/src/components/PoolsPanel.tsx
@@ -127,9 +127,6 @@ export function PoolsPanel() {
             {rows.map((row) => {
               const info = providerByKind.get(row.pool.provider);
               const err = deleteErr[row.pool.id];
-              const harnessPending =
-                (role === "plan" || role === "work") &&
-                !info?.can_spawn;
               return (
                 <div
                   key={row.pool.id}
@@ -142,14 +139,6 @@ export function PoolsPanel() {
                         <span className="text-slate-500">
                           ({info?.display_name ?? row.pool.provider})
                         </span>
-                        {harnessPending && (
-                          <span
-                            className="text-[10px] px-1.5 py-0.5 rounded bg-amber-950/60 border border-amber-800 text-amber-300"
-                            title="Spawn returns ErrNotSupported until harness-v1 lands."
-                          >
-                            Awaiting harness-v1
-                          </span>
-                        )}
                       </div>
                       <div className="text-slate-500 text-xs">
                         {row.pool.model || "—"}

--- a/internal/harness/budget.go
+++ b/internal/harness/budget.go
@@ -1,0 +1,33 @@
+package harness
+
+import "time"
+
+// Budget caps per-session resource use so a runaway model can't burn cycles
+// or wedge the conductor (PRISMCONDUCTOR_PLAN.md §10.5, issue #58 q-budget).
+type Budget struct {
+	MaxTurns       int           // hard turn cap
+	MaxInputTokens int           // cumulative prompt tokens across all turns
+	BashTimeout    time.Duration // per-Bash-call default deadline
+	OutputCap      int           // bytes captured per Bash call
+}
+
+// DefaultBudget mirrors the defaults documented in §10.5: 60 turns, 200k
+// cumulative input tokens, 5-minute Bash timeout, 50 KB Bash output cap.
+func DefaultBudget() Budget {
+	return Budget{
+		MaxTurns:       60,
+		MaxInputTokens: 200_000,
+		BashTimeout:    5 * time.Minute,
+		OutputCap:      50 * 1024,
+	}
+}
+
+type budgetState struct {
+	turns       int
+	inputTokens int
+}
+
+func (b *budgetState) tickTurn()           { b.turns++ }
+func (b *budgetState) addUsage(in, _ int)  { b.inputTokens += in }
+func (b budgetState) Turns() int           { return b.turns }
+func (b budgetState) InputTokens() int     { return b.inputTokens }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -1,0 +1,174 @@
+// Package harness drives the in-process tool-calling loop for non-Claude
+// pools (PRISMCONDUCTOR_PLAN.md §10.5, issue #58).
+//
+// Today's session manager spawns a Claude Code CLI subprocess and consumes
+// its stream-json over a PTY. For OpenAI-compatible providers there's no
+// equivalent CLI binary the conductor can pty.Start, so the conductor drives
+// the agent loop itself: assemble a system prompt from the bundled skill +
+// repo conventions, send the chat turn through Provider.ToolChat, dispatch
+// any tool calls against the in-process tool registry, feed the results
+// back, and synthesize a stream-json byte stream into a pipe so the existing
+// session.tailAndParse + StreamParser machinery sees identical input shape
+// regardless of strategy.
+//
+// The seam in the session manager is `errors.Is(SpawnArgs-err,
+// ErrNotSupported)`: providers either return argv (subprocess strategy) or
+// ErrNotSupported (harness strategy). Adding a sixth provider doesn't touch
+// internal/session.
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/fs"
+
+	"prismconductor/internal/llm"
+	"prismconductor/internal/types"
+)
+
+// Run is the per-session input to Execute. Constructed by the session
+// manager; the harness never reads the SQLite store directly.
+type Run struct {
+	SessionID   string
+	RepoPath    string // ws.RepoPath — used for system-prompt enrichment.
+	WorktreeDir string // tool cwd; defaults to RepoPath when empty.
+	Mode        types.SessionMode
+	SkillMode   types.SkillMode
+	Pool        types.Pool
+	Provider    llm.Provider
+	UserPrompt  string  // already rendered by planPrompt / executePrompt.
+	Skills      fs.FS   // bundle.FS
+	EnvVars     []string // ws.AgentEnv flattened for the Bash tool.
+	Budget      Budget
+	Out         io.Writer // synthetic stream-json sink (the session pipe writer).
+}
+
+// Execute drives the agent loop until: (1) the model emits a sentinel that
+// flips the session state via matchPatterns, (2) the budget is exhausted,
+// (3) the model stops without tool calls, or (4) ctx is cancelled. Errors
+// returned here flow back to the session as `harnessErr`, which
+// mapTerminalState turns into StateFailed unless matchPatterns already saw a
+// sentinel. Clean-stop sentinel exits return nil so the conductor sees the
+// matchPatterns-driven terminal state.
+func Execute(ctx context.Context, r Run) error {
+	em := newEmitter(r.Out)
+	em.systemInit()
+
+	// Hard rule from PRISMCONDUCTOR_PLAN.md §10.5: harness-v1 supports the
+	// Bundled skill mode only. Hybrid/Native rely on a repo-side CLI that
+	// non-Claude providers don't have today; refuse cleanly with a BLOCKED:
+	// sentinel rather than spinning the model on a malformed prompt.
+	if r.SkillMode != "" && r.SkillMode != types.SkillModeBundled {
+		em.assistantMessage("BLOCKED: harness-v1 supports SkillModeBundled only", nil)
+		em.done()
+		return nil
+	}
+
+	system, err := assembleSystemPrompt(r.Skills, string(r.Mode), r.RepoPath)
+	if err != nil {
+		em.assistantMessage("BLOCKED: harness skill bundle missing — "+err.Error(), nil)
+		em.done()
+		return nil
+	}
+
+	cwd := r.WorktreeDir
+	if cwd == "" {
+		cwd = r.RepoPath
+	}
+	e := &env{
+		Cwd:     cwd,
+		EnvVars: r.EnvVars,
+		Budget:  r.Budget,
+	}
+
+	history := []llm.Message{
+		{Role: "user", Content: r.UserPrompt},
+	}
+	tools := Definitions()
+	state := budgetState{}
+
+	for state.Turns() < r.Budget.MaxTurns {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		state.tickTurn()
+		resp, err := r.Provider.ToolChat(ctx, r.Pool, llm.ChatRequest{
+			System:  system,
+			History: history,
+			Tools:   tools,
+		})
+		if err != nil {
+			if errors.Is(err, llm.ErrNotSupported) {
+				em.assistantMessage("BLOCKED: provider does not implement ToolChat", nil)
+				em.done()
+				return nil
+			}
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
+			}
+			em.assistantMessage("BLOCKED: provider error — "+err.Error(), nil)
+			em.done()
+			return nil
+		}
+		state.addUsage(resp.Usage.InputTokens, resp.Usage.OutputTokens)
+
+		callEvents := make([]toolCallEvent, len(resp.ToolCalls))
+		for i, c := range resp.ToolCalls {
+			callEvents[i] = toolCallEvent{ID: c.ID, Name: c.Name, Args: c.Args}
+		}
+		em.assistantMessage(resp.Content, callEvents)
+
+		history = append(history, llm.Message{
+			Role:      "assistant",
+			Content:   resp.Content,
+			ToolCalls: resp.ToolCalls,
+		})
+
+		if len(resp.ToolCalls) == 0 {
+			em.done()
+			return nil
+		}
+
+		for _, call := range resp.ToolCalls {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			result, toolErr := dispatch(ctx, e, call.Name, call.Args)
+			content := result
+			isError := false
+			if toolErr != nil {
+				content = "error: " + toolErr.Error()
+				if result != "" {
+					content += "\n" + result
+				}
+				isError = true
+			}
+			em.toolResult(call.ID, content, isError)
+			history = append(history, llm.Message{
+				Role:       "tool",
+				Content:    content,
+				ToolCallID: call.ID,
+			})
+		}
+
+		if r.Budget.MaxInputTokens > 0 && state.InputTokens() >= r.Budget.MaxInputTokens {
+			em.assistantMessage("BLOCKED: token budget exceeded", nil)
+			em.done()
+			return nil
+		}
+	}
+
+	em.assistantMessage("BLOCKED: turn budget exceeded", nil)
+	em.done()
+	return nil
+}
+
+// EncodeArgs is a small helper so callers can build raw json.RawMessage args
+// without sprinkling json.Marshal noise. Used by tests and any future caller
+// that needs to construct ChatResponse.ToolCalls.Args inline.
+func EncodeArgs(v any) json.RawMessage {
+	b, _ := json.Marshal(v)
+	return b
+}

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -1,0 +1,305 @@
+package harness_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"prismconductor/internal/harness"
+	"prismconductor/internal/llm"
+	"prismconductor/internal/session"
+	"prismconductor/internal/skills/bundle"
+	"prismconductor/internal/types"
+)
+
+// fakeProvider is a programmable Provider used to drive the harness loop in
+// tests without any HTTP. responses is consumed in order; once exhausted,
+// ToolChat returns nextErr (or, by default, an empty Stop response).
+type fakeProvider struct {
+	responses []llm.ChatResponse
+	calls     []llm.ChatRequest
+	nextErr   error
+}
+
+func (fakeProvider) Kind() types.Provider                                { return "fake" }
+func (fakeProvider) DisplayName() string                                 { return "fake" }
+func (fakeProvider) DefaultEndpoint() string                             { return "" }
+func (fakeProvider) NeedsAPIKey() bool                                   { return false }
+func (fakeProvider) CanSpawn() bool                                      { return true }
+func (fakeProvider) ListModels(context.Context, types.Pool) ([]string, error) {
+	return nil, llm.ErrNotSupported
+}
+func (fakeProvider) SpawnArgs(types.Pool, string) ([]string, error) {
+	return nil, llm.ErrNotSupported
+}
+func (fakeProvider) ChatJSON(context.Context, types.Pool, string, string) (string, error) {
+	return "", llm.ErrNotSupported
+}
+func (f *fakeProvider) ToolChat(_ context.Context, _ types.Pool, req llm.ChatRequest) (llm.ChatResponse, error) {
+	f.calls = append(f.calls, req)
+	if len(f.responses) == 0 {
+		if f.nextErr != nil {
+			return llm.ChatResponse{}, f.nextErr
+		}
+		return llm.ChatResponse{Stop: true}, nil
+	}
+	resp := f.responses[0]
+	f.responses = f.responses[1:]
+	return resp, nil
+}
+
+// pipeBuf is an io.Writer + reader-style sink that captures emitted bytes
+// for assertions without a goroutine race on a real os.Pipe.
+type pipeBuf struct {
+	b strings.Builder
+}
+
+func (p *pipeBuf) Write(b []byte) (int, error) {
+	p.b.Write(b)
+	return len(b), nil
+}
+
+func (p *pipeBuf) String() string { return p.b.String() }
+
+func runHarness(t *testing.T, prov llm.Provider, mode types.SessionMode, prompt string) string {
+	t.Helper()
+	out := &pipeBuf{}
+	err := harness.Execute(context.Background(), harness.Run{
+		SessionID:  "test",
+		RepoPath:   t.TempDir(),
+		Mode:       mode,
+		SkillMode:  types.SkillModeBundled,
+		Provider:   prov,
+		UserPrompt: prompt,
+		Skills:     bundle.FS,
+		Budget:     harness.Budget{MaxTurns: 4, MaxInputTokens: 100_000, BashTimeout: 5 * time.Second, OutputCap: 4096},
+		Out:        out,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	return out.String()
+}
+
+// TestExecute_StopWithoutToolCallsTerminates is the simplest happy path:
+// model returns Stop:true with content, harness emits the assistant + done,
+// loop terminates without further turns.
+func TestExecute_StopWithoutToolCallsTerminates(t *testing.T) {
+	prov := &fakeProvider{
+		responses: []llm.ChatResponse{
+			{Content: "Plan written to .prismconductor/plans/9999-rev1.json", Stop: true},
+		},
+	}
+	out := runHarness(t, prov, types.ModePlan, "/conductor-plan --issue 9999")
+	if len(prov.calls) != 1 {
+		t.Errorf("expected 1 chat call, got %d", len(prov.calls))
+	}
+	if !strings.Contains(out, "Plan written to .prismconductor/plans/9999-rev1.json") {
+		t.Errorf("missing assistant text in output: %q", out)
+	}
+}
+
+// TestExecute_SentinelPropagationThroughStreamParser pipes harness output
+// through the live session.StreamParser and asserts the §10.3 sentinel lands
+// on an @asst line — proving matchPatterns will see it identically to a
+// Claude PTY.
+func TestExecute_SentinelPropagationThroughStreamParser(t *testing.T) {
+	prov := &fakeProvider{
+		responses: []llm.ChatResponse{
+			{Content: "Plan written to .prismconductor/plans/9999-rev1.json", Stop: true},
+		},
+	}
+	out := runHarness(t, prov, types.ModePlan, "x")
+	parser := session.NewStreamParser()
+	var lines []string
+	for _, raw := range strings.Split(strings.TrimSpace(out), "\n") {
+		lines = append(lines, parser.Feed(raw)...)
+	}
+	found := false
+	for _, l := range lines {
+		if strings.HasPrefix(l, session.RoleAssistant) && strings.Contains(l, "Plan written to .prismconductor/plans/9999-rev1.json") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("StreamParser never produced an @asst line with the sentinel; lines=%v", lines)
+	}
+}
+
+// TestExecute_TurnBudgetEmitsBlocked drives the loop past MaxTurns by
+// returning tool calls forever; the harness must emit
+// "BLOCKED: turn budget exceeded" so matchPatterns flips state to Blocked.
+func TestExecute_TurnBudgetEmitsBlocked(t *testing.T) {
+	prov := &fakeProvider{}
+	for i := 0; i < 10; i++ {
+		prov.responses = append(prov.responses, llm.ChatResponse{
+			ToolCalls: []llm.ToolCall{{
+				ID:   "c1",
+				Name: "TodoWrite",
+				Args: json.RawMessage(`{"todos":[]}`),
+			}},
+		})
+	}
+	out := &pipeBuf{}
+	err := harness.Execute(context.Background(), harness.Run{
+		SessionID:  "test",
+		RepoPath:   t.TempDir(),
+		Mode:       types.ModePlan,
+		SkillMode:  types.SkillModeBundled,
+		Provider:   prov,
+		UserPrompt: "x",
+		Skills:     bundle.FS,
+		Budget:     harness.Budget{MaxTurns: 3, MaxInputTokens: 999_999, BashTimeout: time.Second, OutputCap: 1024},
+		Out:        out,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.String(), "BLOCKED: turn budget exceeded") {
+		t.Errorf("expected BLOCKED: turn budget exceeded sentinel, got: %s", out.String())
+	}
+}
+
+// TestExecute_TokenBudgetEmitsBlocked verifies the token-cap arm.
+func TestExecute_TokenBudgetEmitsBlocked(t *testing.T) {
+	prov := &fakeProvider{
+		responses: []llm.ChatResponse{
+			{
+				ToolCalls: []llm.ToolCall{{
+					ID:   "c1",
+					Name: "TodoWrite",
+					Args: json.RawMessage(`{"todos":[]}`),
+				}},
+				Usage: llm.UsageCounts{InputTokens: 100, OutputTokens: 1},
+			},
+			{Stop: true, Content: "should not run"},
+		},
+	}
+	out := &pipeBuf{}
+	err := harness.Execute(context.Background(), harness.Run{
+		SessionID:  "test",
+		RepoPath:   t.TempDir(),
+		Mode:       types.ModePlan,
+		SkillMode:  types.SkillModeBundled,
+		Provider:   prov,
+		UserPrompt: "x",
+		Skills:     bundle.FS,
+		Budget:     harness.Budget{MaxTurns: 10, MaxInputTokens: 50, BashTimeout: time.Second, OutputCap: 1024},
+		Out:        out,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.String(), "BLOCKED: token budget exceeded") {
+		t.Errorf("expected token budget BLOCKED sentinel, got: %s", out.String())
+	}
+}
+
+// TestExecute_NonBundledSkillModeRefused pins the q-skillmode answer:
+// Hybrid/Native modes are rejected with a sentinel rather than running an
+// agent loop the model can't make sense of.
+func TestExecute_NonBundledSkillModeRefused(t *testing.T) {
+	prov := &fakeProvider{}
+	out := &pipeBuf{}
+	err := harness.Execute(context.Background(), harness.Run{
+		SessionID:  "test",
+		RepoPath:   t.TempDir(),
+		Mode:       types.ModePlan,
+		SkillMode:  types.SkillModeHybrid,
+		Provider:   prov,
+		UserPrompt: "x",
+		Skills:     bundle.FS,
+		Budget:     harness.DefaultBudget(),
+		Out:        out,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out.String(), "BLOCKED: harness-v1 supports SkillModeBundled only") {
+		t.Errorf("expected SkillMode refusal sentinel, got: %s", out.String())
+	}
+	if len(prov.calls) != 0 {
+		t.Errorf("provider should not be called for refused skill mode, got %d calls", len(prov.calls))
+	}
+}
+
+// TestExecute_NotSupportedFromProviderEmitsBlocked covers the case where a
+// future provider's ToolChat returns ErrNotSupported; the harness must
+// surface a BLOCKED: sentinel instead of looping.
+func TestExecute_NotSupportedFromProviderEmitsBlocked(t *testing.T) {
+	prov := &fakeProvider{nextErr: llm.ErrNotSupported}
+	out := runHarness(t, prov, types.ModePlan, "x")
+	if !strings.Contains(out, "BLOCKED: provider does not implement ToolChat") {
+		t.Errorf("expected provider-not-supported BLOCKED, got: %s", out)
+	}
+}
+
+// TestExecute_ContextCancelPropagates ensures Kill (via ctx.cancel) returns
+// promptly and surfaces context.Canceled as the harness error.
+func TestExecute_ContextCancelPropagates(t *testing.T) {
+	prov := &fakeProvider{}
+	for i := 0; i < 100; i++ {
+		prov.responses = append(prov.responses, llm.ChatResponse{
+			ToolCalls: []llm.ToolCall{{
+				ID:   "c1",
+				Name: "TodoWrite",
+				Args: json.RawMessage(`{"todos":[]}`),
+			}},
+		})
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	out := &pipeBuf{}
+	err := harness.Execute(ctx, harness.Run{
+		SessionID:  "test",
+		RepoPath:   t.TempDir(),
+		Mode:       types.ModePlan,
+		SkillMode:  types.SkillModeBundled,
+		Provider:   prov,
+		UserPrompt: "x",
+		Skills:     bundle.FS,
+		Budget:     harness.DefaultBudget(),
+		Out:        out,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestExecute_ToolErrorSurfacedAsToolResultNotBlock confirms that a tool
+// failure (e.g. bad path) is surfaced to the model as an is_error tool
+// result so it can recover, NOT as a harness-level BLOCKED:.
+func TestExecute_ToolErrorSurfacedAsToolResultNotBlock(t *testing.T) {
+	prov := &fakeProvider{
+		responses: []llm.ChatResponse{
+			{
+				ToolCalls: []llm.ToolCall{{
+					ID:   "c1",
+					Name: "Read",
+					Args: json.RawMessage(`{"file_path":"../../../etc/passwd"}`),
+				}},
+			},
+			{Stop: true, Content: "ok done"},
+		},
+	}
+	out := runHarness(t, prov, types.ModePlan, "x")
+	if strings.Contains(out, "BLOCKED:") {
+		t.Errorf("tool error must not auto-BLOCK, got: %s", out)
+	}
+	if !strings.Contains(out, "escapes worktree") {
+		t.Errorf("expected tool error text in output, got: %s", out)
+	}
+	if len(prov.calls) != 2 {
+		t.Errorf("expected 2 chat turns (tool + final), got %d", len(prov.calls))
+	}
+}
+
+// TestExecute_AssistantOnlyEndsLoop covers the second termination path: the
+// model returns no tool calls and Stop=false, but content is empty — the
+// harness still treats "no calls" as end-of-turn so a model can't wedge.
+var _ io.Writer = (*pipeBuf)(nil)

--- a/internal/harness/integration_test.go
+++ b/internal/harness/integration_test.go
@@ -1,0 +1,119 @@
+//go:build integration
+// +build integration
+
+package harness_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"prismconductor/internal/harness"
+	"prismconductor/internal/llm"
+	"prismconductor/internal/skills/bundle"
+	"prismconductor/internal/types"
+)
+
+// TestHarness_LiveSmokePlan exercises the harness end-to-end against a real
+// OpenAI-compatible endpoint. Gated on PC_HARNESS_SMOKE_ENDPOINT and
+// PC_HARNESS_SMOKE_MODEL — CI never runs this; the maintainer runs it
+// before merging issue #58 (e.g. against LM Studio + a tool-capable model).
+//
+// Build/run:
+//
+//	go test -tags integration ./internal/harness/... -run LiveSmokePlan -v
+//
+// On a clean run the model writes a plan JSON to a temp dir and emits the
+// §10.3 sentinel; we assert the sentinel reaches the harness's transcript
+// stream.
+func TestHarness_LiveSmokePlan(t *testing.T) {
+	endpoint := os.Getenv("PC_HARNESS_SMOKE_ENDPOINT")
+	model := os.Getenv("PC_HARNESS_SMOKE_MODEL")
+	if endpoint == "" || model == "" {
+		t.Skip("set PC_HARNESS_SMOKE_ENDPOINT and PC_HARNESS_SMOKE_MODEL to run")
+	}
+
+	// Resolve the provider via Kind. Default is openai-style (works for
+	// OpenAI / LM Studio / generic OpenAI-compat); override with
+	// PC_HARNESS_SMOKE_PROVIDER=ollama|lmstudio|litellm to use a different
+	// resolver.
+	kind := os.Getenv("PC_HARNESS_SMOKE_PROVIDER")
+	if kind == "" {
+		kind = "lmstudio"
+	}
+	var prov llm.Provider
+	switch kind {
+	case "openai":
+		prov = llm.NewOpenAIProvider()
+	case "ollama":
+		prov = llm.NewOllamaProvider()
+	case "lmstudio":
+		prov = llm.NewLMStudioProvider()
+	case "litellm":
+		prov = llm.NewLiteLLMProvider()
+	default:
+		t.Fatalf("unknown PC_HARNESS_SMOKE_PROVIDER %q", kind)
+	}
+
+	// Sanity check the endpoint is reachable before we burn turns.
+	hc := &http.Client{Timeout: 5 * time.Second}
+	if _, err := hc.Get(endpoint + "/v1/models"); err != nil {
+		t.Skipf("smoke endpoint %s unreachable: %v", endpoint, err)
+	}
+
+	repo := t.TempDir()
+	pool := types.Pool{
+		ID:       "smoke",
+		Provider: types.Provider(kind),
+		Endpoint: endpoint,
+		Model:    model,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pr.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- harness.Execute(ctx, harness.Run{
+			SessionID:  "smoke",
+			RepoPath:   repo,
+			Mode:       types.ModePlan,
+			SkillMode:  types.SkillModeBundled,
+			Pool:       pool,
+			Provider:   prov,
+			UserPrompt: "/conductor-plan --issue 9999 --repo " + repo,
+			Skills:     bundle.FS,
+			Budget:     harness.DefaultBudget(),
+			Out:        pw,
+		})
+		_ = pw.Close()
+	}()
+
+	buf := make([]byte, 0, 64*1024)
+	tmp := make([]byte, 8*1024)
+	for {
+		n, err := pr.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+		}
+		if err != nil {
+			break
+		}
+	}
+	if err := <-done; err != nil {
+		t.Logf("harness terminal error: %v", err)
+	}
+	out := string(buf)
+	if !strings.Contains(out, "Plan written to .prismconductor/plans/") {
+		t.Errorf("smoke run produced no plan-written sentinel; transcript:\n%s", out)
+	}
+}

--- a/internal/harness/prompts.go
+++ b/internal/harness/prompts.go
@@ -1,0 +1,57 @@
+package harness
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// assembleSystemPrompt builds the system prompt for a harness run.
+// In Bundled mode (the only mode v1 supports — see §10.5), it concatenates:
+//
+//  1. The bundled skill markdown (`conductor-plan.md` for ModePlan,
+//     `conductor-execute.md` for ModeExecute) read from the embedded
+//     skills/ FS.
+//  2. The repo's `CLAUDE.md` (silently skipped if absent — §15.8).
+//  3. Every `.md` under the repo's `.claude/rules/` (silently skipped if
+//     absent).
+//
+// The user message is built separately by the session manager
+// (`planPrompt` / `executePrompt`); this function only assembles the system
+// half so the session manager doesn't need to know which skill markdown to
+// read.
+func assembleSystemPrompt(skills fs.FS, mode string, repoPath string) (string, error) {
+	skillFile := "skills/conductor-plan.md"
+	if mode == "execute" {
+		skillFile = "skills/conductor-execute.md"
+	}
+	parts := []string{}
+	if b, err := fs.ReadFile(skills, skillFile); err == nil {
+		parts = append(parts, string(b))
+	} else {
+		return "", err
+	}
+	if repoPath != "" {
+		if b, err := os.ReadFile(filepath.Join(repoPath, "CLAUDE.md")); err == nil {
+			parts = append(parts, "# Repo CLAUDE.md\n\n"+string(b))
+		}
+		rulesDir := filepath.Join(repoPath, ".claude", "rules")
+		if entries, err := os.ReadDir(rulesDir); err == nil {
+			names := make([]string, 0, len(entries))
+			for _, e := range entries {
+				if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
+					names = append(names, e.Name())
+				}
+			}
+			sort.Strings(names)
+			for _, name := range names {
+				if b, err := os.ReadFile(filepath.Join(rulesDir, name)); err == nil {
+					parts = append(parts, "# Repo rule: "+name+"\n\n"+string(b))
+				}
+			}
+		}
+	}
+	return strings.Join(parts, "\n\n---\n\n"), nil
+}

--- a/internal/harness/streamjson.go
+++ b/internal/harness/streamjson.go
@@ -1,0 +1,142 @@
+package harness
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// emitter writes line-delimited stream-json events that the session package's
+// StreamParser already understands (PRISMCONDUCTOR_PLAN.md §10.3 / §10.5).
+// Each method serializes one event matching what `claude -p --output-format
+// stream-json` emits, so the parser can't tell harness output apart from
+// Claude CLI output — which means matchPatterns and the role-prefixed transcript
+// behave identically for both spawn strategies.
+type emitter struct {
+	out io.Writer
+}
+
+func newEmitter(out io.Writer) *emitter { return &emitter{out: out} }
+
+func (e *emitter) write(v map[string]any) {
+	if e == nil || e.out == nil {
+		return
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return
+	}
+	b = append(b, '\n')
+	_, _ = e.out.Write(b)
+}
+
+// system emits a system.init event. Mirrors the StreamParser arm that
+// produces "@sys session initialized — model thinking…".
+func (e *emitter) systemInit() {
+	e.write(map[string]any{
+		"type":    "system",
+		"subtype": "init",
+	})
+}
+
+// systemStatus emits a system.status event so a free-text status line shows
+// up in the transcript with the @sys role prefix.
+func (e *emitter) systemStatus(msg string) {
+	e.write(map[string]any{
+		"type":    "system",
+		"subtype": "status",
+		"status":  msg,
+	})
+}
+
+// assistantMessage emits the full assistant turn so the session
+// StreamParser produces matching @asst / @tool lines. The parser's text
+// handling lives in the `stream_event` arm (it expects content_block_delta
+// events with text_delta), so we emit the text as a single content_block_delta
+// then close with content_block_stop. Tool_use blocks go through the
+// `assistant` arm — that's what the parser uses to emit @tool lines.
+//
+// This is the propagation channel for the §10.3 sentinels (Plan written /
+// BLOCKED: / QUESTION_PENDING: / Work complete. / PR_OPENED:).
+func (e *emitter) assistantMessage(text string, calls []toolCallEvent) {
+	if text != "" {
+		// Ensure the text ends with a newline so the parser's @asst flush
+		// fires; otherwise the line stays in the @live tail and matchPatterns
+		// never sees it.
+		body := text
+		if body[len(body)-1] != '\n' {
+			body += "\n"
+		}
+		e.write(map[string]any{
+			"type": "stream_event",
+			"event": map[string]any{
+				"type": "content_block_delta",
+				"delta": map[string]any{
+					"type": "text_delta",
+					"text": body,
+				},
+			},
+		})
+		e.write(map[string]any{
+			"type":  "stream_event",
+			"event": map[string]any{"type": "content_block_stop"},
+		})
+	}
+	if len(calls) == 0 {
+		return
+	}
+	content := []map[string]any{}
+	for _, c := range calls {
+		input := json.RawMessage(c.Args)
+		if len(input) == 0 {
+			input = json.RawMessage("{}")
+		}
+		content = append(content, map[string]any{
+			"type":  "tool_use",
+			"id":    c.ID,
+			"name":  c.Name,
+			"input": input,
+		})
+	}
+	e.write(map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": content,
+		},
+	})
+}
+
+// toolResult emits a user.tool_result event so the parser produces an "@res"
+// (or "@err" if isError) line for the model's tool call.
+func (e *emitter) toolResult(callID, content string, isError bool) {
+	e.write(map[string]any{
+		"type": "user",
+		"message": map[string]any{
+			"content": []map[string]any{
+				{
+					"type":         "tool_result",
+					"tool_use_id":  callID,
+					"content":      content,
+					"is_error":     isError,
+				},
+			},
+		},
+	})
+}
+
+// done emits the terminal `result` event. The parser's "result" arm appends a
+// "@done completed" line.
+func (e *emitter) done() {
+	e.write(map[string]any{
+		"type":   "result",
+		"result": "completed",
+	})
+}
+
+// toolCallEvent is the harness-internal alias for an OpenAI-shape tool call,
+// used when serializing assistant messages. Mirrors llm.ToolCall but kept
+// local so streamjson.go has no llm import (avoids cycles).
+type toolCallEvent struct {
+	ID   string
+	Name string
+	Args json.RawMessage
+}

--- a/internal/harness/tools.go
+++ b/internal/harness/tools.go
@@ -1,0 +1,519 @@
+package harness
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"prismconductor/internal/llm"
+)
+
+// env holds per-session tool state. Cwd is the worker's working directory
+// (the worktree for execute-mode, the repo root for plan-mode); every path
+// argument is resolved relative to it and rejected if it escapes.
+type env struct {
+	Cwd     string
+	EnvVars []string
+	Budget  Budget
+
+	// Per-session in-memory todo scratchpad (q-todowrite). Not surfaced to the
+	// conductor — the model writes here for its own bookkeeping; the harness
+	// emits a @sys transcript line on each update so the user can see the
+	// list mutating.
+	todos []TodoItem
+}
+
+// TodoItem mirrors Claude Code's TodoWrite tool entry. Kept minimal: the
+// harness never persists or queries this, just stores it in memory.
+type TodoItem struct {
+	Content    string `json:"content"`
+	Status     string `json:"status"`
+	ActiveForm string `json:"activeForm"`
+}
+
+type toolFn func(ctx context.Context, e *env, raw json.RawMessage) (string, error)
+
+var registry = map[string]toolFn{
+	"Read":      toolRead,
+	"Write":     toolWrite,
+	"Edit":      toolEdit,
+	"Bash":      toolBash,
+	"Glob":      toolGlob,
+	"Grep":      toolGrep,
+	"TodoWrite": toolTodoWrite,
+}
+
+// Definitions returns the JSONSchema-shaped tool descriptors the harness
+// passes to Provider.ToolChat as ChatRequest.Tools (issue #58).
+func Definitions() []llm.ToolDef {
+	return []llm.ToolDef{
+		{
+			Name:        "Read",
+			Description: "Read a file from the workspace. Optionally slice by line offset/limit.",
+			Parameters: schema(map[string]any{
+				"file_path": map[string]any{"type": "string", "description": "Path relative to the worktree."},
+				"offset":    map[string]any{"type": "integer", "description": "Skip N lines from the top.", "default": 0},
+				"limit":     map[string]any{"type": "integer", "description": "Read at most N lines.", "default": 0},
+			}, []string{"file_path"}),
+		},
+		{
+			Name:        "Write",
+			Description: "Write a file in the workspace, creating parent dirs as needed. Atomic.",
+			Parameters: schema(map[string]any{
+				"file_path": map[string]any{"type": "string"},
+				"content":   map[string]any{"type": "string"},
+			}, []string{"file_path", "content"}),
+		},
+		{
+			Name:        "Edit",
+			Description: "Replace the first occurrence of old_string with new_string in file_path. Use replace_all=true to replace every occurrence.",
+			Parameters: schema(map[string]any{
+				"file_path":   map[string]any{"type": "string"},
+				"old_string":  map[string]any{"type": "string"},
+				"new_string":  map[string]any{"type": "string"},
+				"replace_all": map[string]any{"type": "boolean", "default": false},
+			}, []string{"file_path", "old_string", "new_string"}),
+		},
+		{
+			Name:        "Bash",
+			Description: "Run a shell command via /bin/bash -c with the worktree as cwd. Output is captured (stdout + stderr merged), capped at the harness output limit.",
+			Parameters: schema(map[string]any{
+				"command": map[string]any{"type": "string"},
+				"timeout": map[string]any{"type": "integer", "description": "Seconds before killing the command. Defaults to the harness BashTimeout."},
+			}, []string{"command"}),
+		},
+		{
+			Name:        "Glob",
+			Description: "Match files in the workspace by glob pattern. Returns up to 200 paths.",
+			Parameters: schema(map[string]any{
+				"pattern": map[string]any{"type": "string"},
+				"path":    map[string]any{"type": "string", "description": "Subdirectory to scope the match. Defaults to worktree root."},
+			}, []string{"pattern"}),
+		},
+		{
+			Name:        "Grep",
+			Description: "Search file contents for a regex. Returns up to 200 match lines with file:line prefixes.",
+			Parameters: schema(map[string]any{
+				"pattern": map[string]any{"type": "string"},
+				"path":    map[string]any{"type": "string"},
+				"glob":    map[string]any{"type": "string", "description": "File-name glob filter."},
+			}, []string{"pattern"}),
+		},
+		{
+			Name:        "TodoWrite",
+			Description: "Replace the harness's per-session todo list. Each item has content, status (pending|in_progress|completed), and activeForm.",
+			Parameters: schema(map[string]any{
+				"todos": map[string]any{
+					"type": "array",
+					"items": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"content":    map[string]any{"type": "string"},
+							"status":     map[string]any{"type": "string"},
+							"activeForm": map[string]any{"type": "string"},
+						},
+						"required": []string{"content", "status", "activeForm"},
+					},
+				},
+			}, []string{"todos"}),
+		},
+	}
+}
+
+func schema(props map[string]any, required []string) json.RawMessage {
+	obj := map[string]any{
+		"type":       "object",
+		"properties": props,
+	}
+	if len(required) > 0 {
+		obj["required"] = required
+	}
+	b, _ := json.Marshal(obj)
+	return b
+}
+
+// dispatch runs the named tool. Unknown names return an error string the
+// model is expected to recover from. Tool errors are returned as the second
+// return; the caller serializes them as is_error tool_results.
+func dispatch(ctx context.Context, e *env, name string, raw json.RawMessage) (string, error) {
+	fn, ok := registry[name]
+	if !ok {
+		return "", fmt.Errorf("unknown tool %q", name)
+	}
+	return fn(ctx, e, raw)
+}
+
+// resolvePath turns user-supplied input into an absolute path inside the
+// worker's cwd. Paths whose canonical form escapes cwd are rejected.
+func resolvePath(e *env, p string) (string, error) {
+	if p == "" {
+		return "", errors.New("empty path")
+	}
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(e.Cwd, p)
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(e.Cwd, abs)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %s escapes worktree", p)
+	}
+	return abs, nil
+}
+
+const readCap = 200 * 1024
+
+func toolRead(_ context.Context, e *env, raw json.RawMessage) (string, error) {
+	var args struct {
+		FilePath string `json:"file_path"`
+		Offset   int    `json:"offset"`
+		Limit    int    `json:"limit"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return "", err
+	}
+	abs, err := resolvePath(e, args.FilePath)
+	if err != nil {
+		return "", err
+	}
+	b, err := os.ReadFile(abs)
+	if err != nil {
+		return "", err
+	}
+	s := string(b)
+	if args.Offset > 0 || args.Limit > 0 {
+		lines := strings.Split(s, "\n")
+		start := args.Offset
+		if start > len(lines) {
+			start = len(lines)
+		}
+		end := len(lines)
+		if args.Limit > 0 && start+args.Limit < end {
+			end = start + args.Limit
+		}
+		s = strings.Join(lines[start:end], "\n")
+	}
+	if len(s) > readCap {
+		s = s[:readCap] + "\n… (truncated)"
+	}
+	return s, nil
+}
+
+func toolWrite(_ context.Context, e *env, raw json.RawMessage) (string, error) {
+	var args struct {
+		FilePath string `json:"file_path"`
+		Content  string `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return "", err
+	}
+	abs, err := resolvePath(e, args.FilePath)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		return "", err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(abs), ".harness-*")
+	if err != nil {
+		return "", err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.WriteString(args.Content); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return "", err
+	}
+	if err := os.Rename(tmpName, abs); err != nil {
+		os.Remove(tmpName)
+		return "", err
+	}
+	return fmt.Sprintf("wrote %d bytes to %s", len(args.Content), args.FilePath), nil
+}
+
+func toolEdit(_ context.Context, e *env, raw json.RawMessage) (string, error) {
+	var args struct {
+		FilePath   string `json:"file_path"`
+		OldString  string `json:"old_string"`
+		NewString  string `json:"new_string"`
+		ReplaceAll bool   `json:"replace_all"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return "", err
+	}
+	abs, err := resolvePath(e, args.FilePath)
+	if err != nil {
+		return "", err
+	}
+	b, err := os.ReadFile(abs)
+	if err != nil {
+		return "", err
+	}
+	src := string(b)
+	if args.OldString == "" {
+		return "", errors.New("old_string is empty")
+	}
+	count := strings.Count(src, args.OldString)
+	if count == 0 {
+		return "", fmt.Errorf("old_string not found in %s", args.FilePath)
+	}
+	var out string
+	if args.ReplaceAll {
+		out = strings.ReplaceAll(src, args.OldString, args.NewString)
+	} else {
+		if count > 1 {
+			return "", fmt.Errorf("old_string matches %d times in %s; pass replace_all=true or extend old_string for uniqueness", count, args.FilePath)
+		}
+		out = strings.Replace(src, args.OldString, args.NewString, 1)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(abs), ".harness-*")
+	if err != nil {
+		return "", err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.WriteString(out); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return "", err
+	}
+	if err := os.Rename(tmpName, abs); err != nil {
+		os.Remove(tmpName)
+		return "", err
+	}
+	if args.ReplaceAll {
+		return fmt.Sprintf("replaced %d occurrences in %s", count, args.FilePath), nil
+	}
+	return fmt.Sprintf("edited %s", args.FilePath), nil
+}
+
+func toolBash(ctx context.Context, e *env, raw json.RawMessage) (string, error) {
+	var args struct {
+		Command string `json:"command"`
+		Timeout int    `json:"timeout"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return "", err
+	}
+	if args.Command == "" {
+		return "", errors.New("empty command")
+	}
+	timeout := e.Budget.BashTimeout
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+	if args.Timeout > 0 {
+		timeout = time.Duration(args.Timeout) * time.Second
+	}
+	cctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, "/bin/bash", "-c", args.Command)
+	cmd.Dir = e.Cwd
+	cmd.Env = append(os.Environ(), e.EnvVars...)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	out := buf.String()
+	cap := e.Budget.OutputCap
+	if cap <= 0 {
+		cap = 50 * 1024
+	}
+	truncated := false
+	if len(out) > cap {
+		out = out[:cap]
+		truncated = true
+	}
+	header := fmt.Sprintf("$ %s\nexit=%d", args.Command, cmd.ProcessState.ExitCode())
+	if cctx.Err() == context.DeadlineExceeded {
+		header += " (timed out)"
+	}
+	if truncated {
+		header += " (output truncated)"
+	}
+	body := header + "\n" + out
+	if err != nil && cctx.Err() != context.DeadlineExceeded {
+		// Non-zero exit. Don't surface as a tool error — the model often
+		// expects to read a failing exit code (e.g. running the test suite to
+		// see what failed). Return the captured output instead.
+		return body, nil
+	}
+	return body, nil
+}
+
+const globCap = 200
+const grepCap = 200
+
+func toolGlob(_ context.Context, e *env, raw json.RawMessage) (string, error) {
+	var args struct {
+		Pattern string `json:"pattern"`
+		Path    string `json:"path"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return "", err
+	}
+	if args.Pattern == "" {
+		return "", errors.New("empty pattern")
+	}
+	root := e.Cwd
+	if args.Path != "" {
+		abs, err := resolvePath(e, args.Path)
+		if err != nil {
+			return "", err
+		}
+		root = abs
+	}
+	type entry struct {
+		path string
+		mod  time.Time
+	}
+	var matches []entry
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if strings.HasPrefix(d.Name(), ".") && p != root {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(e.Cwd, p)
+		if err != nil {
+			return nil
+		}
+		ok, _ := filepath.Match(args.Pattern, filepath.Base(p))
+		if !ok {
+			ok, _ = filepath.Match(args.Pattern, rel)
+		}
+		if !ok {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		matches = append(matches, entry{path: rel, mod: info.ModTime()})
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].mod.After(matches[j].mod)
+	})
+	if len(matches) > globCap {
+		matches = matches[:globCap]
+	}
+	out := make([]string, len(matches))
+	for i, m := range matches {
+		out[i] = m.path
+	}
+	if len(out) == 0 {
+		return "(no matches)", nil
+	}
+	return strings.Join(out, "\n"), nil
+}
+
+func toolGrep(_ context.Context, e *env, raw json.RawMessage) (string, error) {
+	var args struct {
+		Pattern string `json:"pattern"`
+		Path    string `json:"path"`
+		Glob    string `json:"glob"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return "", err
+	}
+	if args.Pattern == "" {
+		return "", errors.New("empty pattern")
+	}
+	re, err := regexp.Compile(args.Pattern)
+	if err != nil {
+		return "", err
+	}
+	root := e.Cwd
+	if args.Path != "" {
+		abs, err := resolvePath(e, args.Path)
+		if err != nil {
+			return "", err
+		}
+		root = abs
+	}
+	var matches []string
+	err = filepath.WalkDir(root, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if strings.HasPrefix(d.Name(), ".") && p != root {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if args.Glob != "" {
+			ok, _ := filepath.Match(args.Glob, filepath.Base(p))
+			if !ok {
+				return nil
+			}
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return nil
+		}
+		rel, _ := filepath.Rel(e.Cwd, p)
+		for i, line := range strings.Split(string(b), "\n") {
+			if !re.MatchString(line) {
+				continue
+			}
+			matches = append(matches, fmt.Sprintf("%s:%d:%s", rel, i+1, line))
+			if len(matches) >= grepCap {
+				return filepath.SkipAll
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(matches) == 0 {
+		return "(no matches)", nil
+	}
+	return strings.Join(matches, "\n"), nil
+}
+
+func toolTodoWrite(_ context.Context, e *env, raw json.RawMessage) (string, error) {
+	var args struct {
+		Todos []TodoItem `json:"todos"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return "", err
+	}
+	e.todos = args.Todos
+	lines := make([]string, len(args.Todos))
+	for i, t := range args.Todos {
+		lines[i] = fmt.Sprintf("[%s] %s", t.Status, t.Content)
+	}
+	return fmt.Sprintf("todo list updated (%d items)\n%s", len(args.Todos), strings.Join(lines, "\n")), nil
+}

--- a/internal/harness/tools_test.go
+++ b/internal/harness/tools_test.go
@@ -1,0 +1,185 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newEnv(t *testing.T) *env {
+	t.Helper()
+	return &env{
+		Cwd:    t.TempDir(),
+		Budget: DefaultBudget(),
+	}
+}
+
+func TestToolRead_HappyPath(t *testing.T) {
+	e := newEnv(t)
+	if err := os.WriteFile(filepath.Join(e.Cwd, "a.txt"), []byte("hello\nworld\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := toolRead(context.Background(), e, json.RawMessage(`{"file_path":"a.txt"}`))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(out, "hello") || !strings.Contains(out, "world") {
+		t.Errorf("missing content: %q", out)
+	}
+}
+
+func TestToolRead_RejectsPathEscape(t *testing.T) {
+	e := newEnv(t)
+	_, err := toolRead(context.Background(), e, json.RawMessage(`{"file_path":"../../etc/passwd"}`))
+	if err == nil {
+		t.Fatal("expected escape rejection")
+	}
+	if !strings.Contains(err.Error(), "escapes worktree") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestToolWrite_AtomicAndScoped(t *testing.T) {
+	e := newEnv(t)
+	_, err := toolWrite(context.Background(), e, json.RawMessage(`{"file_path":"sub/dir/x.txt","content":"hi"}`))
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(e.Cwd, "sub/dir/x.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "hi" {
+		t.Errorf("got %q, want hi", string(b))
+	}
+	if _, err := toolWrite(context.Background(), e, json.RawMessage(`{"file_path":"../bad","content":"x"}`)); err == nil {
+		t.Error("expected escape rejection")
+	}
+}
+
+func TestToolEdit_NonUniqueOldStringRejected(t *testing.T) {
+	e := newEnv(t)
+	if err := os.WriteFile(filepath.Join(e.Cwd, "f.txt"), []byte("foo bar foo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := toolEdit(context.Background(), e, json.RawMessage(`{"file_path":"f.txt","old_string":"foo","new_string":"baz"}`))
+	if err == nil {
+		t.Fatal("expected non-unique error")
+	}
+	if !strings.Contains(err.Error(), "matches 2 times") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestToolEdit_ReplaceAll(t *testing.T) {
+	e := newEnv(t)
+	if err := os.WriteFile(filepath.Join(e.Cwd, "f.txt"), []byte("foo bar foo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := toolEdit(context.Background(), e, json.RawMessage(`{"file_path":"f.txt","old_string":"foo","new_string":"baz","replace_all":true}`))
+	if err != nil {
+		t.Fatalf("edit: %v", err)
+	}
+	b, _ := os.ReadFile(filepath.Join(e.Cwd, "f.txt"))
+	if string(b) != "baz bar baz" {
+		t.Errorf("got %q, want %q", string(b), "baz bar baz")
+	}
+}
+
+func TestToolBash_RunsInCwdAndCapturesOutput(t *testing.T) {
+	e := newEnv(t)
+	out, err := toolBash(context.Background(), e, json.RawMessage(`{"command":"echo hello && pwd"}`))
+	if err != nil {
+		t.Fatalf("bash: %v", err)
+	}
+	if !strings.Contains(out, "hello") {
+		t.Errorf("missing stdout: %s", out)
+	}
+	if !strings.Contains(out, e.Cwd) {
+		t.Errorf("bash didn't run in cwd %s: %s", e.Cwd, out)
+	}
+}
+
+func TestToolBash_TimeoutKills(t *testing.T) {
+	e := newEnv(t)
+	e.Budget.BashTimeout = 200 * time.Millisecond
+	out, err := toolBash(context.Background(), e, json.RawMessage(`{"command":"sleep 5"}`))
+	if err != nil {
+		t.Fatalf("bash: %v", err)
+	}
+	if !strings.Contains(out, "timed out") {
+		t.Errorf("expected timed-out marker, got: %s", out)
+	}
+}
+
+func TestToolBash_OutputCapTrims(t *testing.T) {
+	e := newEnv(t)
+	e.Budget.OutputCap = 64
+	out, err := toolBash(context.Background(), e, json.RawMessage(`{"command":"yes hello | head -c 1024"}`))
+	if err != nil {
+		t.Fatalf("bash: %v", err)
+	}
+	if !strings.Contains(out, "output truncated") {
+		t.Errorf("expected truncation marker, got: %s", out)
+	}
+}
+
+func TestToolGlob_FindsAndSortsByMtime(t *testing.T) {
+	e := newEnv(t)
+	older := filepath.Join(e.Cwd, "old.go")
+	newer := filepath.Join(e.Cwd, "new.go")
+	if err := os.WriteFile(older, []byte("// old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	if err := os.Chtimes(older, now.Add(-2*time.Hour), now.Add(-2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newer, []byte("// new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := toolGlob(context.Background(), e, json.RawMessage(`{"pattern":"*.go"}`))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	idxNew := strings.Index(out, "new.go")
+	idxOld := strings.Index(out, "old.go")
+	if idxNew < 0 || idxOld < 0 {
+		t.Fatalf("missing entries: %s", out)
+	}
+	if idxNew > idxOld {
+		t.Errorf("expected newest-first, got: %s", out)
+	}
+}
+
+func TestToolGrep_FindsLineWithFilePrefix(t *testing.T) {
+	e := newEnv(t)
+	if err := os.WriteFile(filepath.Join(e.Cwd, "a.go"), []byte("hello\nfoo bar\nbaz"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := toolGrep(context.Background(), e, json.RawMessage(`{"pattern":"foo"}`))
+	if err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if !strings.Contains(out, "a.go:2:foo bar") {
+		t.Errorf("expected file:line:content prefix, got: %s", out)
+	}
+}
+
+func TestToolTodoWrite_ReplacesAndReportsCount(t *testing.T) {
+	e := newEnv(t)
+	out, err := toolTodoWrite(context.Background(), e, json.RawMessage(`{"todos":[{"content":"step one","status":"pending","activeForm":"doing one"}]}`))
+	if err != nil {
+		t.Fatalf("todo: %v", err)
+	}
+	if !strings.Contains(out, "1 items") {
+		t.Errorf("missing count: %s", out)
+	}
+	if len(e.todos) != 1 || e.todos[0].Content != "step one" {
+		t.Errorf("env todos not updated: %+v", e.todos)
+	}
+}

--- a/internal/llm/claude.go
+++ b/internal/llm/claude.go
@@ -133,6 +133,12 @@ func (c claudeProvider) ChatJSON(ctx context.Context, p types.Pool, system, user
 	return "", fmt.Errorf("anthropic returned no text content; body: %s", snippetN(string(raw), 200))
 }
 
+// ToolChat is unimplemented for Claude — Claude pools use the subprocess /
+// PTY path via SpawnArgs, not the harness. See PRISMCONDUCTOR_PLAN.md §10.5.
+func (claudeProvider) ToolChat(_ context.Context, _ types.Pool, _ ChatRequest) (ChatResponse, error) {
+	return ChatResponse{}, ErrNotSupported
+}
+
 // claudeCLIFallback shells `claude -p --output-format json` with a combined
 // prompt. Requires the user to be logged in via `claude` CLI. The CLI doesn't
 // expose a system-prompt flag for the headless print mode, so system+user are

--- a/internal/llm/litellm.go
+++ b/internal/llm/litellm.go
@@ -27,7 +27,7 @@ func (litellmProvider) Kind() types.Provider    { return types.ProviderLiteLLM }
 func (litellmProvider) DisplayName() string     { return "LiteLLM" }
 func (litellmProvider) DefaultEndpoint() string { return defaultLiteLLMEndpoint }
 func (litellmProvider) NeedsAPIKey() bool       { return true }
-func (litellmProvider) CanSpawn() bool          { return false }
+func (litellmProvider) CanSpawn() bool          { return true }
 
 // ListModels prefers /model/info (LiteLLM-native — exposes alias names), falls
 // back to /v1/models on any failure.
@@ -71,6 +71,19 @@ func (litellmProvider) SpawnArgs(_ types.Pool, _ string) ([]string, error) {
 }
 
 func (l litellmProvider) ChatJSON(ctx context.Context, p types.Pool, system, user string) (string, error) {
+	endpoint, key := l.resolve(p)
+	return openAICompatChat(ctx, l.client, endpoint, key, p.Model, system, user)
+}
+
+// ToolChat drives a tool-using turn through LiteLLM's OpenAI-compat endpoint
+// (issue #58). LiteLLM forwards `tools[]` to the backing model; whether the
+// model emits tool_calls depends on the backend.
+func (l litellmProvider) ToolChat(ctx context.Context, p types.Pool, req ChatRequest) (ChatResponse, error) {
+	endpoint, key := l.resolve(p)
+	return openAIToolChat(ctx, l.client, endpoint, key, p.Model, req)
+}
+
+func (l litellmProvider) resolve(p types.Pool) (string, string) {
 	endpoint := strings.TrimRight(p.Endpoint, "/")
 	if endpoint == "" {
 		endpoint = defaultLiteLLMEndpoint
@@ -79,5 +92,5 @@ func (l litellmProvider) ChatJSON(ctx context.Context, p types.Pool, system, use
 	if key == "" {
 		key = os.Getenv("LITELLM_API_KEY")
 	}
-	return openAICompatChat(ctx, l.client, endpoint, key, p.Model, system, user)
+	return endpoint, key
 }

--- a/internal/llm/lmstudio.go
+++ b/internal/llm/lmstudio.go
@@ -26,7 +26,7 @@ func (lmstudioProvider) Kind() types.Provider    { return types.ProviderLMStudio
 func (lmstudioProvider) DisplayName() string     { return "LM Studio" }
 func (lmstudioProvider) DefaultEndpoint() string { return defaultLMStudioEndpoint }
 func (lmstudioProvider) NeedsAPIKey() bool       { return true }
-func (lmstudioProvider) CanSpawn() bool          { return false }
+func (lmstudioProvider) CanSpawn() bool          { return true }
 
 // ListModels prefers LM Studio's /api/v0/models (native — includes load state)
 // filtering to loaded entries, falling back to OpenAI-compat /v1/models when
@@ -73,9 +73,23 @@ func (lmstudioProvider) SpawnArgs(_ types.Pool, _ string) ([]string, error) {
 }
 
 func (l lmstudioProvider) ChatJSON(ctx context.Context, p types.Pool, system, user string) (string, error) {
+	endpoint := l.resolveEndpoint(p)
+	return openAICompatChat(ctx, l.client, endpoint, p.APIKey, p.Model, system, user)
+}
+
+// ToolChat drives a tool-using turn through LM Studio's OpenAI-compat endpoint
+// (issue #58). LM Studio's tool-calling support varies by loaded model; for
+// models without native tool tokens the server may emit content only and the
+// harness treats that as a clean stop.
+func (l lmstudioProvider) ToolChat(ctx context.Context, p types.Pool, req ChatRequest) (ChatResponse, error) {
+	endpoint := l.resolveEndpoint(p)
+	return openAIToolChat(ctx, l.client, endpoint, p.APIKey, p.Model, req)
+}
+
+func (l lmstudioProvider) resolveEndpoint(p types.Pool) string {
 	endpoint := strings.TrimRight(p.Endpoint, "/")
 	if endpoint == "" {
 		endpoint = defaultLMStudioEndpoint
 	}
-	return openAICompatChat(ctx, l.client, endpoint, p.APIKey, p.Model, system, user)
+	return endpoint
 }

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -25,7 +25,7 @@ func (ollamaProvider) Kind() types.Provider    { return types.ProviderOllama }
 func (ollamaProvider) DisplayName() string     { return "Ollama" }
 func (ollamaProvider) DefaultEndpoint() string { return defaultOllamaEndpoint }
 func (ollamaProvider) NeedsAPIKey() bool       { return true }
-func (ollamaProvider) CanSpawn() bool          { return false }
+func (ollamaProvider) CanSpawn() bool          { return true }
 
 // ListModels parses Ollama's /api/tags. Bearer auth is forwarded so a tunneled
 // (e.g. Tailscale Funnel) endpoint guarded by HTTP-basic-equivalent auth still
@@ -66,9 +66,23 @@ func (ollamaProvider) SpawnArgs(_ types.Pool, _ string) ([]string, error) {
 // large local models, so callers should pass a context with their own
 // deadline (the orchestrator gives 5 minutes).
 func (o ollamaProvider) ChatJSON(ctx context.Context, p types.Pool, system, user string) (string, error) {
+	endpoint := o.resolveEndpoint(p)
+	return openAICompatChat(ctx, o.client, endpoint, p.APIKey, p.Model, system, user)
+}
+
+// ToolChat drives a tool-using turn through Ollama's OpenAI-compat endpoint
+// (issue #58). Tool support requires an Ollama build that surfaces tool_calls
+// — older builds return content only, which the harness treats as a clean
+// stop.
+func (o ollamaProvider) ToolChat(ctx context.Context, p types.Pool, req ChatRequest) (ChatResponse, error) {
+	endpoint := o.resolveEndpoint(p)
+	return openAIToolChat(ctx, o.client, endpoint, p.APIKey, p.Model, req)
+}
+
+func (o ollamaProvider) resolveEndpoint(p types.Pool) string {
 	endpoint := strings.TrimRight(p.Endpoint, "/")
 	if endpoint == "" {
 		endpoint = defaultOllamaEndpoint
 	}
-	return openAICompatChat(ctx, o.client, endpoint, p.APIKey, p.Model, system, user)
+	return endpoint
 }

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -25,7 +25,7 @@ func (openaiProvider) Kind() types.Provider    { return types.ProviderOpenAI }
 func (openaiProvider) DisplayName() string     { return "OpenAI" }
 func (openaiProvider) DefaultEndpoint() string { return defaultOpenAIEndpoint }
 func (openaiProvider) NeedsAPIKey() bool       { return true }
-func (openaiProvider) CanSpawn() bool          { return false }
+func (openaiProvider) CanSpawn() bool          { return true }
 
 func (o openaiProvider) ListModels(ctx context.Context, p types.Pool) ([]string, error) {
 	endpoint := strings.TrimRight(p.Endpoint, "/")
@@ -50,6 +50,18 @@ func (openaiProvider) SpawnArgs(_ types.Pool, _ string) ([]string, error) {
 // ChatJSON routes through OpenAI's /v1/chat/completions. APIKey falls back to
 // OPENAI_API_KEY so existing operator setups keep working.
 func (o openaiProvider) ChatJSON(ctx context.Context, p types.Pool, system, user string) (string, error) {
+	endpoint, key := o.resolve(p)
+	return openAICompatChat(ctx, o.client, endpoint, key, p.Model, system, user)
+}
+
+// ToolChat drives a tool-using turn against OpenAI's /v1/chat/completions
+// (issue #58). Used by the harness when SpawnArgs returns ErrNotSupported.
+func (o openaiProvider) ToolChat(ctx context.Context, p types.Pool, req ChatRequest) (ChatResponse, error) {
+	endpoint, key := o.resolve(p)
+	return openAIToolChat(ctx, o.client, endpoint, key, p.Model, req)
+}
+
+func (o openaiProvider) resolve(p types.Pool) (string, string) {
 	endpoint := strings.TrimRight(p.Endpoint, "/")
 	if endpoint == "" {
 		endpoint = defaultOpenAIEndpoint
@@ -58,5 +70,5 @@ func (o openaiProvider) ChatJSON(ctx context.Context, p types.Pool, system, user
 	if key == "" {
 		key = os.Getenv("OPENAI_API_KEY")
 	}
-	return openAICompatChat(ctx, o.client, endpoint, key, p.Model, system, user)
+	return endpoint, key
 }

--- a/internal/llm/orchestrator_chat.go
+++ b/internal/llm/orchestrator_chat.go
@@ -74,3 +74,162 @@ func snippetN(s string, n int) string {
 	}
 	return s[:n] + "…"
 }
+
+// openAIToolChat is the harness-side sibling of openAICompatChat. It serializes
+// `tools[]` and `tool_choice:"auto"` and decodes `choices[0].message.tool_calls`
+// into the harness ChatResponse shape (issue #58).
+//
+// Non-streaming for v1 — buffers the full response and returns one
+// ChatResponse. Shared by every OpenAI-compat provider (OpenAI, Ollama, LM
+// Studio, LiteLLM); each provider's ToolChat method resolves endpoint + auth
+// then delegates here.
+func openAIToolChat(ctx context.Context, client *http.Client, baseURL, apiKey, model string, req ChatRequest) (ChatResponse, error) {
+	if model == "" {
+		return ChatResponse{}, fmt.Errorf("tool chat: model required")
+	}
+	url := strings.TrimRight(baseURL, "/") + "/v1/chat/completions"
+
+	msgs := make([]map[string]any, 0, len(req.History)+1)
+	if req.System != "" {
+		msgs = append(msgs, map[string]any{
+			"role":    "system",
+			"content": req.System,
+		})
+	}
+	for _, m := range req.History {
+		switch m.Role {
+		case "tool":
+			msgs = append(msgs, map[string]any{
+				"role":         "tool",
+				"content":      m.Content,
+				"tool_call_id": m.ToolCallID,
+			})
+		case "assistant":
+			am := map[string]any{
+				"role":    "assistant",
+				"content": m.Content,
+			}
+			if len(m.ToolCalls) > 0 {
+				calls := make([]map[string]any, len(m.ToolCalls))
+				for i, c := range m.ToolCalls {
+					args := string(c.Args)
+					if args == "" {
+						args = "{}"
+					}
+					calls[i] = map[string]any{
+						"id":   c.ID,
+						"type": "function",
+						"function": map[string]any{
+							"name":      c.Name,
+							"arguments": args,
+						},
+					}
+				}
+				am["tool_calls"] = calls
+			}
+			msgs = append(msgs, am)
+		default:
+			msgs = append(msgs, map[string]any{
+				"role":    m.Role,
+				"content": m.Content,
+			})
+		}
+	}
+
+	body := map[string]any{
+		"model":       model,
+		"temperature": 0.0,
+		"stream":      false,
+		"messages":    msgs,
+	}
+	if len(req.Tools) > 0 {
+		tools := make([]map[string]any, len(req.Tools))
+		for i, t := range req.Tools {
+			var params any
+			if len(t.Parameters) > 0 {
+				params = json.RawMessage(t.Parameters)
+			} else {
+				params = map[string]any{"type": "object"}
+			}
+			tools[i] = map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":        t.Name,
+					"description": t.Description,
+					"parameters":  params,
+				},
+			}
+		}
+		body["tools"] = tools
+		body["tool_choice"] = "auto"
+	}
+
+	raw, _ := json.Marshal(body)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(raw))
+	if err != nil {
+		return ChatResponse{}, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return ChatResponse{}, err
+	}
+	defer resp.Body.Close()
+	respRaw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return ChatResponse{}, fmt.Errorf("LLM HTTP %d: %s", resp.StatusCode, snippetN(string(respRaw), 200))
+	}
+	var out struct {
+		Choices []struct {
+			FinishReason string `json:"finish_reason"`
+			Message      struct {
+				Content   string `json:"content"`
+				ToolCalls []struct {
+					ID       string `json:"id"`
+					Type     string `json:"type"`
+					Function struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					} `json:"function"`
+				} `json:"tool_calls"`
+			} `json:"message"`
+		} `json:"choices"`
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+		} `json:"usage"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(respRaw, &out); err != nil {
+		return ChatResponse{}, fmt.Errorf("decode response: %w; body: %s", err, snippetN(string(respRaw), 200))
+	}
+	if out.Error != nil {
+		return ChatResponse{}, fmt.Errorf("LLM error: %s", out.Error.Message)
+	}
+	if len(out.Choices) == 0 {
+		return ChatResponse{}, fmt.Errorf("LLM returned no choices; body: %s", snippetN(string(respRaw), 200))
+	}
+	choice := out.Choices[0]
+	calls := make([]ToolCall, 0, len(choice.Message.ToolCalls))
+	for _, c := range choice.Message.ToolCalls {
+		calls = append(calls, ToolCall{
+			ID:   c.ID,
+			Name: c.Function.Name,
+			Args: json.RawMessage(c.Function.Arguments),
+		})
+	}
+	return ChatResponse{
+		Content:   choice.Message.Content,
+		ToolCalls: calls,
+		Stop:      len(calls) == 0,
+		Usage: UsageCounts{
+			InputTokens:  out.Usage.PromptTokens,
+			OutputTokens: out.Usage.CompletionTokens,
+		},
+	}, nil
+}

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -10,13 +10,17 @@ package llm
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 
 	"prismconductor/internal/types"
 )
 
-// ErrNotSupported signals that the operation isn't wired up yet for a provider.
-// Non-Claude providers return it from SpawnArgs until harness-v1 lands.
+// ErrNotSupported signals that the operation isn't wired up for a provider.
+// Claude returns it from ToolChat (the harness only drives non-Claude pools
+// today); the four OpenAI-compat providers return it from SpawnArgs because
+// they have no native CLI to pty.Start — the harness drives their tool loop
+// via ToolChat instead.
 var ErrNotSupported = errors.New("llm: provider does not support this operation yet")
 
 // Provider drives one heterogeneous worker fleet kind.
@@ -26,9 +30,11 @@ type Provider interface {
 	DefaultEndpoint() string
 	NeedsAPIKey() bool
 
-	// CanSpawn reports whether SpawnArgs returns a working argv today. The
-	// worker-pool registry consults this to decide eligibility, so the
-	// orchestrator never compares against `ProviderClaude` literally.
+	// CanSpawn reports whether the session manager can spawn a worker for
+	// this provider — either via SpawnArgs (subprocess strategy) or via
+	// ToolChat (harness strategy). The workerpool registry consults this to
+	// decide eligibility, so the orchestrator never compares against
+	// ProviderClaude literally.
 	CanSpawn() bool
 
 	// ListModels probes the endpoint for available model IDs. Returns
@@ -37,7 +43,11 @@ type Provider interface {
 	ListModels(ctx context.Context, p types.Pool) ([]string, error)
 
 	// SpawnArgs returns the argv the session manager should pty.Start.
-	// Non-Claude providers return ErrNotSupported until harness-v1 lands.
+	// Returns ErrNotSupported for providers driven by the harness instead of
+	// a subprocess. The session manager dispatches:
+	//   - err == nil               → subprocess strategy (Claude today)
+	//   - errors.Is(err, ErrNotSupported) → harness strategy (uses ToolChat)
+	//   - other err                → surfaced to caller
 	SpawnArgs(p types.Pool, prompt string) ([]string, error)
 
 	// ChatJSON sends a system+user prompt and returns the raw model output.
@@ -49,6 +59,64 @@ type Provider interface {
 	//   - ProviderOllama:                  /v1/chat/completions (ollama serves
 	//                                      OpenAI-compat too).
 	ChatJSON(ctx context.Context, p types.Pool, system, user string) (string, error)
+
+	// ToolChat sends a tool-using chat turn and returns the assistant's
+	// content + any requested tool calls (issue #58). Non-streaming for v1.
+	// Claude returns ErrNotSupported — Claude pools keep the PTY/subprocess
+	// path for now. The four OpenAI-compat providers route through their
+	// /v1/chat/completions endpoint with `tools:` serialized.
+	ToolChat(ctx context.Context, p types.Pool, req ChatRequest) (ChatResponse, error)
+}
+
+// ChatRequest is the wire-shape carried into Provider.ToolChat (issue #58).
+type ChatRequest struct {
+	System  string
+	History []Message
+	Tools   []ToolDef
+}
+
+// Message is one turn in the chat history. Role is "user", "assistant", or
+// "tool". For assistant messages, ToolCalls may be populated. For tool
+// messages, ToolCallID identifies which assistant tool call this result
+// answers.
+type Message struct {
+	Role       string
+	Content    string
+	ToolCalls  []ToolCall
+	ToolCallID string
+}
+
+// ToolDef advertises a tool the model can call. Parameters is JSONSchema.
+type ToolDef struct {
+	Name        string
+	Description string
+	Parameters  json.RawMessage
+}
+
+// ToolCall is one model-issued tool invocation. Args is JSON matching the
+// corresponding ToolDef.Parameters.
+type ToolCall struct {
+	ID   string
+	Name string
+	Args json.RawMessage
+}
+
+// ChatResponse is the wire-shape returned from Provider.ToolChat.
+// Stop is true when the model signals end-of-turn with no tool calls
+// (i.e. native stop). Otherwise the harness sends each ToolCall through the
+// tool registry and feeds the results back as additional Messages.
+type ChatResponse struct {
+	Content   string
+	ToolCalls []ToolCall
+	Stop      bool
+	Usage     UsageCounts
+}
+
+// UsageCounts mirror the OpenAI usage block. Captured per-call but not yet
+// aggregated into a cost dashboard (out of scope for #58).
+type UsageCounts struct {
+	InputTokens  int
+	OutputTokens int
 }
 
 // Registry holds one Provider per kind plus a stable ordering for the UI.

--- a/internal/llm/provider_test.go
+++ b/internal/llm/provider_test.go
@@ -26,12 +26,22 @@ func TestRegistryGetAndOrder(t *testing.T) {
 }
 
 func TestRegistryCanSpawn(t *testing.T) {
-	r := NewRegistry(NewClaudeProvider(), NewOpenAIProvider())
+	r := NewRegistry(NewClaudeProvider(), NewOpenAIProvider(), NewLiteLLMProvider(), NewLMStudioProvider(), NewOllamaProvider())
 	if !r.CanSpawn(types.ProviderClaude) {
 		t.Fatal("claude.CanSpawn should be true")
 	}
-	if r.CanSpawn(types.ProviderOpenAI) {
-		t.Fatal("openai.CanSpawn should be false until harness-v1")
+	// Issue #58: harness-v1 flips CanSpawn() to true on the four
+	// OpenAI-compat providers. The session manager dispatches them through
+	// the in-process loop instead of pty.Start.
+	for _, kind := range []types.Provider{
+		types.ProviderOpenAI,
+		types.ProviderLiteLLM,
+		types.ProviderLMStudio,
+		types.ProviderOllama,
+	} {
+		if !r.CanSpawn(kind) {
+			t.Errorf("%s.CanSpawn should be true post harness-v1", kind)
+		}
 	}
 	if r.CanSpawn(types.Provider("missing")) {
 		t.Fatal("unknown provider's CanSpawn should be false")
@@ -74,13 +84,46 @@ func TestNonClaudeProvidersReturnNotSupportedForSpawnArgs(t *testing.T) {
 	}
 	for _, p := range cases {
 		t.Run(string(p.Kind()), func(t *testing.T) {
-			if p.CanSpawn() {
-				t.Fatalf("%s.CanSpawn should be false until harness-v1", p.Kind())
+			// Issue #58: CanSpawn flipped to true; the session manager now
+			// drives these via the harness when SpawnArgs returns
+			// ErrNotSupported. SpawnArgs itself still signals "harness me"
+			// with ErrNotSupported.
+			if !p.CanSpawn() {
+				t.Fatalf("%s.CanSpawn should be true post harness-v1", p.Kind())
 			}
 			if _, err := p.SpawnArgs(types.Pool{}, "x"); err != ErrNotSupported {
 				t.Fatalf("%s.SpawnArgs returned %v, want ErrNotSupported", p.Kind(), err)
 			}
 		})
+	}
+}
+
+// TestClaudeToolChatNotSupported pins Claude's harness-side behavior: until
+// the harness drives Claude pools too (separate ticket), Claude's ToolChat
+// returns ErrNotSupported and the session manager keeps the PTY/subprocess
+// strategy via SpawnArgs.
+func TestClaudeToolChatNotSupported(t *testing.T) {
+	p := NewClaudeProvider()
+	if _, err := p.ToolChat(context.Background(), types.Pool{}, ChatRequest{}); err != ErrNotSupported {
+		t.Fatalf("claude.ToolChat returned %v, want ErrNotSupported", err)
+	}
+}
+
+// TestProvidersImplementToolChat is a compile-time-style guard that every
+// registered provider satisfies the harness-v1 Provider interface (issue
+// #58). If a future provider is added without ToolChat, this test fails to
+// compile.
+func TestProvidersImplementToolChat(t *testing.T) {
+	cases := []Provider{
+		NewClaudeProvider(),
+		NewOpenAIProvider(),
+		NewLiteLLMProvider(),
+		NewLMStudioProvider(),
+		NewOllamaProvider(),
+	}
+	for _, p := range cases {
+		var _ Provider = p
+		_ = p.Kind()
 	}
 }
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -3,6 +3,7 @@ package session
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -17,7 +18,9 @@ import (
 
 	"prismconductor/internal/eventbus"
 	pcgit "prismconductor/internal/git"
+	"prismconductor/internal/harness"
 	"prismconductor/internal/llm"
+	"prismconductor/internal/skills/bundle"
 	"prismconductor/internal/types"
 )
 
@@ -70,7 +73,7 @@ type Manager struct {
 
 type runtimeSession struct {
 	sess           *types.Session
-	cmd            *exec.Cmd
+	cmd            sessionCmd
 	cancel         context.CancelFunc
 	transcriptPath string
 	transcriptFile *os.File
@@ -102,7 +105,76 @@ type runtimeSession struct {
 	// process). Reattach paths skip cmd.Wait + worktree teardown that the
 	// fresh-spawn path needs.
 	reattached bool
+
+	// Issue #58: harness strategy stash. The harness goroutine writes its
+	// terminal error here so synthCmd.Wait can return it, letting
+	// mapTerminalState distinguish a clean exit from a transport failure or
+	// context cancel without requiring the harness to bubble through PTY
+	// stdout.
+	harnessErr error
 }
+
+// sessionCmd is the §10.5 abstraction over both spawn strategies. The
+// subprocess strategy wraps an *exec.Cmd; the harness strategy wraps the
+// goroutine that drives the in-process agent loop. Both expose Wait + Kill
+// + Pid so tailAndParse, Kill, and the persistence layer don't care which
+// strategy a session uses.
+type sessionCmd interface {
+	Wait() error
+	Kill() error
+	Pid() int
+}
+
+// subprocCmd adapts an *exec.Cmd (Claude pools, raw demo spawns) to the
+// sessionCmd interface.
+type subprocCmd struct {
+	cmd *exec.Cmd
+}
+
+func (s *subprocCmd) Wait() error {
+	return s.cmd.Wait()
+}
+
+func (s *subprocCmd) Kill() error {
+	if s.cmd == nil || s.cmd.Process == nil {
+		return nil
+	}
+	return s.cmd.Process.Kill()
+}
+
+func (s *subprocCmd) Pid() int {
+	if s.cmd == nil || s.cmd.Process == nil {
+		return 0
+	}
+	return s.cmd.Process.Pid
+}
+
+// synthCmd adapts the harness goroutine to the sessionCmd interface. Wait
+// blocks until the harness signals done, then returns the captured terminal
+// error (which mapTerminalState turns into StateFailed unless matchPatterns
+// already saw a sentinel that drove the state somewhere else).
+type synthCmd struct {
+	done   chan struct{}
+	err    *error
+	cancel context.CancelFunc
+}
+
+func (s *synthCmd) Wait() error {
+	<-s.done
+	if s.err == nil {
+		return nil
+	}
+	return *s.err
+}
+
+func (s *synthCmd) Kill() error {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	return nil
+}
+
+func (s *synthCmd) Pid() int { return 0 }
 
 func NewManager(bus *eventbus.Bus, emit LineHandler) *Manager {
 	return &Manager{bus: bus, emit: emit, sessions: map[string]*runtimeSession{}}
@@ -132,14 +204,14 @@ func (m *Manager) SetOnActivity(h ActivityHandler) { m.onActivity = h }
 func (m *Manager) SetProviders(r *llm.Registry) { m.providers = r }
 
 // SpawnPlan launches a plan-mode worker per §10.1 / §10.4. The pool's provider
-// determines the argv via Provider.SpawnArgs — Claude pools today, additional
-// providers when harness-v1 lands.
+// determines the spawn strategy: Claude returns argv (subprocess), the four
+// OpenAI-compat providers return llm.ErrNotSupported (harness, §10.5).
 func (m *Manager) SpawnPlan(ws types.Workspace, issue types.Issue, pool types.Pool) (*types.Session, error) {
-	args, err := m.buildPlanCommand(ws, issue, pool)
+	args, prompt, err := m.buildPlanCommand(ws, issue, pool)
 	if err != nil {
 		return nil, err
 	}
-	return m.spawn(ws, issue, types.ModePlan, args, pool.ID)
+	return m.spawn(ws, issue, types.ModePlan, args, prompt, pool)
 }
 
 // SpawnExecute launches an execute-mode worker per §10.2.
@@ -187,12 +259,12 @@ func (m *Manager) SpawnExecute(ws types.Workspace, issue types.Issue, plan types
 		return nil, fmt.Errorf("mirror plan artifacts: %w", err)
 	}
 
-	args, err := m.buildExecuteCommand(ws, issue, plan, pool)
+	args, prompt, err := m.buildExecuteCommand(ws, issue, plan, pool)
 	if err != nil {
 		_ = pcgit.Remove(ws.RepoPath, worktreeDir)
 		return nil, err
 	}
-	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute, args, worktreeDir, branch, pool.ID)
+	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool)
 	if err != nil {
 		_ = pcgit.Remove(ws.RepoPath, worktreeDir)
 		return nil, err
@@ -213,11 +285,11 @@ func (m *Manager) SpawnExecuteResume(ws types.Workspace, issue types.Issue, plan
 	if _, err := os.Stat(worktreeDir); err != nil {
 		return nil, fmt.Errorf("resume worktree missing at %s: %w", worktreeDir, err)
 	}
-	args, err := m.buildExecuteResumeCommand(ws, issue, plan, pool, questionID)
+	args, prompt, err := m.buildExecuteResumeCommand(ws, issue, plan, pool, questionID)
 	if err != nil {
 		return nil, err
 	}
-	return m.spawnWithDir(ws, issue, types.ModeExecute, args, worktreeDir, branch, pool.ID)
+	return m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool)
 }
 
 // branchSlug derives a kebab-case branch suffix from an issue title, lowering
@@ -290,28 +362,38 @@ func mirrorPlanArtifacts(repoPath, worktreeDir string, num, rev int) error {
 	return nil
 }
 
-// SpawnRaw runs a non-skill command via PTY (used by the day-1 demo: `claude --version`).
+// SpawnRaw runs a non-skill command via subprocess (used by the day-1 demo:
+// `claude --version`). Always takes the subprocess strategy — there's no pool
+// to dispatch on.
 func (m *Manager) SpawnRaw(ws types.Workspace, name string, args []string) (*types.Session, error) {
 	demoIssue := types.Issue{Number: 0, WorkspaceID: ws.ID}
 	full := append([]string{name}, args...)
-	return m.spawn(ws, demoIssue, types.ModePlan, full, "")
+	return m.spawn(ws, demoIssue, types.ModePlan, full, "", types.Pool{})
 }
 
-func (m *Manager) spawn(ws types.Workspace, issue types.Issue, mode types.SessionMode, argv []string, poolID string) (*types.Session, error) {
-	return m.spawnWithDir(ws, issue, mode, argv, "", "", poolID)
+func (m *Manager) spawn(ws types.Workspace, issue types.Issue, mode types.SessionMode, argv []string, prompt string, pool types.Pool) (*types.Session, error) {
+	return m.spawnWithDir(ws, issue, mode, argv, prompt, "", "", pool)
 }
 
 // spawnWithDir is the canonical spawn path. When worktreeDir is non-empty the
-// child process runs there instead of ws.RepoPath, and the worktree metadata
-// is captured on the runtimeSession for the cleanup hook in tailAndParse.
+// worker runs there instead of ws.RepoPath, and the worktree metadata is
+// captured on the runtimeSession for the cleanup hook in tailAndParse.
 //
 // Issue #54: the worker's stdout/stderr point at the transcript file directly
 // so it survives a conductor exit (no Go-side copy goroutine that would die
 // with us and break the pipe). The conductor reads worker output by polling
 // the same file (tailAndParse). This also unifies the live-spawn path with
 // the re-attach path: both consume the file.
-func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types.SessionMode, argv []string, worktreeDir, branch, poolID string) (*types.Session, error) {
-	if len(argv) == 0 {
+//
+// Issue #58: dispatches between two strategies — subprocess (Claude pools,
+// raw demo spawns) and harness (the four OpenAI-compat providers). When argv
+// is set, the subprocess path runs as before. When argv is empty (the
+// caller's Provider.SpawnArgs returned llm.ErrNotSupported) the harness
+// goroutine drives the agent loop and writes synthesized stream-json into
+// the transcript file. tailAndParse + StreamParser see identical input
+// shape regardless of strategy.
+func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types.SessionMode, argv []string, prompt, worktreeDir, branch string, pool types.Pool) (*types.Session, error) {
+	if len(argv) == 0 && prompt == "" {
 		return nil, fmt.Errorf("empty command")
 	}
 	if m.transcriptDir == "" {
@@ -329,25 +411,6 @@ func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types
 		return nil, fmt.Errorf("create transcript: %w", err)
 	}
 
-	cmd := exec.Command(argv[0], argv[1:]...)
-	switch {
-	case worktreeDir != "":
-		cmd.Dir = worktreeDir
-	case ws.RepoPath != "":
-		cmd.Dir = ws.RepoPath
-	}
-	cmd.Env = append(os.Environ(), envSpecToSlice(ws.AgentEnv)...)
-	cmd.Stdin = nil
-	cmd.Stdout = tf
-	cmd.Stderr = tf
-	cmd.SysProcAttr = detachedProcAttr()
-
-	if err := cmd.Start(); err != nil {
-		_ = tf.Close()
-		_ = os.Remove(transcriptPath)
-		return nil, fmt.Errorf("cmd.Start: %w", err)
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	sess := &types.Session{
 		ID:          sessID,
@@ -356,13 +419,11 @@ func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types
 		Mode:        mode,
 		State:       types.StateRunning,
 		StartedAt:   time.Now(),
-		PID:         cmd.Process.Pid,
 	}
 	sess.Transcript = transcriptPath
 
 	rs := &runtimeSession{
 		sess:           sess,
-		cmd:            cmd,
 		cancel:         cancel,
 		parser:         NewStreamParser(),
 		transcriptPath: transcriptPath,
@@ -370,7 +431,66 @@ func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types
 		worktreeDir:    worktreeDir,
 		branch:         branch,
 		repoPath:       ws.RepoPath,
-		poolID:         poolID,
+		poolID:         pool.ID,
+	}
+
+	if len(argv) > 0 {
+		// Subprocess strategy.
+		cwd := worktreeDir
+		if cwd == "" {
+			cwd = ws.RepoPath
+		}
+		cmd := exec.Command(argv[0], argv[1:]...)
+		cmd.Dir = cwd
+		cmd.Env = append(os.Environ(), envSpecToSlice(ws.AgentEnv)...)
+		cmd.Stdin = nil
+		cmd.Stdout = tf
+		cmd.Stderr = tf
+		cmd.SysProcAttr = detachedProcAttr()
+		if err := cmd.Start(); err != nil {
+			_ = tf.Close()
+			_ = os.Remove(transcriptPath)
+			cancel()
+			return nil, fmt.Errorf("cmd.Start: %w", err)
+		}
+		sess.PID = cmd.Process.Pid
+		rs.cmd = &subprocCmd{cmd: cmd}
+	} else {
+		// Harness strategy (issue #58). The harness goroutine writes
+		// synthesized stream-json directly into the transcript file; the
+		// conductor's tail loop reads it as it would for a Claude PTY.
+		if m.providers == nil {
+			_ = tf.Close()
+			_ = os.Remove(transcriptPath)
+			cancel()
+			return nil, fmt.Errorf("session manager: provider registry not configured")
+		}
+		prov, ok := m.providers.Get(pool.Provider)
+		if !ok {
+			_ = tf.Close()
+			_ = os.Remove(transcriptPath)
+			cancel()
+			return nil, fmt.Errorf("session manager: unknown provider %q for pool %s", pool.Provider, pool.ID)
+		}
+		done := make(chan struct{})
+		rs.cmd = &synthCmd{done: done, err: &rs.harnessErr, cancel: cancel}
+		go func() {
+			defer close(done)
+			rs.harnessErr = harness.Execute(ctx, harness.Run{
+				SessionID:   sessID,
+				RepoPath:    ws.RepoPath,
+				WorktreeDir: worktreeDir,
+				Mode:        mode,
+				SkillMode:   ws.SkillProfile.Mode,
+				Pool:        pool,
+				Provider:    prov,
+				UserPrompt:  prompt,
+				Skills:      bundle.FS,
+				EnvVars:     envSpecToSlice(ws.AgentEnv),
+				Budget:      harness.DefaultBudget(),
+				Out:         tf,
+			})
+		}()
 	}
 
 	if m.store != nil {
@@ -700,7 +820,10 @@ func (m *Manager) recordActivity(rs *runtimeSession, line string) {
 
 // Kill terminates a running session. For re-attached sessions whose original
 // process is owned by a prior conductor (issue #54), we still send a kill
-// signal directly since the worker is in our PID namespace.
+// signal directly since the worker is in our PID namespace. For harness
+// sessions (issue #58), Kill cancels the harness context — the goroutine
+// unwinds, closes the transcript handle, and surfaces context.Canceled
+// through synthCmd.Wait so mapTerminalState lands on Failed.
 func (m *Manager) Kill(sessionID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -711,8 +834,11 @@ func (m *Manager) Kill(sessionID string) error {
 	if rs.cancel != nil {
 		rs.cancel()
 	}
-	if rs.cmd != nil && rs.cmd.Process != nil {
-		return rs.cmd.Process.Kill()
+	if rs.cmd != nil {
+		if err := rs.cmd.Kill(); err != nil {
+			return err
+		}
+		return nil
 	}
 	if rs.sess != nil && rs.sess.PID > 0 {
 		if p, err := os.FindProcess(rs.sess.PID); err == nil {
@@ -747,38 +873,54 @@ func (m *Manager) Snapshot() []types.Session {
 	return out
 }
 
-// --- §10.4 dispatch ---
+// --- §10.4 / §10.5 dispatch ---
 //
 // Worker argv is provided by the LLM provider registry: each pool's Provider
-// returns the argv via SpawnArgs(pool, prompt). Today only the Claude provider
-// returns a working argv; the others return llm.ErrNotSupported until
-// harness-v1 lands. The prompt itself is mode-specific (plan / execute) and
-// shaped here.
+// returns the argv via SpawnArgs(pool, prompt). Claude returns argv (the
+// session manager runs it as a subprocess); the four OpenAI-compat providers
+// return llm.ErrNotSupported (the session manager runs the in-process
+// harness loop). The prompt itself is mode-specific (plan / execute) and
+// shaped here. Both strategies share the same prompt — the harness uses it
+// as the user-message in its first chat turn.
 
-func (m *Manager) buildPlanCommand(ws types.Workspace, issue types.Issue, pool types.Pool) ([]string, error) {
+func (m *Manager) buildPlanCommand(ws types.Workspace, issue types.Issue, pool types.Pool) ([]string, string, error) {
 	return m.providerArgs(pool, planPrompt(ws, issue))
 }
 
-func (m *Manager) buildExecuteCommand(ws types.Workspace, issue types.Issue, plan types.Plan, pool types.Pool) ([]string, error) {
+func (m *Manager) buildExecuteCommand(ws types.Workspace, issue types.Issue, plan types.Plan, pool types.Pool) ([]string, string, error) {
 	return m.providerArgs(pool, executePrompt(ws, issue, plan))
 }
 
 // buildExecuteResumeCommand mirrors buildExecuteCommand but appends the
 // `--resume-question <id>` flag so the conductor-execute skill knows to skip
 // branch creation and read the mid-run question's context sidecar (#17).
-func (m *Manager) buildExecuteResumeCommand(ws types.Workspace, issue types.Issue, plan types.Plan, pool types.Pool, questionID string) ([]string, error) {
+func (m *Manager) buildExecuteResumeCommand(ws types.Workspace, issue types.Issue, plan types.Plan, pool types.Pool, questionID string) ([]string, string, error) {
 	return m.providerArgs(pool, executeResumePrompt(ws, issue, plan, questionID))
 }
 
-func (m *Manager) providerArgs(pool types.Pool, prompt string) ([]string, error) {
+// providerArgs returns the spawn strategy for a (pool, prompt) pair:
+//   - argv non-nil, err nil       → subprocess strategy
+//   - argv nil, prompt non-empty  → harness strategy (provider returned
+//                                   llm.ErrNotSupported from SpawnArgs, which
+//                                   is the §10.5 signal to use the in-process
+//                                   loop)
+//   - other error                 → bubbled to caller
+func (m *Manager) providerArgs(pool types.Pool, prompt string) ([]string, string, error) {
 	if m.providers == nil {
-		return nil, fmt.Errorf("session manager: provider registry not configured")
+		return nil, "", fmt.Errorf("session manager: provider registry not configured")
 	}
 	prov, ok := m.providers.Get(pool.Provider)
 	if !ok {
-		return nil, fmt.Errorf("session manager: unknown provider %q for pool %s", pool.Provider, pool.ID)
+		return nil, "", fmt.Errorf("session manager: unknown provider %q for pool %s", pool.Provider, pool.ID)
 	}
-	return prov.SpawnArgs(pool, prompt)
+	argv, err := prov.SpawnArgs(pool, prompt)
+	if err == nil {
+		return argv, prompt, nil
+	}
+	if errors.Is(err, llm.ErrNotSupported) {
+		return nil, prompt, nil
+	}
+	return nil, "", err
 }
 
 func planPrompt(ws types.Workspace, issue types.Issue) string {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -157,7 +157,7 @@ func TestSpawnWritesToTranscriptFile(t *testing.T) {
 	issue := types.Issue{Number: 1, WorkspaceID: ws.ID}
 	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute,
 		[]string{"/bin/sh", "-c", "echo hello-from-worker; echo Work complete."},
-		"", "", "")
+		"", "", "", types.Pool{})
 	if err != nil {
 		t.Fatalf("spawnWithDir: %v", err)
 	}


### PR DESCRIPTION
## Summary

Issue #58 — harness-v1. Adds an in-process agent loop (`internal/harness/`) that drives the four OpenAI-compatible providers (OpenAI / Ollama / LM Studio / LiteLLM) through a tool-using chat session, so non-Claude pools become spawnable for plan and execute mode. Claude pools keep their existing PTY/subprocess strategy unchanged.

The session manager's spawn dispatch is now provider-literal-free: it switches on `errors.Is(SpawnArgs-err, llm.ErrNotSupported)` rather than a `Kind() == ProviderClaude` check. Adding a sixth provider never touches `internal/session`.

## Files modified

**Added** (`internal/harness/`):
- `harness.go` — agent loop, sentinel propagation, budget enforcement, skill-mode refusal
- `tools.go` — seven path-scoped tools (Read / Write / Edit / Bash / Glob / Grep / TodoWrite)
- `streamjson.go` — synthesizes Claude-CLI-shaped stream-json so the existing `StreamParser` is unchanged
- `prompts.go` — system-prompt assembly: bundled skill + `CLAUDE.md` + `.claude/rules/*.md`
- `budget.go` — turn / token / Bash-output / Bash-timeout caps (defaults: 60 / 200 K / 50 KB / 5 min)
- `harness_test.go` — loop mechanics, sentinel propagation through real `session.StreamParser`, budget arms, ctx cancel, skill-mode refusal, tool-error recovery
- `tools_test.go` — per-tool unit tests (path escape, atomic writes, replace-all, timeout, output cap, mtime sort)
- `integration_test.go` — `//go:build integration`, gated on `PC_HARNESS_SMOKE_ENDPOINT` / `PC_HARNESS_SMOKE_MODEL`; CI never runs it

**Modified**:
- `internal/llm/provider.go` — adds `ToolChat(ctx, pool, ChatRequest) (ChatResponse, error)` plus `ChatRequest`, `ChatResponse`, `Message`, `ToolDef`, `ToolCall`, `UsageCounts`
- `internal/llm/orchestrator_chat.go` — adds `openAIToolChat` helper alongside the existing `openAICompatChat`
- `internal/llm/{openai,ollama,lmstudio,litellm}.go` — implement `ToolChat`; flip `CanSpawn() → true`
- `internal/llm/claude.go` — `ToolChat` returns `ErrNotSupported` (Claude keeps the subprocess path)
- `internal/llm/provider_test.go` — pin `CanSpawn()` flips, Claude's `ToolChat ErrNotSupported`, all-providers-implement-`ToolChat` guard
- `internal/session/manager.go` — `runtimeSession.cmd` becomes a `sessionCmd` interface (`Wait` / `Kill` / `Pid`) with `subprocCmd` + `synthCmd` adapters; `spawnWithDir` dispatches between strategies via `errors.Is(ErrNotSupported)` on the provider's `SpawnArgs`; harness goroutine writes synthesized stream-json into the transcript file so `tailAndParse` is unchanged
- `internal/session/manager_test.go` — compile-fix for new `pool` parameter
- `frontend/src/components/PoolsPanel.tsx` — drop "Awaiting harness-v1" badge
- `frontend/src/components/PoolEditModal.tsx` — drop the inline harness-v1 notice
- `PRISMCONDUCTOR_PLAN.md` — adds §10.5 (harness-v1), updates §6.6 / §11 to reflect the post-harness world

## Verification

- **Lint:** `go vet ./internal/...` — pass
- **Build:** `wails build` — pass (~7s compile after deps)
- **Tests:** `go test ./internal/... -count=1` — all green; new harness package: 9 tests, all pass; updated llm tests: 8 tests, all pass; session tests unchanged
- **Frontend typecheck:** `cd frontend && npx tsc --noEmit` — clean
- **Integration smoke (deferred):** maintainer runs `go test -tags integration ./internal/harness/... -run LiveSmokePlan` against an LM Studio + tool-capable model before merge

## Notes for review

- Bundled skill mode only for v1 (q-skillmode). Hybrid / Native modes refuse with `BLOCKED: harness-v1 supports SkillModeBundled only`.
- Tool errors flow back to the model as `is_error: true` tool results, never auto-`BLOCKED:`. The model decides whether to retry or escalate.
- Sentinel propagation works because the harness emits the same line-delimited stream-json shape Claude's CLI emits; `StreamParser` and `matchPatterns` see identical bytes regardless of strategy.
- Budgets surface as `BLOCKED:` sentinels (turn / token), not as wait errors — `mapTerminalState` lands on `Blocked` cleanly.

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-58

Closes #58
