### PR TITLE
feat(column): columns contain cards internally with scroll (#50)

### DIFF
--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -24,18 +24,18 @@ export function Column({
     <div
       ref={setNodeRef}
       className={cn(
-        "flex-1 min-w-[200px] rounded-lg p-2 border transition-colors",
+        "flex-1 min-w-[200px] rounded-lg p-2 border transition-colors flex flex-col min-h-0",
         isOver ? "bg-slate-800/60 border-emerald-700" : "bg-slate-900/40 border-slate-800",
       )}
     >
-      <div className="flex items-center text-xs uppercase tracking-wide text-slate-400 mb-2 px-1">
+      <div className="flex items-center text-xs uppercase tracking-wide text-slate-400 mb-2 px-1 shrink-0">
         <span>
           {title} <span className="text-slate-500">({count})</span>
         </span>
         {headerExtra && <span className="ml-auto">{headerExtra}</span>}
       </div>
       <SortableContext items={itemIDs} strategy={verticalListSortingStrategy}>
-        <div className="space-y-1 min-h-[40px]">{children}</div>
+        <div className="space-y-1 min-h-[40px] flex-1 overflow-y-auto pr-1">{children}</div>
       </SortableContext>
     </div>
   );


### PR DESCRIPTION
## Summary

- Each board column is now a fixed-height, internally-scrollable box. Cards no longer overflow the column's rounded border when a column has many items.
- Added `flex flex-col min-h-0` to the Column outer container so it receives a bounded height from the parent flex chain.
- Added `shrink-0` to the column header so it stays visible while cards scroll.
- Added `flex-1 overflow-y-auto pr-1` to the cards wrapper — this is now the scroll container.
- `Board.tsx` already had `h-full` on the columns row; no change needed there.

## Files modified

- `frontend/src/components/Column.tsx`

## Verification

**Lint/typecheck:** `tsc --noEmit` passes cleanly in the main repo (exit 0). The worktree lacks a `node_modules/` install (worktrees share only git objects, not deps), so tsc ran against main repo node_modules. My changes are CSS className string changes only; no TypeScript logic was touched.

**Build:** `go build ./internal/...` — exit 0. `go vet ./...` passes in main repo (exit 0); the worktree reports `no matching files found` for `frontend/dist` because the frontend is not built in worktrees — pre-existing worktree infrastructure issue, unrelated to this change.

## No tests run (no runner detected)

The frontend has no Vitest/Jest configured (no test entries in `package.json` scripts, no test devDependencies). Manual QA acceptance: add many cards to a column; scrollbar appears inside the rounded border, border stays intact, drag-and-drop continues to work.

## Workspace mode

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-50

Closes #50
