### PR TITLE
feat(pools): pool preference ordering + waiting-for-pool state (#40)

### DIFF
--- a/app.go
+++ b/app.go
@@ -189,6 +189,42 @@ func (a *App) startup(ctx context.Context) {
 			})
 		}
 
+		// Issue #40: wire work-role spawn for pending-pool drain (approve_execute
+		// requests that were queued because no work pool had free capacity).
+		if a.wsReg != nil {
+			a.orch.SetSpawnWork(func(workspaceID string, issueNumber int, poolID string) error {
+				ws, ok := a.wsReg.Get(workspaceID)
+				if !ok {
+					return fmt.Errorf("unknown workspace %q", workspaceID)
+				}
+				pool, err := a.store.GetPool(poolID)
+				if err != nil {
+					return fmt.Errorf("resolve pool %q: %w", poolID, err)
+				}
+				issue, err := a.store.LoadIssue(workspaceID, issueNumber)
+				if err != nil {
+					return fmt.Errorf("load issue #%d: %w", issueNumber, err)
+				}
+				plan, err := a.store.LatestPlan(workspaceID, issueNumber)
+				if err != nil || plan == nil {
+					return fmt.Errorf("load plan for #%d: %w", issueNumber, err)
+				}
+				if err := a.store.MoveIssueColumn(workspaceID, issueNumber, types.ColInProgress); err != nil {
+					return fmt.Errorf("move column #%d: %w", issueNumber, err)
+				}
+				_, err = a.mgr.SpawnExecute(ws, issue, *plan, pool)
+				if err != nil {
+					_ = a.store.MoveIssueColumn(workspaceID, issueNumber, types.ColPlan)
+					a.poolReg.ReleaseByPool(poolID)
+				}
+				return err
+			})
+		}
+
+		// Issue #40: drain any pending pool requests from before this startup
+		// so queued work survives conductor restarts.
+		go a.orch.KickDrain("startup")
+
 		// Persist every event for debugging + Phase 7 transcript pattern detector.
 		a.bus.Subscribe(func(e eventbus.Event) {
 			_ = a.store.LogEvent(string(e.Type), e.Payload)
@@ -1921,7 +1957,19 @@ func (a *App) ApprovePlan(workspaceID string, issueNumber, revision int) error {
 	}
 	pool, ok := a.acquireWorkPool(ws)
 	if !ok {
-		return fmt.Errorf("no work pool available")
+		// No work slot available — persist intent and show waiting decoration.
+		// The card stays in IN_PROGRESS; drain fires it when a slot frees.
+		_ = a.store.EnqueuePendingPool(workspaceID, issueNumber, types.RoleWork, "approve_execute")
+		if iss, lerr := a.store.LoadIssue(workspaceID, issueNumber); lerr == nil {
+			iss.WaitingForPool = true
+			_, _ = a.store.SaveIssue(iss)
+		}
+		a.bus.Publish(eventbus.EvtPendingPoolEnqueued, eventbus.PendingPoolChange{
+			WorkspaceID: workspaceID,
+			IssueNumber: issueNumber,
+			Role:        string(types.RoleWork),
+		})
+		return nil
 	}
 	if _, err := a.mgr.SpawnExecute(ws, issue, plan, pool); err != nil {
 		a.poolReg.ReleaseByPool(pool.ID)

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -134,6 +134,8 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
           ? "border-purple-500 card-glow-execute"
           : planReady
           ? "border-amber-500 card-glow-ready"
+          : issue.waiting_for_pool
+          ? "border-pink-500 card-glow-waiting"
           : "border-slate-700",
       )}
     >
@@ -185,6 +187,8 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
         labels={issue.labels ?? []}
         workspaceID={issue.workspace_id}
         issueNumber={issue.number}
+        waitingForPool={issue.waiting_for_pool ?? false}
+        pools={pools}
       />
       {pausedSession && pausedSession.pending_question_id && (
         <MidRunQuestionModal
@@ -220,6 +224,8 @@ function StatusRow({
   labels,
   workspaceID,
   issueNumber,
+  waitingForPool,
+  pools,
 }: {
   activeSession: types.Session | null;
   activity: SessionActivity | null;
@@ -232,6 +238,8 @@ function StatusRow({
   labels: string[];
   workspaceID: string;
   issueNumber: number;
+  waitingForPool: boolean;
+  pools: Record<string, import("../stores/usePoolsStore").PoolEntry>;
 }) {
   if (pausedSession) {
     return (
@@ -271,6 +279,20 @@ function StatusRow({
         {activity && activity.last_action && (
           <ActivityHint activity={activity} />
         )}
+      </div>
+    );
+  }
+  if (!activeSession && waitingForPool) {
+    // Build tooltip: "waiting for an available work pool — 0 of 7 slots free (Opus, Sonnet)"
+    const poolNames = Object.values(pools).map((p) => p.name);
+    const tooltip =
+      poolNames.length > 0
+        ? `waiting for an available agent pool — ${poolNames.join(", ")}`
+        : "no agent pools configured — add one in Settings → Pools";
+    return (
+      <div className="text-[11px] mt-1.5 flex items-center gap-1.5 flex-wrap" title={tooltip}>
+        <Pulse className="bg-pink-400" />
+        <span className="text-pink-300">waiting for available agent pool…</span>
       </div>
     );
   }

--- a/frontend/src/components/PoolsPanel.tsx
+++ b/frontend/src/components/PoolsPanel.tsx
@@ -1,5 +1,20 @@
 import { useEffect, useState } from "react";
 import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
   ListPools,
   ListProviders,
   SavePool,
@@ -41,10 +56,14 @@ export function PoolsPanel() {
     const offFreed = EventsOn("bus.worker_slot_freed", refresh);
     const offChanged = EventsOn("bus.agent_count_changed", refresh);
     const offState = EventsOn("session.state", refresh);
+    const offPending = EventsOn("bus.pending_pool_enqueued", refresh);
+    const offDequeued = EventsOn("bus.pending_pool_dequeued", refresh);
     return () => {
       if (typeof offFreed === "function") offFreed();
       if (typeof offChanged === "function") offChanged();
       if (typeof offState === "function") offState();
+      if (typeof offPending === "function") offPending();
+      if (typeof offDequeued === "function") offDequeued();
     };
   }, []);
 
@@ -94,6 +113,23 @@ export function PoolsPanel() {
     }
   }
 
+  async function onReorder(role: Role, oldIndex: number, newIndex: number) {
+    const rows = [...grouped[role]];
+    const reordered = arrayMove(rows, oldIndex, newIndex);
+    // Assign sequential priorities (0 = highest preference).
+    const updates = reordered.map((row, i) =>
+      SavePool(types.Pool.createFrom({ ...row.pool, priority: i }))
+    );
+    try {
+      await Promise.all(updates);
+      await refresh();
+    } catch (err) {
+      console.error("reorder pools", err);
+    }
+  }
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
   return (
     <div className="space-y-3 text-sm">
       {pools.length > 0 && !hasEnabled("plan") && (
@@ -120,66 +156,67 @@ export function PoolsPanel() {
       {ROLE_ORDER.map((role) => {
         const rows = grouped[role];
         if (rows.length === 0) return null;
+        const sortable = role !== "orchestrator" && rows.length > 1;
         return (
           <div key={role} className="space-y-2">
-            <div className="text-xs uppercase tracking-wide text-slate-500">
+            <div className="text-xs uppercase tracking-wide text-slate-500 flex items-center gap-2">
               {ROLE_LABEL[role]} ({rows.length})
+              {sortable && (
+                <span className="normal-case tracking-normal text-slate-600">
+                  · drag to reorder preference
+                </span>
+              )}
             </div>
-            {rows.map((row) => {
-              const info = providerByKind.get(row.pool.provider);
-              const err = deleteErr[row.pool.id];
-              return (
-                <div
-                  key={row.pool.id}
-                  className="border border-slate-800 rounded p-2 bg-slate-950/40"
+            {sortable ? (
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={(e: DragEndEvent) => {
+                  const { active, over } = e;
+                  if (!over || active.id === over.id) return;
+                  const oldIdx = rows.findIndex((r) => r.pool.id === active.id);
+                  const newIdx = rows.findIndex((r) => r.pool.id === over.id);
+                  if (oldIdx !== -1 && newIdx !== -1) onReorder(role, oldIdx, newIdx);
+                }}
+              >
+                <SortableContext
+                  items={rows.map((r) => r.pool.id)}
+                  strategy={verticalListSortingStrategy}
                 >
-                  <div className="flex items-center gap-2">
-                    <div className="flex-1">
-                      <div className="text-slate-100 font-mono text-xs flex items-center gap-2">
-                        <span>{row.pool.name}</span>
-                        <span className="text-slate-500">
-                          ({info?.display_name ?? row.pool.provider})
-                        </span>
-                      </div>
-                      <div className="text-slate-500 text-xs">
-                        {row.pool.model || "—"}
-                        {row.pool.endpoint && ` · ${row.pool.endpoint}`}
-                      </div>
-                    </div>
-                    {role !== "orchestrator" && (
-                      <div className="font-mono text-slate-300 text-xs">
-                        {row.active}/{row.pool.capacity}
-                      </div>
-                    )}
-                    <label className="flex items-center gap-1 text-xs">
-                      <input
-                        type="checkbox"
-                        checked={row.pool.enabled}
-                        onChange={(e) =>
-                          onToggleEnabled(row.pool, e.target.checked)
-                        }
-                      />
-                      enabled
-                    </label>
-                    <button
-                      className="text-xs text-slate-300 hover:text-slate-100 px-2 py-1 border border-slate-700 rounded"
-                      onClick={() => setEditing(row.pool)}
-                    >
-                      Edit
-                    </button>
-                    <button
-                      className="text-xs text-rose-300 hover:text-rose-200 px-2 py-1 border border-rose-900 rounded"
-                      onClick={() => onRemove(row.pool)}
-                    >
-                      Remove
-                    </button>
-                  </div>
-                  {err && (
-                    <div className="mt-1 text-xs text-rose-300">{err}</div>
-                  )}
-                </div>
-              );
-            })}
+                  {rows.map((row, idx) => (
+                    <SortablePoolRow
+                      key={row.pool.id}
+                      row={row}
+                      role={role}
+                      isFirst={idx === 0}
+                      isLast={idx === rows.length - 1}
+                      providerByKind={providerByKind}
+                      deleteErr={deleteErr[row.pool.id]}
+                      onToggleEnabled={onToggleEnabled}
+                      onEdit={() => setEditing(row.pool)}
+                      onRemove={() => onRemove(row.pool)}
+                    />
+                  ))}
+                </SortableContext>
+              </DndContext>
+            ) : (
+              rows.map((row) => {
+                const err = deleteErr[row.pool.id];
+                return (
+                  <PoolRow
+                    key={row.pool.id}
+                    row={row}
+                    role={role}
+                    providerByKind={providerByKind}
+                    deleteErr={err}
+                    dragHandle={null}
+                    onToggleEnabled={onToggleEnabled}
+                    onEdit={() => setEditing(row.pool)}
+                    onRemove={() => onRemove(row.pool)}
+                  />
+                );
+              })
+            )}
           </div>
         );
       })}
@@ -219,6 +256,135 @@ export function PoolsPanel() {
           }}
         />
       )}
+    </div>
+  );
+}
+
+function SortablePoolRow({
+  row,
+  role,
+  isFirst,
+  isLast,
+  providerByKind,
+  deleteErr,
+  onToggleEnabled,
+  onEdit,
+  onRemove,
+}: {
+  row: workerpool.PoolStatus;
+  role: Role;
+  isFirst: boolean;
+  isLast: boolean;
+  providerByKind: Map<string, main.ProviderInfo>;
+  deleteErr?: string;
+  onToggleEnabled: (p: types.Pool, next: boolean) => void;
+  onEdit: () => void;
+  onRemove: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: row.pool.id,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+  const dragHandle = (
+    <span
+      {...attributes}
+      {...listeners}
+      className="cursor-grab active:cursor-grabbing text-slate-600 hover:text-slate-400 select-none px-1"
+      title="Drag to reorder preference"
+    >
+      ⠿
+    </span>
+  );
+  const hint = isFirst ? "← preferred" : isLast ? "← fallback" : null;
+  return (
+    <div ref={setNodeRef} style={style}>
+      <PoolRow
+        row={row}
+        role={role}
+        providerByKind={providerByKind}
+        deleteErr={deleteErr}
+        dragHandle={dragHandle}
+        preferenceHint={hint ?? undefined}
+        onToggleEnabled={onToggleEnabled}
+        onEdit={onEdit}
+        onRemove={onRemove}
+      />
+    </div>
+  );
+}
+
+function PoolRow({
+  row,
+  role,
+  providerByKind,
+  deleteErr,
+  dragHandle,
+  preferenceHint,
+  onToggleEnabled,
+  onEdit,
+  onRemove,
+}: {
+  row: workerpool.PoolStatus;
+  role: Role;
+  providerByKind: Map<string, main.ProviderInfo>;
+  deleteErr?: string;
+  dragHandle: React.ReactNode;
+  preferenceHint?: string;
+  onToggleEnabled: (p: types.Pool, next: boolean) => void;
+  onEdit: () => void;
+  onRemove: () => void;
+}) {
+  const info = providerByKind.get(row.pool.provider);
+  return (
+    <div className="border border-slate-800 rounded p-2 bg-slate-950/40">
+      <div className="flex items-center gap-2">
+        {dragHandle}
+        <div className="flex-1 min-w-0">
+          <div className="text-slate-100 font-mono text-xs flex items-center gap-2">
+            <span>{row.pool.name}</span>
+            <span className="text-slate-500">
+              ({info?.display_name ?? row.pool.provider})
+            </span>
+            {preferenceHint && (
+              <span className="text-slate-600 font-normal">{preferenceHint}</span>
+            )}
+          </div>
+          <div className="text-slate-500 text-xs">
+            {row.pool.model || "—"}
+            {row.pool.endpoint && ` · ${row.pool.endpoint}`}
+          </div>
+        </div>
+        {role !== "orchestrator" && (
+          <div className="font-mono text-slate-300 text-xs">
+            {row.active}/{row.pool.capacity}
+          </div>
+        )}
+        <label className="flex items-center gap-1 text-xs">
+          <input
+            type="checkbox"
+            checked={row.pool.enabled}
+            onChange={(e) => onToggleEnabled(row.pool, e.target.checked)}
+          />
+          enabled
+        </label>
+        <button
+          className="text-xs text-slate-300 hover:text-slate-100 px-2 py-1 border border-slate-700 rounded"
+          onClick={onEdit}
+        >
+          Edit
+        </button>
+        <button
+          className="text-xs text-rose-300 hover:text-rose-200 px-2 py-1 border border-rose-900 rounded"
+          onClick={onRemove}
+        >
+          Remove
+        </button>
+      </div>
+      {deleteErr && <div className="mt-1 text-xs text-rose-300">{deleteErr}</div>}
     </div>
   );
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -43,4 +43,9 @@ body {
 .card-glow-execute { animation: card-glow-execute 1.6s ease-in-out infinite; }
 .card-glow-ready   { animation: card-glow-ready   2.4s ease-in-out infinite; }
 .card-glow-blocked { animation: card-glow-blocked 1.2s ease-in-out infinite; }
+@keyframes card-glow-waiting {
+  0%, 100% { box-shadow: 0 0 0 1px rgba(244, 114, 182, 0.55), 0 0 12px 2px rgba(244, 114, 182, 0.20); }
+  50%      { box-shadow: 0 0 0 2px rgba(244, 114, 182, 0.90), 0 0 24px 6px rgba(244, 114, 182, 0.45); }
+}
+.card-glow-waiting { animation: card-glow-waiting 2.0s ease-in-out infinite; }
 

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1151,11 +1151,12 @@ export namespace types {
 	    pr_url?: string;
 	    // Go type: time
 	    archived_at?: any;
-	
+	    waiting_for_pool?: boolean;
+
 	    static createFrom(source: any = {}) {
 	        return new Issue(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.number = source["number"];
@@ -1177,6 +1178,7 @@ export namespace types {
 	        this.pr_number = source["pr_number"];
 	        this.pr_url = source["pr_url"];
 	        this.archived_at = this.convertValues(source["archived_at"], null);
+	        this.waiting_for_pool = source["waiting_for_pool"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -1243,11 +1245,12 @@ export namespace types {
 	    role: string;
 	    // Go type: time
 	    created_at: any;
-	
+	    priority: number;
+
 	    static createFrom(source: any = {}) {
 	        return new Pool(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -1260,6 +1263,7 @@ export namespace types {
 	        this.api_key = source["api_key"];
 	        this.role = source["role"];
 	        this.created_at = this.convertValues(source["created_at"], null);
+	        this.priority = source["priority"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -28,6 +28,9 @@ const (
 	EvtLabelsUpdated     EventType = "labels_updated"
 	EvtAutoPullPausedChanged EventType = "auto_pull_paused_changed"
 	EvtIssuesArchived        EventType = "issues_archived"
+	// Issue #40: pending pool queue events.
+	EvtPendingPoolEnqueued EventType = "pending_pool_enqueued"
+	EvtPendingPoolDequeued EventType = "pending_pool_dequeued"
 )
 
 type Event struct {
@@ -42,6 +45,13 @@ type Event struct {
 type WorkerSlotFreed struct {
 	SessionID string `json:"session_id"`
 	PoolID    string `json:"pool_id"`
+}
+
+// PendingPoolChange is the payload for EvtPendingPoolEnqueued / Dequeued (#40).
+type PendingPoolChange struct {
+	WorkspaceID string `json:"workspace_id"`
+	IssueNumber int    `json:"issue_number"`
+	Role        string `json:"role"`
 }
 
 type Handler func(Event)

--- a/internal/orchestrator/drain_pending_pools.go
+++ b/internal/orchestrator/drain_pending_pools.go
@@ -1,0 +1,121 @@
+package orchestrator
+
+import (
+	"log"
+
+	"prismconductor/internal/eventbus"
+	"prismconductor/internal/types"
+)
+
+// drainPendingPools processes persisted pending-pool requests FIFO, spawning
+// workers as slots become available. Called on EvtWorkerSlotFreed and at
+// conductor startup to recover intent that survived a restart (issue #40).
+func (o *Orchestrator) drainPendingPools(reason string) {
+	if o.pool == nil || o.store == nil {
+		return
+	}
+	pending, err := o.store.ListPendingPools(50)
+	if err != nil {
+		log.Printf("orchestrator: drain list pending: %v", err)
+		return
+	}
+	for _, req := range pending {
+		ws := types.Workspace{ID: req.WorkspaceID}
+		if o.lookupWS != nil {
+			if got, ok := o.lookupWS(req.WorkspaceID); ok {
+				ws = got
+			}
+		}
+		poolID, ok := o.selectPool(ws, req.Role)
+		if !ok {
+			// No slot available for this role yet — leave row in place.
+			continue
+		}
+		var spawnErr error
+		switch req.Role {
+		case types.RolePlan:
+			if o.spawn == nil {
+				o.pool.ReleaseByPool(poolID)
+				continue
+			}
+			// Ensure the issue is in PLAN before spawning; it may still be in
+			// TODO if autoPull enqueued it without moving the card.
+			loaded, lerr := o.store.LoadIssue(req.WorkspaceID, req.IssueNumber)
+			if lerr != nil {
+				// Issue gone — drop stale row.
+				_ = o.store.DequeuePendingPool(req.ID)
+				o.pool.ReleaseByPool(poolID)
+				continue
+			}
+			if loaded.Column == types.ColTodo {
+				if err := o.store.MoveIssueColumn(req.WorkspaceID, req.IssueNumber, types.ColPlan); err != nil {
+					o.pool.ReleaseByPool(poolID)
+					continue
+				}
+			}
+			spawnErr = o.spawn(req.WorkspaceID, req.IssueNumber, poolID)
+		case types.RoleWork:
+			if o.spawnWork == nil {
+				o.pool.ReleaseByPool(poolID)
+				continue
+			}
+			spawnErr = o.spawnWork(req.WorkspaceID, req.IssueNumber, poolID)
+		default:
+			o.pool.ReleaseByPool(poolID)
+			_ = o.store.DequeuePendingPool(req.ID)
+			continue
+		}
+
+		if spawnErr != nil {
+			o.pool.ReleaseByPool(poolID)
+			log.Printf("orchestrator: drain spawn failed (reason=%s, issue=#%d role=%s): %v",
+				reason, req.IssueNumber, req.Role, spawnErr)
+			continue
+		}
+
+		// Spawn succeeded: clean up.
+		_ = o.store.DequeuePendingPool(req.ID)
+		o.clearWaitingForPool(req.WorkspaceID, req.IssueNumber)
+		o.bus.Publish(eventbus.EvtPendingPoolDequeued, eventbus.PendingPoolChange{
+			WorkspaceID: req.WorkspaceID,
+			IssueNumber: req.IssueNumber,
+			Role:        string(req.Role),
+		})
+	}
+}
+
+// enqueuePending persists a pending-pool request for iss and marks the issue
+// as waiting_for_pool so the card shows the waiting decoration.
+func (o *Orchestrator) enqueuePending(iss *types.Issue, role types.Role, action string) {
+	if o.store == nil {
+		return
+	}
+	if err := o.store.EnqueuePendingPool(iss.WorkspaceID, iss.Number, role, action); err != nil {
+		log.Printf("orchestrator: enqueue pending pool (#%d): %v", iss.Number, err)
+		return
+	}
+	if loaded, err := o.store.LoadIssue(iss.WorkspaceID, iss.Number); err == nil && !loaded.WaitingForPool {
+		loaded.WaitingForPool = true
+		_, _ = o.store.SaveIssue(loaded)
+	}
+	o.bus.Publish(eventbus.EvtPendingPoolEnqueued, eventbus.PendingPoolChange{
+		WorkspaceID: iss.WorkspaceID,
+		IssueNumber: iss.Number,
+		Role:        string(role),
+	})
+}
+
+// clearWaitingForPool clears the WaitingForPool flag and removes any pending
+// rows for the issue. No-op if the issue is already clear.
+func (o *Orchestrator) clearWaitingForPool(workspaceID string, issueNumber int) {
+	if o.store == nil {
+		return
+	}
+	_ = o.store.DeletePendingForIssue(workspaceID, issueNumber)
+	loaded, err := o.store.LoadIssue(workspaceID, issueNumber)
+	if err != nil || !loaded.WaitingForPool {
+		return
+	}
+	loaded.WaitingForPool = false
+	_, _ = o.store.SaveIssue(loaded)
+}

--- a/internal/orchestrator/drain_test.go
+++ b/internal/orchestrator/drain_test.go
@@ -1,0 +1,139 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"prismconductor/internal/eventbus"
+	"prismconductor/internal/types"
+)
+
+// pendingStubStore extends stubStore with pending-pool tracking.
+type pendingStubStore struct {
+	stubStore
+	enqueued []types.PendingPoolRequest
+	dequeued []int64
+	deleted  []int
+}
+
+func (s *pendingStubStore) EnqueuePendingPool(wsID string, issueNumber int, role types.Role, action string) error {
+	s.enqueued = append(s.enqueued, types.PendingPoolRequest{
+		ID:          int64(len(s.enqueued) + 1),
+		WorkspaceID: wsID,
+		IssueNumber: issueNumber,
+		Role:        role,
+		Action:      action,
+		CreatedAt:   time.Now(),
+	})
+	return nil
+}
+func (s *pendingStubStore) ListPendingPools(limit int) ([]types.PendingPoolRequest, error) {
+	return s.enqueued, nil
+}
+func (s *pendingStubStore) DequeuePendingPool(id int64) error {
+	s.dequeued = append(s.dequeued, id)
+	out := s.enqueued[:0]
+	for _, r := range s.enqueued {
+		if r.ID != id {
+			out = append(out, r)
+		}
+	}
+	s.enqueued = out
+	return nil
+}
+func (s *pendingStubStore) DeletePendingForIssue(wsID string, num int) error {
+	s.deleted = append(s.deleted, num)
+	out := s.enqueued[:0]
+	for _, r := range s.enqueued {
+		if r.WorkspaceID != wsID || r.IssueNumber != num {
+			out = append(out, r)
+		}
+	}
+	s.enqueued = out
+	return nil
+}
+func (s *pendingStubStore) LoadIssue(wsID string, num int) (types.Issue, error) {
+	return s.stubStore.LoadIssue(wsID, num)
+}
+
+// TestAutoPullEnqueuesPendingWhenPoolFull verifies that autoPull persists a
+// pending-pool request when no plan slot is available instead of silently
+// returning (#40).
+func TestAutoPullEnqueuesPendingWhenPoolFull(t *testing.T) {
+	st := &pendingStubStore{}
+	st.goals = []types.Goal{
+		{ID: "g1", WorkspaceID: "ws1", Status: types.GoalActive, Title: "t"},
+	}
+	st.issues = []types.Issue{
+		{WorkspaceID: "ws1", Number: 1, State: "open", Column: types.ColTodo},
+	}
+	pool := &stubPool{free: 0} // pool is full
+	spawnHits := 0
+	spawn := func(string, int, string) error { spawnHits++; return nil }
+
+	o := New(eventbus.New(), nil)
+	o.SetStore(st)
+	o.SetAutoPull(pool, spawn)
+
+	o.autoPull("test")
+
+	if spawnHits != 0 {
+		t.Errorf("spawn called %d times on full pool, want 0", spawnHits)
+	}
+	if len(st.enqueued) != 1 {
+		t.Errorf("enqueued %d pending requests, want 1", len(st.enqueued))
+	}
+	if st.enqueued[0].IssueNumber != 1 {
+		t.Errorf("enqueued issue #%d, want #1", st.enqueued[0].IssueNumber)
+	}
+	if st.enqueued[0].Role != types.RolePlan {
+		t.Errorf("enqueued role %q, want plan", st.enqueued[0].Role)
+	}
+}
+
+// TestDrainPendingPoolsSpawns verifies that drainPendingPools fires the spawn
+// callback when a pending request exists and the pool has a free slot.
+func TestDrainPendingPoolsSpawns(t *testing.T) {
+	st := &pendingStubStore{}
+	st.issues = []types.Issue{
+		{WorkspaceID: "ws1", Number: 5, State: "open", Column: types.ColTodo, WaitingForPool: true},
+	}
+	// Pre-populate with a pending request.
+	_ = st.EnqueuePendingPool("ws1", 5, types.RolePlan, "spawn:plan")
+
+	pool := &stubPool{free: 1}
+	spawnHits := 0
+	spawn := func(wsID string, num int, poolID string) error {
+		spawnHits++
+		return nil
+	}
+
+	o := New(eventbus.New(), nil)
+	o.SetStore(st)
+	o.SetAutoPull(pool, spawn)
+	o.drainPendingPools("test")
+
+	if spawnHits != 1 {
+		t.Errorf("drain spawn called %d times, want 1", spawnHits)
+	}
+	if len(st.enqueued) != 0 {
+		t.Errorf("pending queue has %d rows after drain, want 0", len(st.enqueued))
+	}
+}
+
+// TestDrainNoop verifies that drain does nothing when no pending rows exist.
+func TestDrainNoop(t *testing.T) {
+	st := &pendingStubStore{}
+	pool := &stubPool{free: 1}
+	spawnHits := 0
+	spawn := func(string, int, string) error { spawnHits++; return nil }
+
+	o := New(eventbus.New(), nil)
+	o.SetStore(st)
+	o.SetAutoPull(pool, spawn)
+	o.drainPendingPools("test")
+
+	if spawnHits != 0 {
+		t.Errorf("drain spawn called %d times on empty queue, want 0", spawnHits)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -24,6 +24,12 @@ type Store interface {
 	DepCacheGet(workspaceID string, issueNumber int, goalID, bodyHash string) (string, bool, error)
 	DepCachePut(workspaceID string, issueNumber int, goalID, bodyHash string, payload any) error
 	MoveIssueColumn(workspaceID string, number int, column types.BoardColumn) error
+	// Issue #40: pending pool queue.
+	LoadIssue(workspaceID string, number int) (types.Issue, error)
+	EnqueuePendingPool(workspaceID string, issueNumber int, role types.Role, action string) error
+	ListPendingPools(limit int) ([]types.PendingPoolRequest, error)
+	DequeuePendingPool(id int64) error
+	DeletePendingForIssue(workspaceID string, issueNumber int) error
 }
 
 // PoolRouter is the slice of *workerpool.Registry we need (issue #27,
@@ -33,6 +39,7 @@ type Store interface {
 // exclusively — no fallback to work pools.
 type PoolRouter interface {
 	AcquireForPlan(ws types.Workspace) (poolID string, ok bool)
+	AcquireForWork(ws types.Workspace) (poolID string, ok bool) // issue #40 drain
 	ReleaseByPool(poolID string)
 	FreePlanSlots() int
 }
@@ -49,6 +56,10 @@ type LLMResolver func() LLM
 // and threading the Pool through to the session manager.
 type SpawnPlanFunc func(workspaceID string, issueNumber int, poolID string) error
 
+// SpawnWorkFunc mirrors SpawnPlanFunc for execute-mode workers (issue #40
+// pending pool drain for work role).
+type SpawnWorkFunc func(workspaceID string, issueNumber int, poolID string) error
+
 // WorkspaceLookup returns the full Workspace by ID. Optional — when nil, the
 // orchestrator falls back to a bare-ID Workspace, which means PreferredPlanPoolID
 // pinning is ignored (round-robin only).
@@ -60,6 +71,7 @@ type Orchestrator struct {
 	store      Store
 	pool       PoolRouter
 	spawn      SpawnPlanFunc
+	spawnWork  SpawnWorkFunc // issue #40: work-role drain callback
 	lookupWS   WorkspaceLookup
 
 	mu      sync.Mutex
@@ -111,6 +123,13 @@ func (o *Orchestrator) SetAutoPull(pool PoolRouter, spawn SpawnPlanFunc) {
 // works without it (round-robin among plan pools).
 func (o *Orchestrator) SetWorkspaceLookup(f WorkspaceLookup) { o.lookupWS = f }
 
+// SetSpawnWork wires the work-role spawn callback used by the pending-pool
+// drain when draining approve_execute requests (issue #40).
+func (o *Orchestrator) SetSpawnWork(fn SpawnWorkFunc) { o.spawnWork = fn }
+
+// KickDrain triggers a drain pass outside the normal bus flow (e.g. startup).
+func (o *Orchestrator) KickDrain(reason string) { go o.drainPendingPools(reason) }
+
 // handle is the per-event router from §8.
 //
 // Note: LLM-driven runRank is intentionally NOT auto-fired on issue_added /
@@ -139,7 +158,12 @@ func (o *Orchestrator) handle(e eventbus.Event) {
 				o.pool.ReleaseByPool(payload.PoolID)
 			}
 		}
-		go o.autoPull("worker_slot_freed")
+		go func() {
+			// Drain persisted pending requests first (FIFO: earlier approvals
+			// get the freed slot before new auto-pull candidates).
+			o.drainPendingPools("worker_slot_freed")
+			o.autoPull("worker_slot_freed")
+		}()
 	case eventbus.EvtAgentCountChanged:
 		go o.autoPull("agent_count_changed")
 	case eventbus.EvtPlanRejected:
@@ -184,6 +208,16 @@ func (o *Orchestrator) autoPull(reason string) {
 	// Order by priority desc, with blocked items last.
 	sortByOrchestratorPriority(candidates)
 
+	// If all plan slots are taken, enqueue the next candidate so the drain can
+	// retry as soon as a slot frees (issue #40). Skip if nothing is queued.
+	if o.pool.FreePlanSlots() <= 0 {
+		next := pickNextUnblocked(candidates, all)
+		if next != nil {
+			o.enqueuePending(next, types.RolePlan, "spawn:plan")
+		}
+		return
+	}
+
 	for o.pool.FreePlanSlots() > 0 {
 		next := pickNextUnblocked(candidates, all)
 		if next == nil {
@@ -200,8 +234,13 @@ func (o *Orchestrator) autoPull(reason string) {
 		}
 		poolID, ok := o.pool.AcquireForPlan(ws)
 		if !ok {
+			// Race: slot taken between FreePlanSlots() check and AcquireForPlan.
+			// Enqueue and stop — the drain will retry on next slot-freed event.
+			o.enqueuePending(next, types.RolePlan, "spawn:plan")
 			return
 		}
+		// Clear any pre-existing waiting state before moving to PLAN.
+		o.clearWaitingForPool(next.WorkspaceID, next.Number)
 		if err := o.store.MoveIssueColumn(next.WorkspaceID, next.Number, types.ColPlan); err != nil {
 			o.pool.ReleaseByPool(poolID)
 			return

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -21,7 +21,15 @@ func (s *stubStore) ListIssues(string) ([]types.Issue, error) {
 	s.listIssuesHits++
 	return s.issues, nil
 }
-func (s *stubStore) SaveIssue(types.Issue) (bool, error) { return false, nil }
+func (s *stubStore) SaveIssue(iss types.Issue) (bool, error) {
+	for i := range s.issues {
+		if s.issues[i].WorkspaceID == iss.WorkspaceID && s.issues[i].Number == iss.Number {
+			s.issues[i] = iss
+			return false, nil
+		}
+	}
+	return false, nil
+}
 func (s *stubStore) ListGoals() ([]types.Goal, error) {
 	s.listGoalsHits++
 	return s.goals, nil
@@ -32,6 +40,20 @@ func (s *stubStore) DepCacheGet(string, int, string, string) (string, bool, erro
 }
 func (s *stubStore) DepCachePut(string, int, string, string, any) error    { return nil }
 func (s *stubStore) MoveIssueColumn(string, int, types.BoardColumn) error { return nil }
+
+// Issue #40 additions.
+func (s *stubStore) LoadIssue(workspaceID string, number int) (types.Issue, error) {
+	for _, iss := range s.issues {
+		if iss.WorkspaceID == workspaceID && iss.Number == number {
+			return iss, nil
+		}
+	}
+	return types.Issue{}, nil
+}
+func (s *stubStore) EnqueuePendingPool(string, int, types.Role, string) error { return nil }
+func (s *stubStore) ListPendingPools(int) ([]types.PendingPoolRequest, error)  { return nil, nil }
+func (s *stubStore) DequeuePendingPool(int64) error                            { return nil }
+func (s *stubStore) DeletePendingForIssue(string, int) error                   { return nil }
 
 type stubPool struct {
 	free        int
@@ -49,7 +71,8 @@ func (p *stubPool) AcquireForPlan(types.Workspace) (string, bool) {
 	p.free--
 	return "stub-pool", true
 }
-func (p *stubPool) ReleaseByPool(string) { p.releases++; p.free++ }
+func (p *stubPool) AcquireForWork(types.Workspace) (string, bool) { return "", false }
+func (p *stubPool) ReleaseByPool(string)                          { p.releases++; p.free++ }
 
 func TestSetPausedToggles(t *testing.T) {
 	o := New(eventbus.New(), nil)

--- a/internal/orchestrator/select_pool.go
+++ b/internal/orchestrator/select_pool.go
@@ -1,0 +1,17 @@
+package orchestrator
+
+import "prismconductor/internal/types"
+
+// selectPool acquires a slot on the highest-preference available pool for the
+// given role (preference = lowest Priority value, then created_at). Returns
+// the pool ID on success. The registry's acquireRoundRobin already sorts by
+// priority; this wrapper just dispatches to the right role method.
+func (o *Orchestrator) selectPool(ws types.Workspace, role types.Role) (string, bool) {
+	switch role {
+	case types.RolePlan:
+		return o.pool.AcquireForPlan(ws)
+	case types.RoleWork:
+		return o.pool.AcquireForWork(ws)
+	}
+	return "", false
+}

--- a/internal/store/pending_pool.go
+++ b/internal/store/pending_pool.go
@@ -1,0 +1,76 @@
+package store
+
+import (
+	"errors"
+	"time"
+
+	"prismconductor/internal/types"
+)
+
+// EnqueuePendingPool records that the given issue is waiting for a free slot
+// of the specified role. The UNIQUE constraint silently de-duplicates
+// concurrent enqueue attempts for the same (workspace, issue, role, action).
+func (s *Store) EnqueuePendingPool(workspaceID string, issueNumber int, role types.Role, action string) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	_, err := s.DB.Exec(`
+INSERT INTO pending_pool_for (workspace_id, issue_number, role, action, created_at)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(workspace_id, issue_number, role, action) DO NOTHING`,
+		workspaceID, issueNumber, string(role), action, time.Now().Unix())
+	return err
+}
+
+// DequeuePendingPool removes a single pending row by primary key.
+func (s *Store) DequeuePendingPool(id int64) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	_, err := s.DB.Exec(`DELETE FROM pending_pool_for WHERE id = ?`, id)
+	return err
+}
+
+// ListPendingPools returns up to limit pending requests ordered FIFO.
+func (s *Store) ListPendingPools(limit int) ([]types.PendingPoolRequest, error) {
+	if s == nil || s.DB == nil {
+		return nil, errors.New("store unavailable")
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.DB.Query(`
+SELECT id, workspace_id, issue_number, role, action, created_at
+FROM pending_pool_for
+ORDER BY created_at ASC, id ASC
+LIMIT ?`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []types.PendingPoolRequest
+	for rows.Next() {
+		var req types.PendingPoolRequest
+		var role string
+		var createdAt int64
+		if err := rows.Scan(&req.ID, &req.WorkspaceID, &req.IssueNumber, &role, &req.Action, &createdAt); err != nil {
+			return nil, err
+		}
+		req.Role = types.Role(role)
+		req.CreatedAt = time.Unix(createdAt, 0)
+		out = append(out, req)
+	}
+	return out, rows.Err()
+}
+
+// DeletePendingForIssue removes all pending rows for a given issue.
+// Called when a spawn succeeds or when an issue is explicitly cancelled.
+func (s *Store) DeletePendingForIssue(workspaceID string, issueNumber int) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	_, err := s.DB.Exec(
+		`DELETE FROM pending_pool_for WHERE workspace_id = ? AND issue_number = ?`,
+		workspaceID, issueNumber)
+	return err
+}

--- a/internal/store/pools.go
+++ b/internal/store/pools.go
@@ -23,9 +23,9 @@ func (s *Store) ListPools() ([]types.Pool, error) {
 		return nil, errors.New("store unavailable")
 	}
 	rows, err := s.DB.Query(`
-SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at
+SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority
 FROM pools
-ORDER BY created_at ASC, id ASC`)
+ORDER BY priority ASC, created_at ASC, id ASC`)
 	if err != nil {
 		return nil, err
 	}
@@ -47,10 +47,10 @@ func (s *Store) ListPoolsByRole(role types.Role) ([]types.Pool, error) {
 		return nil, errors.New("store unavailable")
 	}
 	rows, err := s.DB.Query(`
-SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at
+SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority
 FROM pools
 WHERE role = ?
-ORDER BY created_at ASC, id ASC`, string(role))
+ORDER BY priority ASC, created_at ASC, id ASC`, string(role))
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (s *Store) GetPool(id string) (types.Pool, error) {
 		return types.Pool{}, errors.New("store unavailable")
 	}
 	row := s.DB.QueryRow(`
-SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at
+SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority
 FROM pools WHERE id = ?`, id)
 	return scanPool(row)
 }
@@ -117,8 +117,8 @@ func (s *Store) SavePool(p types.Pool) error {
 		enabled = 1
 	}
 	_, err := s.DB.Exec(`
-INSERT INTO pools (id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO pools (id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     name = excluded.name,
     provider = excluded.provider,
@@ -127,9 +127,10 @@ ON CONFLICT(id) DO UPDATE SET
     capacity = excluded.capacity,
     enabled = excluded.enabled,
     api_key = excluded.api_key,
-    role = excluded.role`,
+    role = excluded.role,
+    priority = excluded.priority`,
 		p.ID, p.Name, string(p.Provider), p.Endpoint, p.Model,
-		p.Capacity, enabled, p.APIKey, string(p.Role), p.CreatedAt.Unix())
+		p.Capacity, enabled, p.APIKey, string(p.Role), p.CreatedAt.Unix(), p.Priority)
 	return err
 }
 
@@ -167,7 +168,7 @@ func scanPool(r rowScanner) (types.Pool, error) {
 	var enabled int
 	var createdAt int64
 	if err := r.Scan(&p.ID, &p.Name, &provider, &p.Endpoint, &p.Model,
-		&p.Capacity, &enabled, &p.APIKey, &role, &createdAt); err != nil {
+		&p.Capacity, &enabled, &p.APIKey, &role, &createdAt, &p.Priority); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return types.Pool{}, fmt.Errorf("pool not found")
 		}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -162,6 +162,25 @@ CREATE TABLE IF NOT EXISTS pools (
 			return err
 		}
 	}
+	// Issue #40: pool preference ordering. Default 0 keeps existing pools
+	// at equal priority (unchanged behaviour until the user reorders).
+	if _, err := s.DB.Exec(`ALTER TABLE pools ADD COLUMN priority INTEGER NOT NULL DEFAULT 0`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column name") {
+			return err
+		}
+	}
+	// Issue #40: persisted pending-pool queue so restart doesn't lose intent.
+	if _, err := s.DB.Exec(`CREATE TABLE IF NOT EXISTS pending_pool_for (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    workspace_id TEXT NOT NULL,
+    issue_number INTEGER NOT NULL,
+    role         TEXT NOT NULL,
+    action       TEXT NOT NULL,
+    created_at   INTEGER NOT NULL,
+    UNIQUE(workspace_id, issue_number, role, action)
+)`); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -79,6 +79,21 @@ type Pool struct {
 	APIKey    string    `json:"api_key,omitempty"`
 	Role      Role      `json:"role"`
 	CreatedAt time.Time `json:"created_at"`
+	// Priority controls pool selection order within a role group (issue #40).
+	// Lower value = higher preference. Default 0. Pools with equal priority
+	// are tried in ascending created_at order.
+	Priority int `json:"priority"`
+}
+
+// PendingPoolRequest is a persisted "waiting for pool" request. Created when
+// a spawn attempt finds no free slot; drained when a slot frees (issue #40).
+type PendingPoolRequest struct {
+	ID          int64     `json:"id"`
+	WorkspaceID string    `json:"workspace_id"`
+	IssueNumber int       `json:"issue_number"`
+	Role        Role      `json:"role"`
+	Action      string    `json:"action"`
+	CreatedAt   time.Time `json:"created_at"`
 }
 
 // Role names which step in the orchestration loop a pool serves (issue #39).
@@ -172,6 +187,9 @@ type Issue struct {
 	PRNumber     *int        `json:"pr_number,omitempty"`
 	PRURL        string      `json:"pr_url,omitempty"`
 	ArchivedAt   *time.Time  `json:"archived_at,omitempty"`
+	// WaitingForPool is set true when a spawn attempt was queued because no
+	// pool had free capacity (issue #40). Cleared on successful drain.
+	WaitingForPool bool `json:"waiting_for_pool,omitempty"`
 }
 
 type BoardColumn string

--- a/internal/workerpool/pool.go
+++ b/internal/workerpool/pool.go
@@ -227,18 +227,39 @@ func (r *Registry) acquireRoundRobin(role types.Role) (string, bool) {
 		r.mu.Unlock()
 		return "", false
 	}
-	start := 0
-	switch role {
-	case types.RolePlan:
-		start = r.nextPlanIdx % len(ids)
-	case types.RoleWork:
-		start = r.nextWorkIdx % len(ids)
+	// Sort by priority ASC (lower = preferred). Pools with equal priority keep
+	// their insertion order (SliceStable). This implements #40 preference ordering.
+	sort.SliceStable(ids, func(i, j int) bool {
+		return r.meta[ids[i]].Priority < r.meta[ids[j]].Priority
+	})
+	// Apply round-robin within the lowest-priority-value group so equal-priority
+	// pools share load. Higher-priority groups (lower number) are always tried
+	// first before falling back to lower-priority groups.
+	if len(ids) > 0 {
+		topPriority := r.meta[ids[0]].Priority
+		prefixLen := 0
+		for _, id := range ids {
+			if r.meta[id].Priority != topPriority {
+				break
+			}
+			prefixLen++
+		}
+		start := 0
+		switch role {
+		case types.RolePlan:
+			start = r.nextPlanIdx % prefixLen
+			r.nextPlanIdx = (r.nextPlanIdx + 1) % prefixLen
+		case types.RoleWork:
+			start = r.nextWorkIdx % prefixLen
+			r.nextWorkIdx = (r.nextWorkIdx + 1) % prefixLen
+		}
+		// Rotate the preferred group to start at `start`, leave rest unchanged.
+		preferred := append(ids[start:prefixLen:prefixLen], ids[:start]...)
+		ids = append(preferred, ids[prefixLen:]...)
 	}
 	r.mu.Unlock()
 
-	for off := 0; off < len(ids); off++ {
-		idx := (start + off) % len(ids)
-		id := ids[idx]
+	for _, id := range ids {
 		r.mu.RLock()
 		p := r.pools[id]
 		r.mu.RUnlock()
@@ -246,14 +267,6 @@ func (r *Registry) acquireRoundRobin(role types.Role) (string, bool) {
 			continue
 		}
 		if p.TryAcquire() {
-			r.mu.Lock()
-			switch role {
-			case types.RolePlan:
-				r.nextPlanIdx = (idx + 1) % len(ids)
-			case types.RoleWork:
-				r.nextWorkIdx = (idx + 1) % len(ids)
-			}
-			r.mu.Unlock()
 			return id, true
 		}
 	}
@@ -343,7 +356,12 @@ func (r *Registry) Snapshot() []PoolStatus {
 		}
 		out = append(out, PoolStatus{Pool: meta, Active: active})
 	}
+	// Sort by priority ASC, then created_at for tie-breaking (matches pool
+	// selection order so the UI reflects actual acquisition preference).
 	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Pool.Priority != out[j].Pool.Priority {
+			return out[i].Pool.Priority < out[j].Pool.Priority
+		}
 		return out[i].Pool.CreatedAt.Before(out[j].Pool.CreatedAt)
 	})
 	return out

--- a/internal/workerpool/pool_test.go
+++ b/internal/workerpool/pool_test.go
@@ -187,3 +187,38 @@ func TestAcquireForPlan_PrefersWorkspacePin(t *testing.T) {
 		t.Fatalf("AcquireForPlan with pin = (%q, %v), want (p2, true)", id, ok)
 	}
 }
+
+// TestPriorityOrderingPlanPools verifies that a pool with lower Priority value
+// is acquired before a pool with higher Priority value (issue #40).
+func TestPriorityOrderingPlanPools(t *testing.T) {
+	r := NewRegistry(func(types.Provider) bool { return true })
+	// p2 has priority 0 (preferred), p1 has priority 1 (fallback).
+	r.Sync([]types.Pool{
+		{ID: "p1", Provider: types.ProviderClaude, Capacity: 2, Enabled: true, Role: types.RolePlan, Priority: 1},
+		{ID: "p2", Provider: types.ProviderClaude, Capacity: 2, Enabled: true, Role: types.RolePlan, Priority: 0},
+	})
+	id, ok := r.AcquireForPlan(types.Workspace{})
+	if !ok || id != "p2" {
+		t.Fatalf("AcquireForPlan with priority ordering = (%q, %v), want (p2, true)", id, ok)
+	}
+}
+
+// TestPriorityFallbackWhenPreferredFull verifies fallback to lower-preference
+// pool when the preferred pool is at capacity (issue #40).
+func TestPriorityFallbackWhenPreferredFull(t *testing.T) {
+	r := NewRegistry(func(types.Provider) bool { return true })
+	r.Sync([]types.Pool{
+		{ID: "preferred", Provider: types.ProviderClaude, Capacity: 1, Enabled: true, Role: types.RolePlan, Priority: 0},
+		{ID: "fallback", Provider: types.ProviderClaude, Capacity: 1, Enabled: true, Role: types.RolePlan, Priority: 1},
+	})
+	// Fill the preferred pool.
+	first, ok := r.AcquireForPlan(types.Workspace{})
+	if !ok || first != "preferred" {
+		t.Fatalf("first acquire = (%q, %v), want (preferred, true)", first, ok)
+	}
+	// Second acquire should fall back to the fallback pool.
+	second, ok := r.AcquireForPlan(types.Workspace{})
+	if !ok || second != "fallback" {
+		t.Fatalf("second acquire = (%q, %v), want (fallback, true)", second, ok)
+	}
+}


### PR DESCRIPTION
## Summary

- Pools now have an explicit `priority` field (lower = more preferred); drag-reorder in Settings → Pools persists the order immediately via `SavePool`
- When no pool has a free slot, the issue stays in its current column and shows a pink-pulsing **"waiting for available agent pool…"** card decoration; the intent is persisted to `pending_pool_for` and retried on every slot-freed event and at startup
- Pool selection in the registry now respects `priority ASC` before falling back to round-robin within equal-priority groups

## Files modified

- `internal/types/types.go` — `Priority int` on Pool, `WaitingForPool bool` on Issue, new `PendingPoolRequest` type
- `internal/store/sqlite.go` — idempotent migrations: `priority` column on pools, `pending_pool_for` table
- `internal/store/pools.go` — all queries updated for 11-column scan
- `internal/store/pending_pool.go` *(new)* — `EnqueuePendingPool`, `DequeuePendingPool`, `ListPendingPools`, `DeletePendingForIssue`
- `internal/workerpool/pool.go` — `acquireRoundRobin` sorts by priority ASC, round-robin within same-priority group
- `internal/eventbus/bus.go` — `EvtPendingPoolEnqueued`, `EvtPendingPoolDequeued`, `PendingPoolChange` payload
- `internal/orchestrator/orchestrator.go` — extended Store/PoolRouter interfaces, `SpawnWorkFunc`, `KickDrain`; `autoPull` enqueues when pool full; `handle` drains before auto-pull on slot-freed
- `internal/orchestrator/select_pool.go` *(new)* — `selectPool` helper dispatching by role
- `internal/orchestrator/drain_pending_pools.go` *(new)* — `drainPendingPools`, `enqueuePending`, `clearWaitingForPool`
- `app.go` — `SetSpawnWork` callback for work-role drain; startup `KickDrain`; `ApprovePlan` enqueues pending when no work slot
- `frontend/src/style.css` — `card-glow-waiting` pink-pulsing keyframes
- `frontend/src/components/Card.tsx` — `waiting_for_pool` border + pink decoration + tooltip
- `frontend/src/components/PoolsPanel.tsx` — dnd-kit drag-reorder for plan/work role groups; "← preferred" / "← fallback" hints
- `frontend/wailsjs/go/models.ts` — `waiting_for_pool` on Issue, `priority` on Pool (pending `wails generate module` on full build)

## Verification

- **Lint:** `go build ./internal/...` → clean; `tsc --noEmit` → clean
- **Build:** `go build ./internal/...` exit 0
- **Tests:** `go test ./internal/...` — all pass (17 packages, 0 failures); new tests: `TestPriorityOrderingPlanPools`, `TestPriorityFallbackWhenPreferredFull`, `TestAutoPullEnqueuesPendingWhenPoolFull`, `TestDrainPendingPoolsSpawns`, `TestDrainNoop`; `wails build` not run in worktree (requires frontend/dist)

## Notes

- Work-role drain (approve_execute) is wired; requires `LatestPlan` returning a non-nil plan for the drained issue
- Equal-priority pools preserve round-robin load balancing (existing test `TestRoundRobinPlanPools` continues to pass)
- Answers to plan questions: q1=global per-role, q2=leave stale rows for next drain pass, q3=show pool names in tooltip, q4=hide reorder UI for orchestrator role

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-40

Closes #40