### PR TITLE
feat(card): show provider icon badge on card headers (#37)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import { useArchivedStore, useIssueStore } from "./stores/issueStore";
 import { useGoalStore } from "./stores/goalStore";
 import { usePlanReadyStore } from "./stores/planReadyStore";
 import { useLabelsStore } from "./stores/labelsStore";
+import { usePoolsStore } from "./stores/usePoolsStore";
 import { Toast } from "./components/Toast";
 import { useToastStore, type Toast as ToastT } from "./stores/toastStore";
 
@@ -198,8 +199,12 @@ function App() {
         })
         .catch(() => {});
     refreshPool();
+    usePoolsStore.getState().refresh();
     const offPoolFreed = EventsOn("bus.worker_slot_freed", refreshPool);
-    const offPoolChanged = EventsOn("bus.agent_count_changed", refreshPool);
+    const offPoolChanged = EventsOn("bus.agent_count_changed", () => {
+      refreshPool();
+      usePoolsStore.getState().refresh();
+    });
     const offPoolState = EventsOn("session.state", refreshPool);
     GetAutoPullPaused().then(setAutoPaused).catch(() => {});
     const offPause = EventsOn(

--- a/frontend/src/assets/providers/claude.svg
+++ b/frontend/src/assets/providers/claude.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="16" height="16">
+  <path d="M8 1L14.5 8L8 15L1.5 8Z"/>
+</svg>

--- a/frontend/src/assets/providers/generic.svg
+++ b/frontend/src/assets/providers/generic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="16" height="16">
+  <circle cx="8" cy="8" r="7"/>
+</svg>

--- a/frontend/src/assets/providers/lmstudio.svg
+++ b/frontend/src/assets/providers/lmstudio.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="16" height="16">
+  <path d="M8 1L11.5 4.5 15 8 11.5 11.5 8 15 4.5 11.5 1 8 4.5 4.5Z"/>
+</svg>

--- a/frontend/src/assets/providers/ollama.svg
+++ b/frontend/src/assets/providers/ollama.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="16" height="16">
+  <rect x="1" y="1" width="14" height="14" rx="3"/>
+</svg>

--- a/frontend/src/assets/providers/openai.svg
+++ b/frontend/src/assets/providers/openai.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="16" height="16">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8z"/>
+  <path d="M8 5a.75.75 0 01.75.75v2.5h2.5a.75.75 0 010 1.5h-2.5v2.5a.75.75 0 01-1.5 0v-2.5h-2.5a.75.75 0 010-1.5h2.5v-2.5A.75.75 0 018 5z"/>
+</svg>

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -7,6 +7,8 @@ import { types } from "../../wailsjs/go/models";
 import { useSessionStore, SessionActivity } from "../stores/sessionStore";
 import { usePlanReadyStore } from "../stores/planReadyStore";
 import { useLabelsStore, EMPTY_LABELS } from "../stores/labelsStore";
+import { usePoolsStore } from "../stores/usePoolsStore";
+import { resolveProviderIcon } from "../lib/providerIcon";
 import { getContrastText } from "../lib/contrast";
 import { LabelManagePopover } from "./LabelManagePopover";
 import { MidRunQuestionModal } from "./MidRunQuestionModal";
@@ -34,15 +36,21 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
   // Live state: subscribe to the *whole* sessions table so we re-render when any
   // session changes.
   const allSessions = useSessionStore((s) => s.sessions);
-  const { activeSession, activity, lastFailure, pausedSession } = (() => {
+  const pools = usePoolsStore((s) => s.pools);
+  const { activeSession, activity, lastFailure, pausedSession, mostRecentSession } = (() => {
     let active: types.Session | null = null;
     let activeAct: SessionActivity | null = null;
     let lastFail: types.Session | null = null;
     let paused: types.Session | null = null;
+    let mostRecent: types.Session | null = null;
     for (const view of Object.values(allSessions)) {
       const m = view.meta;
       if (!m) continue;
       if (m.workspace_id !== issue.workspace_id || m.issue_number !== issue.number) continue;
+      // Track most-recent session by start time for provider badge (issue #37).
+      if (!mostRecent || String(m.started_at ?? "") > String(mostRecent.started_at ?? "")) {
+        mostRecent = m;
+      }
       if (m.state === "paused_for_question") {
         // Paused for a mid-run question (#17). Track separately so it overrides
         // both running/active and last-failure rendering.
@@ -61,7 +69,21 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
         }
       }
     }
-    return { activeSession: active, activity: activeAct, lastFailure: lastFail, pausedSession: paused };
+    return { activeSession: active, activity: activeAct, lastFailure: lastFail, pausedSession: paused, mostRecentSession: mostRecent };
+  })();
+
+  // Provider badge (issue #37): resolve from most-recent session's pool_id.
+  const providerBadge = (() => {
+    const poolId = mostRecentSession?.pool_id;
+    if (!poolId) return null;
+    const pool = pools[poolId];
+    if (!pool) {
+      // Pool was deleted — show generic icon with deleted tooltip.
+      const icon = resolveProviderIcon("generic");
+      return { icon, tooltipName: "(deleted pool)", deleted: true };
+    }
+    const icon = resolveProviderIcon(pool.provider);
+    return { icon, tooltipName: pool.name, deleted: false };
   })();
   if (activeSession) {
     // Visible in DevTools (Cmd+Opt+I in the Wails window) — confirms the
@@ -122,6 +144,15 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
           <span className="text-slate-500 truncate">{workspaceLabel ?? issue.workspace_id}</span>
         </span>
         <span className="flex items-center gap-1.5 shrink-0">
+          {/* Provider badge (issue #37): visible when any session has a known pool. */}
+          {providerBadge && (
+            <span
+              className="text-slate-400 inline-flex items-center w-4 h-4 opacity-75"
+              title={`${providerBadge.icon.label}${providerBadge.deleted ? " (deleted pool)" : `: ${providerBadge.tooltipName}`}`}
+              aria-label={providerBadge.icon.label}
+              dangerouslySetInnerHTML={{ __html: providerBadge.icon.svgContent }}
+            />
+          )}
           {/* PR chip stays visible across columns/session states (rev4 q3). */}
           {issue.pr_number != null && issue.pr_url && (
             <button

--- a/frontend/src/lib/providerIcon.ts
+++ b/frontend/src/lib/providerIcon.ts
@@ -1,0 +1,33 @@
+// Provider icon registry for the card-header badge (issue #37).
+// SVG strings use fill="currentColor" so the icon inherits the parent's
+// text color. Rendered via dangerouslySetInnerHTML in a <span>.
+// Source SVG files live in frontend/src/assets/providers/ per the plan.
+
+const SVG_CLAUDE = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M8 1L14.5 8L8 15L1.5 8Z"/></svg>`;
+
+const SVG_OPENAI = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path fill-rule="evenodd" clip-rule="evenodd" d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8z"/><path d="M8 5a.75.75 0 01.75.75v2.5h2.5a.75.75 0 010 1.5h-2.5v2.5a.75.75 0 01-1.5 0v-2.5h-2.5a.75.75 0 010-1.5h2.5v-2.5A.75.75 0 018 5z"/></svg>`;
+
+const SVG_OLLAMA = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><rect x="1" y="1" width="14" height="14" rx="3"/></svg>`;
+
+const SVG_LMSTUDIO = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M8 1L11.5 4.5 15 8 11.5 11.5 8 15 4.5 11.5 1 8 4.5 4.5Z"/></svg>`;
+
+const SVG_GENERIC = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><circle cx="8" cy="8" r="7"/></svg>`;
+
+export type ProviderIconInfo = {
+  svgContent: string;
+  label: string;
+};
+
+const registry: Record<string, ProviderIconInfo> = {
+  claude:   { svgContent: SVG_CLAUDE,   label: "Anthropic Claude" },
+  openai:   { svgContent: SVG_OPENAI,   label: "OpenAI" },
+  litellm:  { svgContent: SVG_OPENAI,   label: "LiteLLM" },
+  ollama:   { svgContent: SVG_OLLAMA,   label: "Ollama" },
+  lmstudio: { svgContent: SVG_LMSTUDIO, label: "LM Studio" },
+  gemini:   { svgContent: SVG_OPENAI,   label: "Google Gemini" },
+  generic:  { svgContent: SVG_GENERIC,  label: "Unknown provider" },
+};
+
+export function resolveProviderIcon(provider: string): ProviderIconInfo {
+  return registry[provider] ?? registry.generic;
+}

--- a/frontend/src/stores/usePoolsStore.ts
+++ b/frontend/src/stores/usePoolsStore.ts
@@ -1,0 +1,35 @@
+import { create } from "zustand";
+import { ListPools } from "../../wailsjs/go/main/App";
+
+export type PoolEntry = {
+  id: string;
+  name: string;
+  provider: string;
+};
+
+type State = {
+  pools: Record<string, PoolEntry>;
+  refresh: () => Promise<void>;
+};
+
+export const usePoolsStore = create<State>((set) => ({
+  pools: {},
+  refresh: async () => {
+    try {
+      const rows = await ListPools();
+      const next: Record<string, PoolEntry> = {};
+      for (const r of rows ?? []) {
+        if (r.pool?.id) {
+          next[r.pool.id] = {
+            id: r.pool.id,
+            name: r.pool.name,
+            provider: r.pool.provider,
+          };
+        }
+      }
+      set({ pools: next });
+    } catch {
+      // silently ignore — pools badge degrades to missing (shows nothing)
+    }
+  },
+}));

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1295,6 +1295,7 @@ export namespace types {
 	    last_prompt: string;
 	    blocked_reason?: string;
 	    pending_question_id?: string;
+	    pool_id?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new Session(source);
@@ -1313,6 +1314,7 @@ export namespace types {
 	        this.last_prompt = source["last_prompt"];
 	        this.blocked_reason = source["blocked_reason"];
 	        this.pending_question_id = source["pending_question_id"];
+	        this.pool_id = source["pool_id"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/google/go-github/v62 v62.0.0
 	github.com/google/uuid v1.6.0
+	github.com/mozilla-ai/any-llm-go v0.9.0
 	github.com/wailsapp/wails/v2 v2.11.0
 	modernc.org/sqlite v1.50.0
 )
@@ -32,7 +33,6 @@ require (
 	github.com/leaanthony/u v1.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mozilla-ai/any-llm-go v0.9.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/go-github/v62 v62.0.0 h1:/6mGCaRywZz9MuHyw9gD1CwsbmBX8GWsbFkwMmHdhl4=
@@ -114,8 +112,8 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tkrajina/go-reflector v0.5.8 h1:yPADHrwmUbMq4RGEyaOUpz2H90sRsETNVpjzo3DLVQQ=
 github.com/tkrajina/go-reflector v0.5.8/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
@@ -132,8 +130,6 @@ go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
-golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
 golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -149,8 +145,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210505024714-0287a6fb4125/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
-golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
 golang.org/x/net v0.47.0 h1:Mx+4dIFzqraBXUugkia1OOvlD6LemFo1ALMHjrXDOhY=
 golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -175,8 +169,6 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
-golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
 golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=
 golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -419,6 +419,7 @@ func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types
 		Mode:        mode,
 		State:       types.StateRunning,
 		StartedAt:   time.Now(),
+		PoolID:      pool.ID,
 	}
 	sess.Transcript = transcriptPath
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -209,3 +209,37 @@ func TestSpawnWritesToTranscriptFile(t *testing.T) {
 		t.Errorf("expected transcript_offset to be persisted at least once")
 	}
 }
+
+// TestSpawnPersistsPoolID verifies that PoolID from the spawning pool is
+// recorded on the session row (issue #37).
+func TestSpawnPersistsPoolID(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX-only")
+	}
+	tdir := t.TempDir()
+	store := &fakePersister{}
+	m := NewManager(nil, nil)
+	m.Configure(filepath.Join(tdir, "transcripts"), store, nil)
+
+	ws := types.Workspace{ID: "ws-1", RepoPath: tdir}
+	issue := types.Issue{Number: 2, WorkspaceID: ws.ID}
+	pool := types.Pool{ID: "pool-xyz", Name: "test", Provider: "claude"}
+
+	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute,
+		[]string{"/bin/sh", "-c", "echo Work complete."},
+		"", "", "", pool)
+	if err != nil {
+		t.Fatalf("spawnWithDir: %v", err)
+	}
+	if sess.PoolID != "pool-xyz" {
+		t.Errorf("sess.PoolID = %q, want %q", sess.PoolID, "pool-xyz")
+	}
+	// The persisted JSON blob must also carry the pool_id.
+	if len(store.saves) == 0 {
+		t.Fatalf("expected SaveSession to be called")
+	}
+	saved := store.saves[0]
+	if saved.PoolID != "pool-xyz" {
+		t.Errorf("persisted PoolID = %q, want %q", saved.PoolID, "pool-xyz")
+	}
+}

--- a/internal/types/session_test.go
+++ b/internal/types/session_test.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSessionPoolIDOmitempty(t *testing.T) {
+	s := Session{ID: "s1", WorkspaceID: "ws", IssueNumber: 1}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "pool_id") {
+		t.Errorf("expected omitempty to drop pool_id when empty; got %s", b)
+	}
+}
+
+func TestSessionPoolIDRoundTrip(t *testing.T) {
+	s := Session{ID: "s1", WorkspaceID: "ws", IssueNumber: 1, PoolID: "pool-abc"}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got Session
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.PoolID != "pool-abc" {
+		t.Errorf("PoolID round-trip: got %q want %q", got.PoolID, "pool-abc")
+	}
+}
+
+func TestSessionLegacyJSONNoPoolID(t *testing.T) {
+	legacy := []byte(`{"id":"s1","workspace_id":"ws","issue_number":1,"mode":"plan","state":"completed","started_at":"2025-01-01T00:00:00Z","pid":0,"last_prompt":""}`)
+	var s Session
+	if err := json.Unmarshal(legacy, &s); err != nil {
+		t.Fatalf("legacy unmarshal: %v", err)
+	}
+	if s.PoolID != "" {
+		t.Errorf("expected empty PoolID for legacy session; got %q", s.PoolID)
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -249,6 +249,10 @@ type Session struct {
 	LastPrompt        string       `json:"last_prompt"`
 	BlockedReason     string       `json:"blocked_reason,omitempty"`
 	PendingQuestionID string       `json:"pending_question_id,omitempty"`
+	// PoolID is the pool that spawned this session (issue #37). Used by the
+	// frontend to resolve provider attribution on card badges. Empty for
+	// sessions spawned before this field was introduced.
+	PoolID string `json:"pool_id,omitempty"`
 
 	// TranscriptOffset is the byte offset into the transcript file of the
 	// last fully-processed line (issue #54). Lives on the sessions column,


### PR DESCRIPTION
## Summary

- Adds a 16×16 monochrome SVG provider icon badge to each Kanban card header, derived from the most-recent session's `pool_id`
- Users can see which LLM provider (Claude, OpenAI, Ollama, LM Studio, etc.) handled each issue at a glance
- Deleted/missing pools fall back to a generic circle icon with "(deleted pool)" tooltip per Q2 answer
- Badge renders regardless of session terminal state (running, completed, failed, etc.) per Q1 answer

## Files modified

- `internal/types/types.go` — added `PoolID string` to `Session` struct with `json:"pool_id,omitempty"`
- `internal/session/manager.go` — set `sess.PoolID = pool.ID` in `spawnWithDir`
- `internal/types/session_test.go` — 3 new tests: omitempty, round-trip, legacy JSON compat
- `internal/session/manager_test.go` — added `TestSpawnPersistsPoolID`
- `frontend/src/assets/providers/` — 5 new SVG icons: claude, openai, ollama, lmstudio, generic
- `frontend/src/lib/providerIcon.ts` — provider registry mapping provider names to icon+label
- `frontend/src/stores/usePoolsStore.ts` — Zustand store backed by `ListPools()` for pool lookup
- `frontend/src/components/Card.tsx` — badge rendering using most-recent session's pool_id
- `frontend/src/App.tsx` — startup pool refresh + refresh on pool change events
- `frontend/wailsjs/go/models.ts` — `pool_id?: string` on Session (regenerated by wails build)
- `go.mod` / `go.sum` — dependency tidy from wails build

## Verification

- **Lint/typecheck:** `cd frontend && npx tsc --noEmit` → PASSED
- **Vet:** `go vet ./...` → PASSED
- **Tests:** `go test ./internal/types/... ./internal/session/...` → PASSED (ok both packages)
- **Build:** `wails build` → PASSED (Built in 6.984s)

## Design notes

- SVGs use `fill="currentColor"` so the badge inherits the parent `text-slate-400` CSS color on dark card backgrounds; rendered via `dangerouslySetInnerHTML` on a `<span>` (safe — content is statically bundled assets)
- Pool lookup is cached in `usePoolsStore` (refreshed on startup and on `bus.agent_count_changed` events); no new bound Go methods required

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-37

Closes #37