### PR TITLE
feat(harness): enforce §9.1 plan contract at the Write boundary (#71)

### DIFF
--- a/internal/harness/tools.go
+++ b/internal/harness/tools.go
@@ -16,7 +16,13 @@ import (
 	"time"
 
 	"prismconductor/internal/llm"
+	"prismconductor/internal/planio"
 )
+
+// planFilePathRE matches a path under `.prismconductor/plans/` whose basename
+// follows the §9.1 `<num>-rev<N>.json` convention. The harness validates such
+// writes against the §9.1 contract before they hit disk (issue #71).
+var planFilePathRE = regexp.MustCompile(`(^|/)\.prismconductor/plans/\d+-rev\d+\.json$`)
 
 // env holds per-session tool state. Cwd is the worker's working directory
 // (the worktree for execute-mode, the repo root for plan-mode); every path
@@ -225,6 +231,14 @@ func toolWrite(_ context.Context, e *env, raw json.RawMessage) (string, error) {
 	abs, err := resolvePath(e, args.FilePath)
 	if err != nil {
 		return "", err
+	}
+	// Issue #71: enforce the §9.1 plan contract at the harness boundary.
+	// A misshapen plan never lands on disk; the model gets the validator
+	// error back as a tool_result and retries on the next turn.
+	if planFilePathRE.MatchString(filepath.ToSlash(args.FilePath)) {
+		if err := planio.ValidatePlanJSON([]byte(args.Content)); err != nil {
+			return "", fmt.Errorf("plan rejected by validator (#71): %w. Fix the field(s) above and call Write again — do NOT proceed past this without a passing plan", err)
+		}
 	}
 	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
 		return "", err

--- a/internal/harness/tools_test.go
+++ b/internal/harness/tools_test.go
@@ -61,6 +61,84 @@ func TestToolWrite_AtomicAndScoped(t *testing.T) {
 	}
 }
 
+// TestToolWrite_RejectsBadPlan pins the harness's pre-write validation
+// boundary (issue #71): a plan written under .prismconductor/plans/ that
+// doesn't satisfy §9.1 must be rejected, no file landing on disk, and the
+// error must name the offending field so the model can self-correct on
+// the next turn.
+func TestToolWrite_RejectsBadPlan(t *testing.T) {
+	e := newEnv(t)
+	body := `{
+		"issue": 5,
+		"rev": 1,
+		"plan_markdown": "x",
+		"files_to_modify": [],
+		"dependencies_detected": [],
+		"questions": [],
+		"estimated_complexity": "S",
+		"ready_to_execute": false
+	}`
+	args, _ := json.Marshal(map[string]string{
+		"file_path": ".prismconductor/plans/5-rev1.json",
+		"content":   body,
+	})
+	_, err := toolWrite(context.Background(), e, args)
+	if err == nil {
+		t.Fatal("expected validator rejection for bad plan, got nil")
+	}
+	if !strings.Contains(err.Error(), "issue_number") {
+		t.Errorf("error should name `issue_number` so the model can fix: %v", err)
+	}
+	// File must NOT exist on disk.
+	if _, statErr := os.Stat(filepath.Join(e.Cwd, ".prismconductor/plans/5-rev1.json")); statErr == nil {
+		t.Error("rejected plan should not have been written to disk")
+	}
+}
+
+// TestToolWrite_AcceptsGoodPlan pins the happy path: a §9.1-conforming plan
+// under the plans dir writes successfully through the validator.
+func TestToolWrite_AcceptsGoodPlan(t *testing.T) {
+	e := newEnv(t)
+	body := `{
+		"issue_number": 5,
+		"revision": 1,
+		"plan_markdown": "x",
+		"files_to_modify": [],
+		"dependencies_detected": [],
+		"questions": [],
+		"estimated_complexity": "S",
+		"ready_to_execute": false
+	}`
+	args, _ := json.Marshal(map[string]string{
+		"file_path": ".prismconductor/plans/5-rev1.json",
+		"content":   body,
+	})
+	out, err := toolWrite(context.Background(), e, args)
+	if err != nil {
+		t.Fatalf("good plan rejected: %v", err)
+	}
+	if !strings.Contains(out, "5-rev1.json") {
+		t.Errorf("write result should reference the path: %q", out)
+	}
+	if _, statErr := os.Stat(filepath.Join(e.Cwd, ".prismconductor/plans/5-rev1.json")); statErr != nil {
+		t.Errorf("good plan should be on disk: %v", statErr)
+	}
+}
+
+// TestToolWrite_NonPlanPathBypassesValidator pins that the validator is
+// scoped to plan-file paths only — regular code edits under the worktree
+// are not subject to §9.1.
+func TestToolWrite_NonPlanPathBypassesValidator(t *testing.T) {
+	e := newEnv(t)
+	args, _ := json.Marshal(map[string]string{
+		"file_path": "src/main.go",
+		"content":   `package main // not a plan file`,
+	})
+	if _, err := toolWrite(context.Background(), e, args); err != nil {
+		t.Fatalf("non-plan write should bypass validator: %v", err)
+	}
+}
+
 func TestToolEdit_NonUniqueOldStringRejected(t *testing.T) {
 	e := newEnv(t)
 	if err := os.WriteFile(filepath.Join(e.Cwd, "f.txt"), []byte("foo bar foo"), 0o644); err != nil {

--- a/internal/planio/planio.go
+++ b/internal/planio/planio.go
@@ -31,42 +31,27 @@ func AnswerPath(repoPath string, issueNumber, revision int) string {
 	return filepath.Join(repoPath, subdirAnswers, fmt.Sprintf("%d-rev%d.json", issueNumber, revision))
 }
 
-// ReadPlan reads + validates a plan JSON file against the §9.1 contract.
+// ReadPlan reads a plan file and runs strict §9.1 validation. By the time a
+// plan reaches this codepath the harness's Write tool has already validated
+// it (issue #71); the duplication here exists for plans loaded from disk on
+// startup, replan, etc. — i.e. paths that don't pass through the harness.
 //
-// Two leniency arms exist for non-Claude planners (issue #67):
-//
-//  1. `issue` is accepted as an alias for `issue_number`, `rev` for `revision`.
-//     gpt-5-mini and similar abbreviate these consistently; rather than fight
-//     each model's tendencies via prompt-tuning, the validator normalizes.
-//  2. `workspace_id` is no longer required at the worker boundary. The worker
-//     has no way to know the conductor's internal workspace id; the conductor
-//     attaches it post-read (see app.handlePlanReady).
+// `workspace_id` is intentionally not required: the worker has no way to know
+// the conductor's internal workspace id, so the conductor attaches it post-
+// read in app.handlePlanReady. Any other field-name divergence is rejected
+// — there is no alias acceptance and no per-model fallback. The contract is
+// the contract.
 func ReadPlan(path string) (*types.Plan, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
+	if err := ValidatePlanJSON(b); err != nil {
+		return nil, fmt.Errorf("plan validation failed for %s: %w", path, err)
+	}
 	var p types.Plan
 	if err := json.Unmarshal(b, &p); err != nil {
 		return nil, fmt.Errorf("invalid plan JSON at %s: %w", path, err)
-	}
-	if p.IssueNumber == 0 || p.Revision == 0 {
-		// Try the abbreviated aliases used by some hosted models.
-		var aliased struct {
-			Issue int `json:"issue"`
-			Rev   int `json:"rev"`
-		}
-		if err := json.Unmarshal(b, &aliased); err == nil {
-			if p.IssueNumber == 0 {
-				p.IssueNumber = aliased.Issue
-			}
-			if p.Revision == 0 {
-				p.Revision = aliased.Rev
-			}
-		}
-	}
-	if p.IssueNumber == 0 || p.Revision == 0 {
-		return nil, errors.New("plan JSON missing required fields (issue_number/issue, revision/rev)")
 	}
 	if p.GeneratedAt.IsZero() {
 		p.GeneratedAt = time.Now()

--- a/internal/planio/planio_test.go
+++ b/internal/planio/planio_test.go
@@ -16,9 +16,8 @@ func writeTemp(t *testing.T, body string) string {
 	return p
 }
 
-// TestReadPlanCanonicalShape pins the long-standing happy path: a Claude-shaped
-// plan with `issue_number` / `revision` reads cleanly without `workspace_id`
-// being present (it is attached post-read by the conductor — issue #67).
+// TestReadPlanCanonicalShape pins the happy path: a §9.1-shaped plan reads
+// cleanly without `workspace_id` (the conductor attaches it post-read).
 func TestReadPlanCanonicalShape(t *testing.T) {
 	p := writeTemp(t, `{
 		"issue_number": 42,
@@ -39,11 +38,11 @@ func TestReadPlanCanonicalShape(t *testing.T) {
 	}
 }
 
-// TestReadPlanAcceptsAbbreviatedAliases pins the leniency added in #67:
-// non-Claude planners (gpt-5-mini observed in the wild) emit `issue` / `rev`
-// instead of the canonical names. The validator normalizes rather than
-// rejecting silently.
-func TestReadPlanAcceptsAbbreviatedAliases(t *testing.T) {
+// TestReadPlanRejectsAbbreviatedAliases pins the strict-contract direction
+// from #71: the previous lenient acceptance of `issue` / `rev` is gone. Every
+// model — Claude, gpt-5-mini, Gemini, qwen3 — must emit the canonical names
+// or the plan is rejected with a specific actionable error.
+func TestReadPlanRejectsAbbreviatedAliases(t *testing.T) {
 	p := writeTemp(t, `{
 		"issue": 53,
 		"rev": 1,
@@ -54,35 +53,25 @@ func TestReadPlanAcceptsAbbreviatedAliases(t *testing.T) {
 		"estimated_complexity": "S",
 		"ready_to_execute": false
 	}`)
-	plan, err := ReadPlan(p)
-	if err != nil {
-		t.Fatalf("ReadPlan with aliases: %v", err)
+	_, err := ReadPlan(p)
+	if err == nil {
+		t.Fatal("expected validation error rejecting `issue`/`rev` alias, got nil")
 	}
-	if plan.IssueNumber != 53 {
-		t.Errorf("issue alias not applied, got %d", plan.IssueNumber)
-	}
-	if plan.Revision != 1 {
-		t.Errorf("rev alias not applied, got %d", plan.Revision)
+	// The message should name the offending field so a model reading it in
+	// a tool_result knows what to fix.
+	msg := err.Error()
+	if !contains(msg, "issue_number") || !contains(msg, "issue") {
+		t.Errorf("error message %q should call out `issue` and recommend `issue_number`", msg)
 	}
 }
 
-// TestReadPlanCanonicalWinsOverAlias pins precedence: when both forms are
-// present the canonical name takes priority. (Defensive — should never happen
-// in practice, but locks in the rule.)
-func TestReadPlanCanonicalWinsOverAlias(t *testing.T) {
-	p := writeTemp(t, `{
-		"issue_number": 100, "issue": 200,
-		"revision": 5, "rev": 9,
-		"plan_markdown": "x",
-		"files_to_modify": [], "questions": []
-	}`)
-	plan, err := ReadPlan(p)
-	if err != nil {
-		t.Fatalf("ReadPlan precedence: %v", err)
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
 	}
-	if plan.IssueNumber != 100 || plan.Revision != 5 {
-		t.Errorf("got issue=%d rev=%d, want 100/5 (canonical wins)", plan.IssueNumber, plan.Revision)
-	}
+	return false
 }
 
 // TestReadPlanRejectsTrulyMissingFields pins that the leniency does not turn

--- a/internal/planio/validate.go
+++ b/internal/planio/validate.go
@@ -1,0 +1,257 @@
+package planio
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ValidatePlanJSON enforces the §9.1 plan contract on a raw JSON document
+// (issue #71). The harness's Write tool calls this *before* writing a file
+// matching `.prismconductor/plans/<num>-rev<N>.json`, so a misshapen plan
+// never lands on disk and the model gets immediate, actionable feedback.
+//
+// The validator is intentionally strict: no field-name aliases, no per-model
+// fallbacks, no "we'll figure it out later" lenience. Unknown extra fields
+// are tolerated (the schema may grow); known fields with the wrong key
+// (`issue` instead of `issue_number`) are rejected with a specific message.
+//
+// Errors are formatted to be self-explanatory to a model reading them in a
+// tool_result: every message starts with the offending field name and gives
+// the rule that was violated.
+func ValidatePlanJSON(b []byte) error {
+	// Stage 1: parse as a generic map so we can detect unknown vs aliased
+	// keys before Go's strict-types decoder rejects on a type mismatch.
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
+	var raw map[string]any
+	if err := dec.Decode(&raw); err != nil {
+		return fmt.Errorf("plan body is not a valid JSON object: %w", err)
+	}
+
+	if _, hasAlias := raw["issue"]; hasAlias {
+		if _, ok := raw["issue_number"]; !ok {
+			return fmt.Errorf("field `issue` is not the contract — use `issue_number` (an integer matching the issue you were dispatched against)")
+		}
+	}
+	if _, hasAlias := raw["rev"]; hasAlias {
+		if _, ok := raw["revision"]; !ok {
+			return fmt.Errorf("field `rev` is not the contract — use `revision` (an integer; first plan is 1)")
+		}
+	}
+
+	if err := requireInt(raw, "issue_number", 1); err != nil {
+		return err
+	}
+	if err := requireInt(raw, "revision", 1); err != nil {
+		return err
+	}
+	if err := requireString(raw, "plan_markdown"); err != nil {
+		return err
+	}
+	if err := requireString(raw, "estimated_complexity"); err != nil {
+		return err
+	}
+	if err := requireBool(raw, "ready_to_execute"); err != nil {
+		return err
+	}
+
+	if err := validateFilesToModify(raw); err != nil {
+		return err
+	}
+	if err := validateDependenciesDetected(raw); err != nil {
+		return err
+	}
+	if err := validateSuggestedLabels(raw); err != nil {
+		return err
+	}
+	if err := validateQuestions(raw); err != nil {
+		return err
+	}
+	return nil
+}
+
+// requireInt asserts that key holds a JSON number >= min.
+func requireInt(raw map[string]any, key string, min int) error {
+	v, ok := raw[key]
+	if !ok {
+		return fmt.Errorf("required field `%s` is missing", key)
+	}
+	n, ok := v.(json.Number)
+	if !ok {
+		return fmt.Errorf("`%s` must be an integer, got %T", key, v)
+	}
+	i, err := n.Int64()
+	if err != nil {
+		return fmt.Errorf("`%s` must be an integer, got %s", key, n.String())
+	}
+	if int(i) < min {
+		return fmt.Errorf("`%s` must be >= %d, got %d", key, min, i)
+	}
+	return nil
+}
+
+// requireString asserts that key holds a non-empty JSON string.
+func requireString(raw map[string]any, key string) error {
+	v, ok := raw[key]
+	if !ok {
+		return fmt.Errorf("required field `%s` is missing", key)
+	}
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("`%s` must be a string, got %T", key, v)
+	}
+	if strings.TrimSpace(s) == "" {
+		return fmt.Errorf("`%s` must be a non-empty string", key)
+	}
+	return nil
+}
+
+// requireBool asserts that key holds a JSON boolean (presence required;
+// false is acceptable). Plans must always make a yes/no decision on
+// ready-to-execute even when the answer is no.
+func requireBool(raw map[string]any, key string) error {
+	v, ok := raw[key]
+	if !ok {
+		return fmt.Errorf("required field `%s` is missing", key)
+	}
+	if _, ok := v.(bool); !ok {
+		return fmt.Errorf("`%s` must be a boolean, got %T", key, v)
+	}
+	return nil
+}
+
+// validateFilesToModify rejects the {add,modify,delete} lists shape some
+// models invent and pins the array-of-{path,intent} contract.
+func validateFilesToModify(raw map[string]any) error {
+	v, ok := raw["files_to_modify"]
+	if !ok {
+		return fmt.Errorf("required field `files_to_modify` is missing — use [] if no files change")
+	}
+	if m, isMap := v.(map[string]any); isMap {
+		_, hasAdd := m["add"]
+		_, hasMod := m["modify"]
+		_, hasDel := m["delete"]
+		if hasAdd || hasMod || hasDel {
+			return fmt.Errorf("`files_to_modify` must be an array of `{path, intent}` objects, not a `{add, modify, delete}` shape")
+		}
+		return fmt.Errorf("`files_to_modify` must be an array, got an object")
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return fmt.Errorf("`files_to_modify` must be an array, got %T", v)
+	}
+	for i, item := range arr {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			return fmt.Errorf("`files_to_modify[%d]` must be an object with `path` and `intent`, got %T", i, item)
+		}
+		path, ok := obj["path"].(string)
+		if !ok || strings.TrimSpace(path) == "" {
+			return fmt.Errorf("`files_to_modify[%d].path` is required and must be a non-empty string", i)
+		}
+		intent, ok := obj["intent"].(string)
+		if !ok || strings.TrimSpace(intent) == "" {
+			return fmt.Errorf("`files_to_modify[%d].intent` is required and must be a non-empty string (e.g. \"modify\", \"add\", \"delete\")", i)
+		}
+	}
+	return nil
+}
+
+// validateDependenciesDetected requires the field to exist (so re-planning
+// can omit-vs-empty distinguish), but accepts an empty array.
+func validateDependenciesDetected(raw map[string]any) error {
+	v, ok := raw["dependencies_detected"]
+	if !ok {
+		return fmt.Errorf("required field `dependencies_detected` is missing — use [] if no dependencies")
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return fmt.Errorf("`dependencies_detected` must be an array of issue numbers, got %T", v)
+	}
+	for i, item := range arr {
+		n, ok := item.(json.Number)
+		if !ok {
+			return fmt.Errorf("`dependencies_detected[%d]` must be an integer issue number, got %T", i, item)
+		}
+		if _, err := n.Int64(); err != nil {
+			return fmt.Errorf("`dependencies_detected[%d]` must be an integer issue number, got %s", i, n.String())
+		}
+	}
+	return nil
+}
+
+// validateSuggestedLabels is optional; if present it must be an array of plain
+// label strings (no `(create)` / `(use)` annotations the prose-leaning models
+// invent).
+func validateSuggestedLabels(raw map[string]any) error {
+	v, ok := raw["suggested_labels"]
+	if !ok {
+		return nil
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return fmt.Errorf("`suggested_labels` must be an array of label strings, got %T", v)
+	}
+	for i, item := range arr {
+		s, ok := item.(string)
+		if !ok {
+			return fmt.Errorf("`suggested_labels[%d]` must be a string, got %T", i, item)
+		}
+		if strings.Contains(s, "(") || strings.Contains(s, ")") {
+			return fmt.Errorf("`suggested_labels[%d]` (%q) must be a plain label name, not a label-with-annotation", i, s)
+		}
+		if strings.TrimSpace(s) == "" {
+			return fmt.Errorf("`suggested_labels[%d]` must be non-empty", i)
+		}
+	}
+	return nil
+}
+
+// validateQuestions enforces the §6.4 Question shape on every entry: id +
+// type + prompt + default required, type ∈ enum, options required when type
+// is single_choice or multi_choice.
+func validateQuestions(raw map[string]any) error {
+	v, ok := raw["questions"]
+	if !ok {
+		return fmt.Errorf("required field `questions` is missing — use [] if no questions")
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return fmt.Errorf("`questions` must be an array, got %T", v)
+	}
+	validTypes := map[string]bool{
+		"single_choice": true,
+		"multi_choice":  true,
+		"free_text":     true,
+		"yes_no":        true,
+	}
+	for i, item := range arr {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			return fmt.Errorf("`questions[%d]` must be an object, got %T", i, item)
+		}
+		id, ok := obj["id"].(string)
+		if !ok || strings.TrimSpace(id) == "" {
+			return fmt.Errorf("`questions[%d].id` is required and must be a non-empty string", i)
+		}
+		qType, ok := obj["type"].(string)
+		if !ok || !validTypes[qType] {
+			return fmt.Errorf("`questions[%d].type` (id=%q) must be one of single_choice / multi_choice / free_text / yes_no", i, id)
+		}
+		if prompt, ok := obj["prompt"].(string); !ok || strings.TrimSpace(prompt) == "" {
+			return fmt.Errorf("`questions[%d].prompt` (id=%q) is required and must be a non-empty string", i, id)
+		}
+		if _, present := obj["default"]; !present {
+			return fmt.Errorf("`questions[%d].default` (id=%q) is required — every question must carry one recommended answer", i, id)
+		}
+		if qType == "single_choice" || qType == "multi_choice" {
+			opts, ok := obj["options"].([]any)
+			if !ok || len(opts) == 0 {
+				return fmt.Errorf("`questions[%d].options` (id=%q, type=%s) must be a non-empty array", i, id, qType)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/planio/validate_test.go
+++ b/internal/planio/validate_test.go
@@ -1,0 +1,177 @@
+package planio
+
+import (
+	"strings"
+	"testing"
+)
+
+func mustValid(t *testing.T, body string) {
+	t.Helper()
+	if err := ValidatePlanJSON([]byte(body)); err != nil {
+		t.Fatalf("expected valid plan, got error: %v", err)
+	}
+}
+
+func mustReject(t *testing.T, body, expectSubstr string) {
+	t.Helper()
+	err := ValidatePlanJSON([]byte(body))
+	if err == nil {
+		t.Fatalf("expected rejection containing %q, got nil", expectSubstr)
+	}
+	if !strings.Contains(err.Error(), expectSubstr) {
+		t.Fatalf("expected error to contain %q, got: %v", expectSubstr, err)
+	}
+}
+
+const minimalValidPlan = `{
+	"issue_number": 7,
+	"revision": 1,
+	"plan_markdown": "do the thing",
+	"files_to_modify": [],
+	"dependencies_detected": [],
+	"questions": [],
+	"estimated_complexity": "S",
+	"ready_to_execute": false
+}`
+
+// Plan with every field populated correctly should validate cleanly.
+func TestValidatePlanJSON_HappyPath(t *testing.T) {
+	mustValid(t, `{
+		"issue_number": 42,
+		"revision": 2,
+		"goal_summary": "...",
+		"executive_summary": "...",
+		"plan_markdown": "## Plan\n...",
+		"files_to_modify": [
+			{ "path": "frontend/src/Card.tsx", "intent": "modify" },
+			{ "path": "internal/llm/foo.go", "intent": "add" }
+		],
+		"dependencies_detected": [13, 27],
+		"suggested_labels": ["enhancement", "frontend"],
+		"questions": [
+			{
+				"id": "q1",
+				"type": "single_choice",
+				"prompt": "Which approach?",
+				"options": ["A", "B"],
+				"default": "A",
+				"required": true
+			},
+			{
+				"id": "q2",
+				"type": "yes_no",
+				"prompt": "Bundle?",
+				"default": "no",
+				"required": false
+			},
+			{
+				"id": "q3",
+				"type": "free_text",
+				"prompt": "Notes?",
+				"default": "no notes",
+				"required": false
+			}
+		],
+		"estimated_complexity": "M",
+		"ready_to_execute": false
+	}`)
+}
+
+func TestValidatePlanJSON_Minimal(t *testing.T) {
+	mustValid(t, minimalValidPlan)
+}
+
+// `issue` instead of `issue_number` is the most common gpt-5-mini failure
+// mode. The validator must call out the rule explicitly so the model can fix
+// it on the next turn.
+func TestValidatePlanJSON_RejectsIssueAlias(t *testing.T) {
+	mustReject(t, `{
+		"issue": 7, "revision": 1,
+		"plan_markdown": "x", "files_to_modify": [], "dependencies_detected": [],
+		"questions": [], "estimated_complexity": "S", "ready_to_execute": false
+	}`, "issue_number")
+}
+
+func TestValidatePlanJSON_RejectsRevAlias(t *testing.T) {
+	mustReject(t, `{
+		"issue_number": 7, "rev": 1,
+		"plan_markdown": "x", "files_to_modify": [], "dependencies_detected": [],
+		"questions": [], "estimated_complexity": "S", "ready_to_execute": false
+	}`, "revision")
+}
+
+// Some models emit files_to_modify as a {add, modify, delete} object instead
+// of an array. Specifically reject so the error message points at the shape.
+func TestValidatePlanJSON_RejectsFilesToModifyAsObject(t *testing.T) {
+	mustReject(t, `{
+		"issue_number": 7, "revision": 1, "plan_markdown": "x",
+		"files_to_modify": {"add": ["foo"], "modify": [], "delete": []},
+		"dependencies_detected": [], "questions": [],
+		"estimated_complexity": "S", "ready_to_execute": false
+	}`, "{add, modify, delete}")
+}
+
+func TestValidatePlanJSON_RejectsFileIntentMissingPath(t *testing.T) {
+	mustReject(t, `{
+		"issue_number": 7, "revision": 1, "plan_markdown": "x",
+		"files_to_modify": [{"intent": "modify"}],
+		"dependencies_detected": [], "questions": [],
+		"estimated_complexity": "S", "ready_to_execute": false
+	}`, "files_to_modify[0].path")
+}
+
+func TestValidatePlanJSON_RejectsLabelWithAnnotation(t *testing.T) {
+	mustReject(t, `{
+		"issue_number": 7, "revision": 1, "plan_markdown": "x",
+		"files_to_modify": [], "dependencies_detected": [],
+		"suggested_labels": ["enhancement (create)"],
+		"questions": [], "estimated_complexity": "S", "ready_to_execute": false
+	}`, "label-with-annotation")
+}
+
+func TestValidatePlanJSON_RejectsBadQuestionType(t *testing.T) {
+	mustReject(t, `{
+		"issue_number": 7, "revision": 1, "plan_markdown": "x",
+		"files_to_modify": [], "dependencies_detected": [],
+		"questions": [{"id": "q1", "type": "checkbox", "prompt": "?", "default": "x"}],
+		"estimated_complexity": "S", "ready_to_execute": false
+	}`, "single_choice / multi_choice / free_text / yes_no")
+}
+
+func TestValidatePlanJSON_RejectsQuestionMissingDefault(t *testing.T) {
+	mustReject(t, `{
+		"issue_number": 7, "revision": 1, "plan_markdown": "x",
+		"files_to_modify": [], "dependencies_detected": [],
+		"questions": [{"id": "q1", "type": "yes_no", "prompt": "?"}],
+		"estimated_complexity": "S", "ready_to_execute": false
+	}`, "default")
+}
+
+func TestValidatePlanJSON_RejectsSingleChoiceMissingOptions(t *testing.T) {
+	mustReject(t, `{
+		"issue_number": 7, "revision": 1, "plan_markdown": "x",
+		"files_to_modify": [], "dependencies_detected": [],
+		"questions": [{"id": "q1", "type": "single_choice", "prompt": "?", "default": "A"}],
+		"estimated_complexity": "S", "ready_to_execute": false
+	}`, "options")
+}
+
+func TestValidatePlanJSON_RejectsZeroIssueNumber(t *testing.T) {
+	mustReject(t, `{
+		"issue_number": 0, "revision": 1, "plan_markdown": "x",
+		"files_to_modify": [], "dependencies_detected": [],
+		"questions": [], "estimated_complexity": "S", "ready_to_execute": false
+	}`, "issue_number")
+}
+
+func TestValidatePlanJSON_RejectsMalformedJSON(t *testing.T) {
+	mustReject(t, `{not json`, "valid JSON")
+}
+
+func TestValidatePlanJSON_RejectsMissingReadyToExecute(t *testing.T) {
+	mustReject(t, `{
+		"issue_number": 7, "revision": 1, "plan_markdown": "x",
+		"files_to_modify": [], "dependencies_detected": [],
+		"questions": [], "estimated_complexity": "S"
+	}`, "ready_to_execute")
+}

--- a/internal/skills/bundle/skills/conductor-plan.md
+++ b/internal/skills/bundle/skills/conductor-plan.md
@@ -111,12 +111,15 @@ Bundled by PrismConductor. Used in Bundled and Hybrid skill modes (PRISMCONDUCTO
    }
    ```
 
-   Field name rules (strict — the conductor's validator requires the canonical names):
+   The harness validates this file against the §9.1 contract **before** writing it to disk. If the validator rejects your plan you'll receive a tool_result with `is_error: true` and a specific message naming the offending field — fix that field and call `Write` again with the corrected content. Do not proceed (no `Plan written to ...`, no other tool calls) until the validator accepts the plan.
+
+   Field name rules:
    - `issue_number` (NOT `issue`).
    - `revision` (NOT `rev`).
    - `files_to_modify` is an array of `{path, intent}` objects, NOT `{add, modify, delete}` lists.
-   - `suggested_labels` is an array of plain label strings (`"enhancement"`), NOT label-with-action strings (`"enhancement (create)"`).
-   - Omit `suggested_labels` entirely if empty.
+   - `suggested_labels` is an array of plain label strings (`"enhancement"`), NOT label-with-action strings (`"enhancement (create)"`). Omit entirely if empty.
+   - `dependencies_detected` is required — use `[]` if there are none.
+   - `ready_to_execute` is required — emit a literal `true` or `false`.
    - Do NOT include `workspace_id` — the conductor attaches it on read.
 
 7. Print `Plan written to .prismconductor/plans/<issue>-rev1.json` so the conductor's PTY parser picks it up (§10.3).


### PR DESCRIPTION
Reverts the alias acceptance from #67 and moves contract enforcement to where the model crosses our boundary: the harness's Write tool. A misshapen plan never lands on disk; the model sees a specific validator error in the next tool_result and can self-correct.

This rejects the wrong instinct from #67 (silently normalize whatever the model emitted) in favor of the right one: every model — Claude, gpt-5-mini, Gemini, qwen3 — faces the same wall and learns from the same actionable errors. Drift is impossible because there's no quiet acceptance path.

Concrete changes:

- New planio.ValidatePlanJSON([]byte) error: strict §9.1 enforcement, field-by-field error messages naming the offending key. Detects the common failure modes seen in the wild (issue/rev aliases, files_to_modify as {add,modify,delete} object, label-with-annotation strings, missing default on questions).
- planio.ReadPlan now delegates to ValidatePlanJSON. Dropped the alias acceptance entirely. workspace_id requirement stays removed (real contract bug — worker can't know it).
- Harness tools.go: a Write to a path matching .prismconductor/plans/ <num>-rev<N>.json runs ValidatePlanJSON before the file lands on disk. Failure becomes a tool_result error the model receives on its next turn.
- conductor-plan.md skill markdown: replaces the prose "fix and retry" hand-holding with a clear note about the harness-side validator. The skill describes the contract; the harness enforces it.
- Tests: 11 ValidatePlanJSON cases covering happy path + every failure mode, 3 harness-Write integration tests covering bad-plan-rejected / good-plan-passes / non-plan-path-bypasses.

Closes #71.