### PR TITLE
fix(llm): path-aware OpenAI-compat URL composition (#65)

### DIFF
--- a/internal/llm/litellm.go
+++ b/internal/llm/litellm.go
@@ -59,7 +59,7 @@ func (l litellmProvider) ListModels(ctx context.Context, p types.Pool) ([]string
 		}
 	}
 
-	body, err := httpGetWithBearer(ctx, l.client, endpoint+"/v1/models", key)
+	body, err := httpGetWithBearer(ctx, l.client, modelsURL(endpoint), key)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/llm/lmstudio.go
+++ b/internal/llm/lmstudio.go
@@ -61,7 +61,7 @@ func (l lmstudioProvider) ListModels(ctx context.Context, p types.Pool) ([]strin
 		}
 	}
 
-	body, err := httpGetWithBearer(ctx, l.client, endpoint+"/v1/models", key)
+	body, err := httpGetWithBearer(ctx, l.client, modelsURL(endpoint), key)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -11,7 +11,11 @@ import (
 	"prismconductor/internal/types"
 )
 
-const defaultOpenAIEndpoint = "https://api.openai.com/v1"
+// defaultOpenAIEndpoint is the bare host. The `/v1` segment is added by
+// `chatCompletionsURL` (orchestrator_chat.go) and by ListModels below; keeping
+// it out of the constant means a user pasting `https://api.openai.com/v1` into
+// the pool editor doesn't double-prefix into `…/v1/v1/chat/completions`.
+const defaultOpenAIEndpoint = "https://api.openai.com"
 
 type openaiProvider struct {
 	client *http.Client
@@ -36,7 +40,7 @@ func (o openaiProvider) ListModels(ctx context.Context, p types.Pool) ([]string,
 	if key == "" {
 		key = os.Getenv("OPENAI_API_KEY")
 	}
-	body, err := httpGetWithBearer(ctx, o.client, endpoint+"/models", key)
+	body, err := httpGetWithBearer(ctx, o.client, modelsURL(endpoint), key)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/llm/orchestrator_chat.go
+++ b/internal/llm/orchestrator_chat.go
@@ -7,8 +7,39 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 )
+
+// versionedPathRE matches a baseURL whose path already ends with a
+// version-like segment (`/v1`, `/v2beta`, `/v1beta/openai`, etc.). When it
+// matches we append only `/chat/completions`; otherwise we prepend `/v1/`.
+//
+// Concretely: Gemini's OpenAI-compat base is
+// `https://generativelanguage.googleapis.com/v1beta/openai`, OpenAI's default
+// is `https://api.openai.com/v1`, and LM Studio / Ollama / LiteLLM defaults
+// are bare `http://host:port`. All three shapes need to resolve to a single
+// `…/chat/completions` URL.
+var versionedPathRE = regexp.MustCompile(`/v\d+[A-Za-z0-9]*(/[A-Za-z0-9]+)*/?$`)
+
+// chatCompletionsURL composes the final POST URL for an OpenAI-compatible
+// chat-completions call, idempotent on the trailing version segment.
+func chatCompletionsURL(baseURL string) string {
+	return openAICompatPath(baseURL, "chat/completions")
+}
+
+// modelsURL composes the GET URL for an OpenAI-compatible /models listing.
+func modelsURL(baseURL string) string {
+	return openAICompatPath(baseURL, "models")
+}
+
+func openAICompatPath(baseURL, leaf string) string {
+	trimmed := strings.TrimRight(baseURL, "/")
+	if versionedPathRE.MatchString(trimmed) {
+		return trimmed + "/" + leaf
+	}
+	return trimmed + "/v1/" + leaf
+}
 
 // openAICompatChat sends a system+user prompt to an OpenAI-compatible
 // /v1/chat/completions endpoint and returns the assistant's content. Shared by
@@ -18,7 +49,7 @@ func openAICompatChat(ctx context.Context, client *http.Client, baseURL, apiKey,
 	if model == "" {
 		return "", fmt.Errorf("orchestrator chat: model required")
 	}
-	url := strings.TrimRight(baseURL, "/") + "/v1/chat/completions"
+	url := chatCompletionsURL(baseURL)
 	reqBody := map[string]any{
 		"model":       model,
 		"temperature": 0.0,
@@ -87,7 +118,7 @@ func openAIToolChat(ctx context.Context, client *http.Client, baseURL, apiKey, m
 	if model == "" {
 		return ChatResponse{}, fmt.Errorf("tool chat: model required")
 	}
-	url := strings.TrimRight(baseURL, "/") + "/v1/chat/completions"
+	url := chatCompletionsURL(baseURL)
 
 	msgs := make([]map[string]any, 0, len(req.History)+1)
 	if req.System != "" {

--- a/internal/llm/url_test.go
+++ b/internal/llm/url_test.go
@@ -1,0 +1,45 @@
+package llm
+
+import "testing"
+
+func TestChatCompletionsURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare host", "http://localhost:1234", "http://localhost:1234/v1/chat/completions"},
+		{"trailing slash", "http://localhost:1234/", "http://localhost:1234/v1/chat/completions"},
+		{"openai with v1", "https://api.openai.com/v1", "https://api.openai.com/v1/chat/completions"},
+		{"openai bare", "https://api.openai.com", "https://api.openai.com/v1/chat/completions"},
+		{"gemini openai compat", "https://generativelanguage.googleapis.com/v1beta/openai", "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"},
+		{"gemini trailing slash", "https://generativelanguage.googleapis.com/v1beta/openai/", "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"},
+		{"v2 only", "https://example.com/v2", "https://example.com/v2/chat/completions"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := chatCompletionsURL(c.in); got != c.want {
+				t.Errorf("chatCompletionsURL(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestModelsURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare", "http://localhost:1234", "http://localhost:1234/v1/models"},
+		{"openai with v1", "https://api.openai.com/v1", "https://api.openai.com/v1/models"},
+		{"gemini openai compat", "https://generativelanguage.googleapis.com/v1beta/openai", "https://generativelanguage.googleapis.com/v1beta/openai/models"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := modelsURL(c.in); got != c.want {
+				t.Errorf("modelsURL(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
/v1/chat/completions was hardcoded onto every OpenAI-compat baseURL, which double-prefixed https://api.openai.com/v1 to /v1/v1/chat/completions and broke Gemini's /v1beta/openai path. Add chatCompletionsURL and modelsURL helpers that detect a trailing version segment and append only /chat/completions (or /models) when present.

OpenAI default endpoint dropped its /v1 so the helper handles it uniformly. ListModels for OpenAI/LM Studio/LiteLLM now also route through the helper. Unit tests cover OpenAI default, OpenAI with explicit /v1, LM Studio bare host, and Gemini /v1beta/openai.