### PR TITLE
fix(plan): non-Claude planners actually plan (#67)

### DIFF
--- a/app.go
+++ b/app.go
@@ -1402,12 +1402,14 @@ func (a *App) handlePlanReady(sess types.Session, relPath string) {
 	plan, err := planio.ReadPlan(abs)
 	if err != nil {
 		log.Printf("plan ingest failed: %v\n", err)
+		a.markSessionBlocked(sess, fmt.Sprintf("plan ingest failed: %v", err))
 		return
 	}
 	plan.WorkspaceID = sess.WorkspaceID
 	plan.IssueNumber = sess.IssueNumber
 	if err := a.store.SavePlan(*plan); err != nil {
 		log.Printf("plan save failed: %v\n", err)
+		a.markSessionBlocked(sess, fmt.Sprintf("plan save failed: %v", err))
 		return
 	}
 	// Issue #24: auto-apply planner-suggested labels before announcing plan_ready
@@ -1460,11 +1462,13 @@ func (a *App) handlePROpened(sess types.Session, prURL string) {
 	prURL = strings.TrimSpace(prURL)
 	if prURL == "" {
 		log.Printf("PR_OPENED: empty URL on session %s, skipping", sess.ID)
+		a.markSessionBlocked(sess, "PR_OPENED sentinel had empty URL")
 		return
 	}
 	n, ok := pullNumberFromURL(prURL)
 	if !ok {
 		log.Printf("PR_OPENED: could not parse PR number from %q (session %s), skipping", prURL, sess.ID)
+		a.markSessionBlocked(sess, fmt.Sprintf("PR_OPENED URL %q had no /pull/<n> segment", prURL))
 		return
 	}
 	if _, ok := a.wsReg.Get(sess.WorkspaceID); !ok {
@@ -1473,6 +1477,7 @@ func (a *App) handlePROpened(sess types.Session, prURL string) {
 	}
 	if err := a.store.MarkPROpened(sess.WorkspaceID, sess.IssueNumber, n, prURL); err != nil {
 		log.Printf("PR_OPENED: MarkPROpened failed for #%d: %v", sess.IssueNumber, err)
+		a.markSessionBlocked(sess, fmt.Sprintf("PR_OPENED store update failed: %v", err))
 		return
 	}
 	a.bus.Publish(eventbus.EvtPROpened, map[string]any{
@@ -2060,6 +2065,33 @@ func (a *App) GitHubLoginPoll() (*githubauth.User, error) {
 
 // GitHubLogout clears the cached token.
 func (a *App) GitHubLogout() error { return githubauth.ClearToken(a.cfgDir) }
+
+// markSessionBlocked retroactively flips a session row to BLOCKED with the
+// given reason and re-publishes the state change so the card surfaces the
+// failure (issue #67). Used by post-completion handlers (plan ingest, plan
+// save, …) where the session is already `completed` from the worker's POV
+// but the conductor's downstream processing failed silently. Without this,
+// the card looks "completed" while no plan exists and the user has no
+// indication anything went wrong.
+func (a *App) markSessionBlocked(sess types.Session, reason string) {
+	if a.store == nil {
+		return
+	}
+	if len(reason) > 500 {
+		reason = reason[:500]
+	}
+	prev := sess.State
+	sess.State = types.StateBlocked
+	sess.BlockedReason = reason
+	if err := a.store.SaveSession(&sess, sess.Transcript); err != nil {
+		log.Printf("markSessionBlocked: SaveSession %s: %v", sess.ID, err)
+		return
+	}
+	if err := a.store.UpdateSessionState(sess.ID, types.StateBlocked); err != nil {
+		log.Printf("markSessionBlocked: UpdateSessionState %s: %v", sess.ID, err)
+	}
+	a.handleSessionStateChange(sess, prev)
+}
 
 // GitHubListRepos returns repos the authenticated user can access. Used by the
 // "Add Workspace" picker so the user doesn't have to type a path.

--- a/internal/llm/openai_models.go
+++ b/internal/llm/openai_models.go
@@ -24,8 +24,15 @@ func decodeOpenAIModels(r io.Reader) ([]string, error) {
 	}
 	ids := make([]string, 0, len(out.Data))
 	for _, m := range out.Data {
-		if m.ID != "" {
-			ids = append(ids, m.ID)
+		// Gemini's OpenAI-compat /models endpoint returns IDs in its native
+		// form `models/<id>` (e.g. `models/gemini-2.0-flash`). The chat
+		// completions surface, however, expects the bare ID. Strip the prefix
+		// here so the dropdown surfaces a model the user can immediately use.
+		// LM Studio / OpenAI / LiteLLM never emit this prefix, so the trim is a
+		// no-op for them.
+		id := strings.TrimPrefix(m.ID, "models/")
+		if id != "" {
+			ids = append(ids, id)
 		}
 	}
 	sort.Strings(ids)

--- a/internal/llm/provider_test.go
+++ b/internal/llm/provider_test.go
@@ -144,6 +144,27 @@ func TestDecodeOpenAIModelsParsesEnvelope(t *testing.T) {
 	}
 }
 
+// TestDecodeOpenAIModelsStripsGeminiPrefix pins the Gemini OpenAI-compat
+// dropdown fix: /v1beta/openai/models returns IDs like `models/gemini-2.0-flash`
+// but the chat-completions surface expects the bare ID. The decoder strips the
+// `models/` prefix so the UI surfaces a model name the user can pick directly.
+func TestDecodeOpenAIModelsStripsGeminiPrefix(t *testing.T) {
+	body := `{"data":[{"id":"models/gemini-2.0-flash"},{"id":"models/gemini-2.5-flash"},{"id":"gpt-4o"}]}`
+	got, err := decodeOpenAIModels(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("decodeOpenAIModels error: %v", err)
+	}
+	want := []string{"gemini-2.0-flash", "gemini-2.5-flash", "gpt-4o"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %s, want %s", i, got[i], want[i])
+		}
+	}
+}
+
 func TestClaudeListModelsReturnsCanonicalSet(t *testing.T) {
 	got, err := NewClaudeProvider().ListModels(context.Background(), types.Pool{})
 	if err != nil {

--- a/internal/planio/planio.go
+++ b/internal/planio/planio.go
@@ -32,6 +32,15 @@ func AnswerPath(repoPath string, issueNumber, revision int) string {
 }
 
 // ReadPlan reads + validates a plan JSON file against the §9.1 contract.
+//
+// Two leniency arms exist for non-Claude planners (issue #67):
+//
+//  1. `issue` is accepted as an alias for `issue_number`, `rev` for `revision`.
+//     gpt-5-mini and similar abbreviate these consistently; rather than fight
+//     each model's tendencies via prompt-tuning, the validator normalizes.
+//  2. `workspace_id` is no longer required at the worker boundary. The worker
+//     has no way to know the conductor's internal workspace id; the conductor
+//     attaches it post-read (see app.handlePlanReady).
 func ReadPlan(path string) (*types.Plan, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
@@ -41,8 +50,23 @@ func ReadPlan(path string) (*types.Plan, error) {
 	if err := json.Unmarshal(b, &p); err != nil {
 		return nil, fmt.Errorf("invalid plan JSON at %s: %w", path, err)
 	}
-	if p.IssueNumber == 0 || p.WorkspaceID == "" || p.Revision == 0 {
-		return nil, errors.New("plan JSON missing required fields (issue_number, workspace_id, revision)")
+	if p.IssueNumber == 0 || p.Revision == 0 {
+		// Try the abbreviated aliases used by some hosted models.
+		var aliased struct {
+			Issue int `json:"issue"`
+			Rev   int `json:"rev"`
+		}
+		if err := json.Unmarshal(b, &aliased); err == nil {
+			if p.IssueNumber == 0 {
+				p.IssueNumber = aliased.Issue
+			}
+			if p.Revision == 0 {
+				p.Revision = aliased.Rev
+			}
+		}
+	}
+	if p.IssueNumber == 0 || p.Revision == 0 {
+		return nil, errors.New("plan JSON missing required fields (issue_number/issue, revision/rev)")
 	}
 	if p.GeneratedAt.IsZero() {
 		p.GeneratedAt = time.Now()

--- a/internal/planio/planio_test.go
+++ b/internal/planio/planio_test.go
@@ -1,0 +1,110 @@
+package planio
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTemp(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "plan.json")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write tmp plan: %v", err)
+	}
+	return p
+}
+
+// TestReadPlanCanonicalShape pins the long-standing happy path: a Claude-shaped
+// plan with `issue_number` / `revision` reads cleanly without `workspace_id`
+// being present (it is attached post-read by the conductor — issue #67).
+func TestReadPlanCanonicalShape(t *testing.T) {
+	p := writeTemp(t, `{
+		"issue_number": 42,
+		"revision": 1,
+		"plan_markdown": "do the thing",
+		"files_to_modify": [],
+		"dependencies_detected": [],
+		"questions": [],
+		"estimated_complexity": "S",
+		"ready_to_execute": false
+	}`)
+	plan, err := ReadPlan(p)
+	if err != nil {
+		t.Fatalf("ReadPlan canonical: %v", err)
+	}
+	if plan.IssueNumber != 42 || plan.Revision != 1 {
+		t.Errorf("got issue=%d rev=%d, want 42/1", plan.IssueNumber, plan.Revision)
+	}
+}
+
+// TestReadPlanAcceptsAbbreviatedAliases pins the leniency added in #67:
+// non-Claude planners (gpt-5-mini observed in the wild) emit `issue` / `rev`
+// instead of the canonical names. The validator normalizes rather than
+// rejecting silently.
+func TestReadPlanAcceptsAbbreviatedAliases(t *testing.T) {
+	p := writeTemp(t, `{
+		"issue": 53,
+		"rev": 1,
+		"plan_markdown": "x",
+		"files_to_modify": [],
+		"dependencies_detected": [],
+		"questions": [],
+		"estimated_complexity": "S",
+		"ready_to_execute": false
+	}`)
+	plan, err := ReadPlan(p)
+	if err != nil {
+		t.Fatalf("ReadPlan with aliases: %v", err)
+	}
+	if plan.IssueNumber != 53 {
+		t.Errorf("issue alias not applied, got %d", plan.IssueNumber)
+	}
+	if plan.Revision != 1 {
+		t.Errorf("rev alias not applied, got %d", plan.Revision)
+	}
+}
+
+// TestReadPlanCanonicalWinsOverAlias pins precedence: when both forms are
+// present the canonical name takes priority. (Defensive — should never happen
+// in practice, but locks in the rule.)
+func TestReadPlanCanonicalWinsOverAlias(t *testing.T) {
+	p := writeTemp(t, `{
+		"issue_number": 100, "issue": 200,
+		"revision": 5, "rev": 9,
+		"plan_markdown": "x",
+		"files_to_modify": [], "questions": []
+	}`)
+	plan, err := ReadPlan(p)
+	if err != nil {
+		t.Fatalf("ReadPlan precedence: %v", err)
+	}
+	if plan.IssueNumber != 100 || plan.Revision != 5 {
+		t.Errorf("got issue=%d rev=%d, want 100/5 (canonical wins)", plan.IssueNumber, plan.Revision)
+	}
+}
+
+// TestReadPlanRejectsTrulyMissingFields pins that the leniency does not turn
+// the validator into a doormat: a plan with neither canonical nor alias still
+// errors so the conductor can flip the card to BLOCKED with a real message.
+func TestReadPlanRejectsTrulyMissingFields(t *testing.T) {
+	p := writeTemp(t, `{
+		"plan_markdown": "x",
+		"files_to_modify": [],
+		"questions": []
+	}`)
+	if _, err := ReadPlan(p); err == nil {
+		t.Fatal("expected error for plan with no issue id, got nil")
+	}
+}
+
+// TestReadPlanRejectsInvalidJSON locks the JSON-decode error path: a malformed
+// body returns a wrapped error so the conductor's BLOCKED message includes the
+// actual decode failure.
+func TestReadPlanRejectsInvalidJSON(t *testing.T) {
+	p := writeTemp(t, `{not json}`)
+	if _, err := ReadPlan(p); err == nil {
+		t.Fatal("expected JSON decode error, got nil")
+	}
+}

--- a/internal/skills/bundle/skills/conductor-plan.md
+++ b/internal/skills/bundle/skills/conductor-plan.md
@@ -82,8 +82,43 @@ Bundled by PrismConductor. Used in Bundled and Hybrid skill modes (PRISMCONDUCTO
    **One recommendation per question — always.** If you find yourself wanting to recommend more than one answer for a single question, the question's scope is too large. Split it into multiple `yes_no` questions (or smaller `single_choice` questions), each with exactly one recommendation. This applies to `multi_choice` in particular: if you'd recommend two or more options, replace the `multi_choice` question with one `yes_no` per option.
 
    Refusing to recommend ("I'm not sure, you decide") is not allowed. If you genuinely cannot pick, the question should be split into smaller yes_no questions or removed.
-6. Write the plan to `.prismconductor/plans/<issue>-rev1.json` matching §9.1 exactly. Include the
-   suggestions as the `suggested_labels` array (omit the field entirely if empty).
+6. Write the plan to `.prismconductor/plans/<issue>-rev1.json` using **exactly** these top-level keys (verbatim — `issue_number`, `revision`, etc., not `issue` / `rev`):
+
+   ```json
+   {
+     "issue_number": 53,
+     "revision": 1,
+     "goal_summary": "...",
+     "executive_summary": "...",
+     "plan_markdown": "...",
+     "files_to_modify": [
+       { "path": "frontend/src/components/Card.tsx", "intent": "modify" }
+     ],
+     "dependencies_detected": [],
+     "suggested_labels": ["enhancement"],
+     "questions": [
+       {
+         "id": "q1",
+         "type": "single_choice",
+         "prompt": "...",
+         "options": ["A", "B"],
+         "default": "A",
+         "required": true
+       }
+     ],
+     "estimated_complexity": "S",
+     "ready_to_execute": false
+   }
+   ```
+
+   Field name rules (strict — the conductor's validator requires the canonical names):
+   - `issue_number` (NOT `issue`).
+   - `revision` (NOT `rev`).
+   - `files_to_modify` is an array of `{path, intent}` objects, NOT `{add, modify, delete}` lists.
+   - `suggested_labels` is an array of plain label strings (`"enhancement"`), NOT label-with-action strings (`"enhancement (create)"`).
+   - Omit `suggested_labels` entirely if empty.
+   - Do NOT include `workspace_id` — the conductor attaches it on read.
+
 7. Print `Plan written to .prismconductor/plans/<issue>-rev1.json` so the conductor's PTY parser picks it up (§10.3).
 8. Stop. Do not edit code.
 

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# restart.sh — one-shot: switch to main, pull, kill, build, relaunch.
+#
+# Usage:
+#   ./scripts/restart.sh             # release build
+#   ./scripts/restart.sh --debug     # debug build (devtools enabled)
+#   ./scripts/restart.sh --no-pull   # skip git pull (offline / mid-flight)
+#
+# Exit codes:
+#   0  success — app launched
+#   1  not in a git repo / repo path missing
+#   2  git operation failed (switch, pull, dirty tree)
+#   3  wails build failed
+#   4  binary missing after build
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$REPO/build/bin/prismconductor.app/Contents/MacOS/prismconductor"
+APP="$REPO/build/bin/prismconductor.app"
+
+WAILS_FLAGS=()
+DO_PULL=1
+
+for arg in "$@"; do
+  case "$arg" in
+    --debug)    WAILS_FLAGS+=("-debug") ;;
+    --no-pull)  DO_PULL=0 ;;
+    -h|--help)
+      sed -n '2,10p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown flag: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+cd "$REPO" || { echo "repo missing: $REPO" >&2; exit 1; }
+
+# ── 1. switch to main ────────────────────────────────────────────────
+CURRENT="$(git branch --show-current 2>/dev/null || echo)"
+if [[ "$CURRENT" != "main" ]]; then
+  echo "→ switching to main (was: ${CURRENT:-detached HEAD})"
+  if ! git switch main; then
+    echo "✗ git switch main failed — resolve dirty tree first" >&2
+    exit 2
+  fi
+else
+  echo "→ already on main"
+fi
+
+# ── 2. pull latest ──────────────────────────────────────────────────
+if [[ "$DO_PULL" -eq 1 ]]; then
+  echo "→ pulling latest"
+  git pull --ff-only origin main || {
+    echo "✗ pull failed (non-fast-forward? local commits ahead?)" >&2
+    exit 2
+  }
+else
+  echo "→ skipping pull (--no-pull)"
+fi
+
+# ── 3. kill existing processes ──────────────────────────────────────
+echo "→ killing any running prismconductor processes"
+pkill -f "build/bin/prismconductor" 2>/dev/null || true
+sleep 1
+
+# ── 4. build ────────────────────────────────────────────────────────
+echo "→ wails build${WAILS_FLAGS[*]:+ ${WAILS_FLAGS[*]}}"
+if ! wails build "${WAILS_FLAGS[@]}"; then
+  echo "✗ wails build failed" >&2
+  exit 3
+fi
+
+if [[ ! -x "$BIN" ]]; then
+  echo "✗ expected binary not found: $BIN" >&2
+  exit 4
+fi
+
+# ── 5. relaunch ─────────────────────────────────────────────────────
+echo "→ launching $APP"
+open "$APP"
+
+# Show the resulting PID for sanity.
+sleep 1
+PID="$(pgrep -f "build/bin/prismconductor.app" | head -1 || true)"
+if [[ -n "$PID" ]]; then
+  echo "✓ launched (PID $PID)"
+else
+  echo "⚠ open returned but no process visible — check Console"
+fi


### PR DESCRIPTION
Three separate failures conspired to make non-Claude plan runs look like they died silently. Plan ran fine, file landed on disk, session state flipped to "completed" — but the card never showed a plan and there was no error.

Root causes + fixes:

1. Plan validator required `workspace_id` before the conductor had any chance to attach it. Worker has no way to know the conductor's workspace id; only Claude happened to invent a string that passed the not-empty check. Drop the requirement and document the contract.

2. Validator rejected the abbreviated key names some hosted models prefer (`issue` / `rev` instead of `issue_number` / `revision`). Observed in the wild from gpt-5-mini via OpenRouter. Accept both forms; canonical wins on conflict.

3. Ingest failures from `handlePlanReady` went to `log.Printf` and were invisible on the card. Add `markSessionBlocked` and use it from the plan ingest + plan save + PR_OPENED handlers so any post-completion failure surfaces as a red BLOCKED card with the actual reason text.

Also tighten the conductor-plan skill markdown with a literal JSON template (key names, file shape, label string format) so weaker models have less room to improvise. And strip the `models/` prefix from ListModels results — Gemini's OpenAI-compat /models endpoint returns IDs in its native form, but its chat completions surface expects the bare ID. Fixes the dropdown surfacing un-usable model names.

Tests cover canonical / alias / precedence / missing-fields / bad-JSON in planio, and Gemini-prefix stripping in the model decoder.

Closes #67.