### PR TITLE
feat(plan): split PlanModal into Goal/Code/Executive sections (#55)

### DIFF
--- a/PRISMCONDUCTOR_PLAN.md
+++ b/PRISMCONDUCTOR_PLAN.md
@@ -300,6 +300,8 @@ type Plan struct {
     IssueNumber          int          `json:"issue_number"`
     WorkspaceID          string       `json:"workspace_id"`
     Revision             int          `json:"revision"`              // 1, 2, 3...
+    GoalSummary          string       `json:"goal_summary,omitempty"`      // planner restatement of intent (#55)
+    ExecutiveSummary     string       `json:"executive_summary,omitempty"` // outcome-focused, plain-language (#55)
     PlanMarkdown         string       `json:"plan_markdown"`         // for human display
     FilesToModify        []FileIntent `json:"files_to_modify"`
     DependenciesDetected []int        `json:"dependencies_detected"`
@@ -483,6 +485,8 @@ When a worker finishes plan mode, it MUST emit a JSON file at `<repo>/.prismcond
   "issue_number": 1130,
   "workspace_id": "prismengine",
   "revision": 1,
+  "goal_summary": "The user wants a new utility spell in the FIRE_LORE family that fits between the existing seed=10 and seed=12 entries...",
+  "executive_summary": "Adds a new spell variant players can cast for moderate fire damage with reduced mana cost. Designed to give early-game characters a sustainable AoE option without unbalancing late-game fights.",
   "plan_markdown": "## What I'll do\n\n1. Add new spell schema...\n2. Wire up...\n",
   "files_to_modify": [
     {"path": "games/gsx/scripts/spells/new_spell.py", "intent": "add"},
@@ -506,6 +510,16 @@ When a worker finishes plan mode, it MUST emit a JSON file at `<repo>/.prismcond
 ```
 
 `ready_to_execute` is `true` only when `questions` is empty (or all answered in a revision).
+
+`goal_summary` and `executive_summary` are **schema-optional but skill-required** (issue #55). The
+`omitempty` tags mean older plans on disk (written before these fields existed) deserialize cleanly
+with empty strings, and the PlanModal renders sensible fallbacks. New plans produced by the
+bundled `conductor-plan` skill MUST populate both: `goal_summary` is 2-3 paragraphs of intent (the
+planner's restatement of the issue body in their own words — what is this actually trying to
+achieve?), and `executive_summary` is 3-4 plain-language sentences a non-coder PM would understand
+(outcome-focused — what does the user get when this ships? No file paths, no symbol names). If the
+planner cannot write a `goal_summary`, the issue is too thin to plan — emit a `Question` asking the
+user to clarify intent rather than producing an empty string.
 
 `suggested_labels` is optional (`omitempty`). Populated by `conductor-plan` with one **axis** label
 at index 0 (`enhancement` / `bug` / `refactor` / `documentation` / `test` — mapped from the issue

--- a/frontend/src/components/PlanModal.tsx
+++ b/frontend/src/components/PlanModal.tsx
@@ -184,13 +184,22 @@ export function PlanModal({
                 onIssueRefresh={refreshIssues}
               />
 
-              <Section title="What the agent plans to do">
-                <Markdown text={plan.plan_markdown} />
-              </Section>
+              <CollapsibleSection title="The Goal" defaultOpen={true}>
+                {plan.goal_summary ? (
+                  <Markdown text={plan.goal_summary} />
+                ) : (
+                  <>
+                    <Markdown text={plan.plan_markdown} />
+                    <p className="text-xs text-slate-500 mt-2">
+                      Older plan format — showing implementation detail. Reject and replan to populate the goal summary.
+                    </p>
+                  </>
+                )}
+              </CollapsibleSection>
 
-              {(plan.files_to_modify ?? []).length > 0 && (
-                <Section title="Files to modify">
-                  <ul className="font-mono text-xs space-y-0.5">
+              <CollapsibleSection title="The Code" defaultOpen={false}>
+                {(plan.files_to_modify ?? []).length > 0 && (
+                  <ul className="font-mono text-xs space-y-0.5 mb-3">
                     {plan.files_to_modify.map((f) => (
                       <li key={f.path} className="text-slate-300">
                         <span className="text-slate-500 w-3 inline-block">{INTENT_GLYPH[f.intent] ?? "?"}</span>{" "}
@@ -199,18 +208,24 @@ export function PlanModal({
                       </li>
                     ))}
                   </ul>
-                </Section>
-              )}
-
-              {(plan.dependencies_detected ?? []).length > 0 && (
-                <Section title="Detected dependencies">
-                  <ul className="text-xs space-y-0.5">
+                )}
+                {plan.goal_summary && <Markdown text={plan.plan_markdown} />}
+                {(plan.dependencies_detected ?? []).length > 0 && (
+                  <ul className="text-xs space-y-0.5 mt-3">
                     {plan.dependencies_detected.map((n) => (
                       <li key={n} className="text-amber-300">• Depends on #{n}</li>
                     ))}
                   </ul>
-                </Section>
-              )}
+                )}
+              </CollapsibleSection>
+
+              <CollapsibleSection title="Executive Summary" defaultOpen={true}>
+                {plan.executive_summary ? (
+                  <Markdown text={plan.executive_summary} />
+                ) : (
+                  <p className="text-slate-500 text-xs italic">Planner didn't produce one — replan to fill in.</p>
+                )}
+              </CollapsibleSection>
 
               {hasQuestions && (
                 <Section title={`Questions (${questions.length})`}>
@@ -415,6 +430,36 @@ function Section({ title, children }: { title: string; children: React.ReactNode
     <div>
       <div className="text-xs uppercase tracking-wide text-slate-500 mb-1">{title}</div>
       {children}
+    </div>
+  );
+}
+
+function CollapsibleSection({
+  title,
+  defaultOpen = true,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center gap-2 text-left text-xs uppercase tracking-wide text-slate-500 hover:text-slate-300 mb-1"
+      >
+        <span
+          className="transition-transform duration-150"
+          style={{ display: "inline-block", transform: open ? "rotate(90deg)" : "rotate(0)" }}
+        >
+          ▶
+        </span>
+        {title}
+      </button>
+      {open && <div>{children}</div>}
     </div>
   );
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1075,6 +1075,8 @@ export namespace types {
 	    issue_number: number;
 	    workspace_id: string;
 	    revision: number;
+	    goal_summary?: string;
+	    executive_summary?: string;
 	    plan_markdown: string;
 	    files_to_modify: FileIntent[];
 	    dependencies_detected: number[];
@@ -1096,6 +1098,8 @@ export namespace types {
 	        this.issue_number = source["issue_number"];
 	        this.workspace_id = source["workspace_id"];
 	        this.revision = source["revision"];
+	        this.goal_summary = source["goal_summary"];
+	        this.executive_summary = source["executive_summary"];
 	        this.plan_markdown = source["plan_markdown"];
 	        this.files_to_modify = this.convertValues(source["files_to_modify"], FileIntent);
 	        this.dependencies_detected = source["dependencies_detected"];

--- a/internal/skills/bundle/skills/conductor-plan.md
+++ b/internal/skills/bundle/skills/conductor-plan.md
@@ -42,11 +42,28 @@ Bundled by PrismConductor. Used in Bundled and Hybrid skill modes (PRISMCONDUCTO
    Axis names MUST map to existing repo labels via the priority lists above — do not invent
    axis names. The "suggest even if missing" rule applies to topicals only.
 5. Compose a plan that lists:
-   - What to do (markdown)
+   - **Goal summary** (`goal_summary`, REQUIRED — non-empty): 2-3 paragraphs at medium-high level,
+     what the issue is actually trying to accomplish. Intent, not implementation. The planner's
+     restatement of the issue body in their own words. If a reader only sees this, they should be
+     able to say "yes that's right" or "no, replan with this clarification." If you genuinely cannot
+     summarize the goal, the issue is too thin to plan — add a `Question` asking the user to clarify
+     intent rather than producing an empty `goal_summary`.
+   - **Executive summary** (`executive_summary`, REQUIRED — non-empty): 3-4 plain-language sentences
+     a non-coder PM would understand. What does the user get when this ships? Outcome-focused.
+     **No file paths, no symbol names, no code references.** If you're tempted to mention
+     `Foo.bar()`, write it differently.
+   - **Plan markdown** (`plan_markdown`, REQUIRED): the technical body. Step-by-step, file
+     rationale, code-level decisions. Lives under the collapsed `The Code` section in the PlanModal,
+     so the audience for this content is a reviewer who's already decided to dig in — not a top-line
+     summary.
    - Files to add/modify/delete
    - Detected dependencies (other open issue numbers)
    - Suggested labels (from step 4; empty array if nothing matches)
    - Open questions to ask the user (structured per §6.4 Question schema)
+
+   The `goal_summary` and `executive_summary` fields are tagged `omitempty` in the Go struct so old
+   on-disk plans deserialize cleanly, but the skill-level requirement is that NEW plans MUST have
+   both populated. This is the dual interpretation: schema-level optional, skill-level required.
 
    **Question authoring rules (NON-NEGOTIABLE — the UI rendering depends on these):**
    - The `prompt` field is the *question only* — one or two sentences. Do NOT inline the answer choices into the prompt text ("A) … B) … C) …"). The prompt should read cleanly without the options.

--- a/internal/types/plan_test.go
+++ b/internal/types/plan_test.go
@@ -1,0 +1,83 @@
+package types
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPlanGoalAndExecutiveSummaryOmitempty(t *testing.T) {
+	p := Plan{
+		IssueNumber:  55,
+		WorkspaceID:  "prismconductor",
+		Revision:     1,
+		PlanMarkdown: "## hi",
+	}
+	out, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(out)
+	if strings.Contains(s, "goal_summary") {
+		t.Errorf("expected omitempty to drop goal_summary when empty; got %s", s)
+	}
+	if strings.Contains(s, "executive_summary") {
+		t.Errorf("expected omitempty to drop executive_summary when empty; got %s", s)
+	}
+}
+
+func TestPlanGoalAndExecutiveSummaryRoundTrip(t *testing.T) {
+	p := Plan{
+		IssueNumber:      55,
+		WorkspaceID:      "prismconductor",
+		Revision:         2,
+		GoalSummary:      "Restate the issue intent.",
+		ExecutiveSummary: "Outcome the user gets when this ships.",
+		PlanMarkdown:     "## steps\n1. do thing",
+	}
+	out, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got Plan
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.GoalSummary != p.GoalSummary {
+		t.Errorf("goal_summary round-trip: got %q want %q", got.GoalSummary, p.GoalSummary)
+	}
+	if got.ExecutiveSummary != p.ExecutiveSummary {
+		t.Errorf("executive_summary round-trip: got %q want %q", got.ExecutiveSummary, p.ExecutiveSummary)
+	}
+}
+
+// Old plans on disk (written before #55) lack the new fields entirely. The
+// schema-level "omitempty + non-pointer string" contract is what lets them
+// keep deserializing cleanly — this test pins that behavior.
+func TestPlanLegacyJSONDeserializesCleanly(t *testing.T) {
+	legacy := []byte(`{
+		"issue_number": 1,
+		"workspace_id": "demo",
+		"revision": 1,
+		"plan_markdown": "## old plan",
+		"files_to_modify": [],
+		"dependencies_detected": [],
+		"questions": [],
+		"estimated_complexity": "small",
+		"ready_to_execute": true,
+		"generated_at": "2025-01-01T00:00:00Z"
+	}`)
+	var p Plan
+	if err := json.Unmarshal(legacy, &p); err != nil {
+		t.Fatalf("legacy unmarshal: %v", err)
+	}
+	if p.GoalSummary != "" {
+		t.Errorf("expected empty GoalSummary on legacy plan; got %q", p.GoalSummary)
+	}
+	if p.ExecutiveSummary != "" {
+		t.Errorf("expected empty ExecutiveSummary on legacy plan; got %q", p.ExecutiveSummary)
+	}
+	if p.PlanMarkdown != "## old plan" {
+		t.Errorf("plan_markdown not preserved: %q", p.PlanMarkdown)
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -184,6 +184,8 @@ type Plan struct {
 	IssueNumber          int          `json:"issue_number"`
 	WorkspaceID          string       `json:"workspace_id"`
 	Revision             int          `json:"revision"`
+	GoalSummary          string       `json:"goal_summary,omitempty"`
+	ExecutiveSummary     string       `json:"executive_summary,omitempty"`
 	PlanMarkdown         string       `json:"plan_markdown"`
 	FilesToModify        []FileIntent `json:"files_to_modify"`
 	DependenciesDetected []int        `json:"dependencies_detected"`


### PR DESCRIPTION
## Summary

Reshapes the PlanModal so reviewers see **outcomes** first — `The Goal` (planner restatement of intent) at the top, `Executive Summary` (plain-language outcome) at the bottom — with implementation detail (files, plan markdown, dependencies) tucked under a collapsed `The Code` header. Adds two `omitempty` fields (`goal_summary`, `executive_summary`) to `types.Plan` plus `CollapsibleSection` primitive in PlanModal. Old plans on disk render gracefully via fallbacks.

## Files modified

- `internal/types/types.go` — `GoalSummary` + `ExecutiveSummary` fields with `omitempty`
- `internal/types/plan_test.go` — round-trip + legacy-deserialization tests (new file)
- `PRISMCONDUCTOR_PLAN.md` — §6.4 struct + §9.1 example JSON + dual-interpretation prose
- `internal/skills/bundle/skills/conductor-plan.md` — step 5 now requires both summary fields
- `frontend/src/components/PlanModal.tsx` — `CollapsibleSection` helper + reordered Goal/Code/Executive layout
- `frontend/wailsjs/go/models.ts` — regenerated by `wails generate module`

## Verification

- **Lint:** `go vet ./...` → pass (no output). `npx tsc --noEmit` (frontend) → pass.
- **Build:** `go build ./...` → pass. (Full `wails build` not invoked — would require frontend production bundle; equivalent gates covered.)
- **Tests:** `go test ./...` → all packages pass, including new `internal/types/plan_test.go` (3 new tests: omitempty, round-trip, legacy deserialization).

Frontend has no Vitest/Jest setup — the new `CollapsibleSection` component is exercised manually only. Noted per execute skill rules.

## Behavior notes

- `The Code` resets to collapsed every time the modal opens (per-modal-instance `useState`, no zustand).
- Legacy plans (no `goal_summary`) render `plan_markdown` under `The Goal` with a slate-500 footnote, and suppress the duplicate render inside `The Code` so the same body doesn't appear twice.
- Detected dependencies and Files-to-modify both moved inside `The Code`; their standalone `<Section>` wrappers are gone.

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-55

Closes #55
