### PR TITLE
feat(search): live title search bar in top header (#76)

### DIFF
--- a/app.go
+++ b/app.go
@@ -690,32 +690,6 @@ func (a *App) ListArchivedIssues(workspaceID string) ([]types.Issue, error) {
 	return a.store.ListArchivedIssues(workspaceID)
 }
 
-// FetchIssueDetail returns fresh GitHub metadata for a single issue, cached for
-// 60 s. The frontend calls this lazily on modal open to surface up-to-date
-// body/labels without waiting for the next poll cycle.
-func (a *App) FetchIssueDetail(workspaceID string, issueNumber int) (types.Issue, error) {
-	if a.gh == nil || a.wsReg == nil {
-		return types.Issue{}, fmt.Errorf("github client unavailable")
-	}
-	key := workspaceID + "/" + strconv.Itoa(issueNumber)
-	if v, ok := a.issueDetailCache.Load(key); ok {
-		entry := v.(issueDetailEntry)
-		if time.Now().Before(entry.expiresAt) {
-			return entry.issue, nil
-		}
-	}
-	ws, ok := a.wsReg.Get(workspaceID)
-	if !ok {
-		return types.Issue{}, fmt.Errorf("workspace %q not found", workspaceID)
-	}
-	iss, err := a.gh.GetIssueDetail(a.ctx, ws, issueNumber)
-	if err != nil {
-		return types.Issue{}, err
-	}
-	a.issueDetailCache.Store(key, issueDetailEntry{issue: iss, expiresAt: time.Now().Add(60 * time.Second)})
-	return iss, nil
-}
-
 // ArchiveDone flags every DONE row in the workspace as archived (#34). Returns
 // the count archived. Empty workspaceID archives across every workspace
 // (matches the All switcher case). Publishes EvtIssuesArchived when n > 0 so

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ import { useLabelsStore } from "./stores/labelsStore";
 import { usePoolsStore } from "./stores/usePoolsStore";
 import { Toast } from "./components/Toast";
 import { useToastStore, type Toast as ToastT } from "./stores/toastStore";
+import { TitleSearch } from "./components/Header";
 
 type PlanRef = { workspace_id: string; number: number };
 type PlanTarget = PlanRef | null;
@@ -292,6 +293,7 @@ function App() {
     <div className="h-screen flex flex-col bg-slate-950 text-slate-200">
       <header className="flex items-center justify-between px-4 py-2 border-b border-slate-800">
         <div className="font-semibold">PrismConductor</div>
+        <TitleSearch />
         <div className="flex items-center gap-2">
           {selectedWorkspace && (
             <>

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -17,6 +17,7 @@ import { arrayMove } from "@dnd-kit/sortable";
 import { ArchiveDone, FilterIssuesByActiveGoal } from "../../wailsjs/go/main/App";
 import { types } from "../../wailsjs/go/models";
 import { useIssueStore, Column as ColumnID } from "../stores/issueStore";
+import { matchesQuery } from "../lib/matchesQuery";
 import { useWorkspaceStore } from "../stores/workspaceStore";
 import { Card } from "./Card";
 import { Column } from "./Column";
@@ -54,7 +55,7 @@ const fromCardID = (id: string) => {
 };
 
 export function Board({ onCardClick }: { onCardClick?: (issue: types.Issue) => void }) {
-  const { issues, refresh, applyLocalMove, applyLocalReorder, moveColumn, reorder } = useIssueStore();
+  const { issues, refresh, applyLocalMove, applyLocalReorder, moveColumn, reorder, searchQuery } = useIssueStore();
   const { workspaces, selectedID } = useWorkspaceStore();
   const [filteredTodoNums, setFilteredTodoNums] = useState<Set<string> | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -111,13 +112,14 @@ export function Board({ onCardClick }: { onCardClick?: (issue: types.Issue) => v
     for (const i of issues) {
       const col = (i.column || "todo") as ColumnID;
       if (col === "todo" && filteredTodoNums && !filteredTodoNums.has(cardID(i))) continue;
+      if (!matchesQuery(i.title, searchQuery)) continue;
       if (out[col]) out[col].push(i);
     }
     // ListIssues already returns by (column, manual_order, number). For TODO, if
     // every item shares manual_order=0 (no human reorder yet), use priority.
     out.todo = sortTodoByPriority(out.todo);
     return out;
-  }, [issues, filteredTodoNums]);
+  }, [issues, filteredTodoNums, searchQuery]);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from "react";
+import { useIssueStore } from "../stores/issueStore";
+
+const DEBOUNCE_MS = 80;
+
+export function TitleSearch() {
+  const setSearchQuery = useIssueStore((s) => s.setSearchQuery);
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setSearchQuery(value), DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [value, setSearchQuery]);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape" && document.activeElement === inputRef.current) {
+        setValue("");
+        setSearchQuery("");
+        inputRef.current?.blur();
+        return;
+      }
+      if (e.key === "/" && document.activeElement !== inputRef.current) {
+        const tag = (document.activeElement as HTMLElement)?.tagName?.toLowerCase();
+        const editable = (document.activeElement as HTMLElement)?.isContentEditable;
+        if (tag === "input" || tag === "textarea" || editable) return;
+        e.preventDefault();
+        inputRef.current?.focus();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [setSearchQuery]);
+
+  function clear() {
+    setValue("");
+    setSearchQuery("");
+    inputRef.current?.focus();
+  }
+
+  return (
+    <div className="relative flex items-center">
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Search title… (/)"
+        aria-label="Search cards by title"
+        className="w-60 bg-slate-900 border border-slate-700 rounded px-2 py-1 pr-6 text-xs text-slate-200 placeholder-slate-500 focus:outline-none focus:border-slate-500"
+      />
+      {value && (
+        <button
+          onClick={clear}
+          aria-label="Clear search"
+          className="absolute right-1.5 text-slate-500 hover:text-slate-300 text-xs leading-none"
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/matchesQuery.test.ts
+++ b/frontend/src/lib/matchesQuery.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { matchesQuery } from "./matchesQuery";
+
+describe("matchesQuery", () => {
+  it("returns true for empty query regardless of title", () => {
+    expect(matchesQuery("hello", "")).toBe(true);
+    expect(matchesQuery(undefined, "")).toBe(true);
+    expect(matchesQuery(null, "")).toBe(true);
+  });
+
+  it("case-insensitive substring match", () => {
+    expect(matchesQuery("Fix Bug", "fix")).toBe(true);
+    expect(matchesQuery("fix bug", "Fix")).toBe(true);
+    expect(matchesQuery("Fix Bug", "FIX BUG")).toBe(true);
+    expect(matchesQuery("some title here", "title")).toBe(true);
+  });
+
+  it("returns false for non-matching query", () => {
+    expect(matchesQuery("hello world", "xyz")).toBe(false);
+  });
+
+  it("returns false for null/undefined title with non-empty query", () => {
+    expect(matchesQuery(null, "x")).toBe(false);
+    expect(matchesQuery(undefined, "x")).toBe(false);
+  });
+});

--- a/frontend/src/lib/matchesQuery.ts
+++ b/frontend/src/lib/matchesQuery.ts
@@ -1,0 +1,5 @@
+export function matchesQuery(title: string | undefined | null, q: string): boolean {
+  if (!q) return true;
+  if (!title) return false;
+  return title.toLowerCase().includes(q.toLowerCase());
+}

--- a/frontend/src/stores/issueStore.ts
+++ b/frontend/src/stores/issueStore.ts
@@ -15,10 +15,12 @@ export type Column = "todo" | "plan" | "in_progress" | "review" | "done";
 type State = {
   issues: types.Issue[];
   loading: boolean;
+  searchQuery: string;
   refresh: (workspaceID?: string) => Promise<void>;
   moveColumn: (workspaceID: string, number: number, column: Column) => Promise<void>;
   reorder: (workspaceID: string, column: Column, ordered: number[]) => Promise<void>;
   remove: (workspaceID: string, number: number) => Promise<void>;
+  setSearchQuery: (q: string) => void;
   // Optimistic local update before backend confirms — keeps drag UX smooth.
   applyLocalMove: (workspaceID: string, number: number, column: Column) => void;
   applyLocalReorder: (workspaceID: string, column: Column, ordered: number[]) => void;
@@ -27,6 +29,8 @@ type State = {
 export const useIssueStore = create<State>((set, get) => ({
   issues: [],
   loading: false,
+  searchQuery: "",
+  setSearchQuery: (q) => set({ searchQuery: q }),
   refresh: async (workspaceID) => {
     set({ loading: true });
     try {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -23,6 +23,10 @@
   "include": [
     "src"
   ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ],
   "references": [
     {
       "path": "./tsconfig.node.json"


### PR DESCRIPTION
## Summary

- Adds a `TitleSearch` component in `Header.tsx` with a ~240px input between the logo and action cluster in the top header
- Typing filters board cards in real time (80ms debounce, case-insensitive substring match); empty columns still show the drop placeholder
- `/` focuses the input (unless another input is active); `Esc` clears and blurs; the clear `✕` button clears and keeps focus
- Search state is ephemeral (not persisted) and lives in `issueStore.searchQuery`; the archived drawer is unaffected

## Files modified

- `frontend/src/components/Header.tsx` — new `TitleSearch` component (search input, clear button, `'/'` / `Esc` keyboard shortcuts)
- `frontend/src/stores/issueStore.ts` — added `searchQuery: string` and `setSearchQuery` to the store
- `frontend/src/components/Board.tsx` — filters the `grouped` useMemo by `matchesQuery(i.title, searchQuery)`
- `frontend/src/lib/matchesQuery.ts` — new utility: case-insensitive substring match, handles null/undefined titles
- `frontend/src/lib/matchesQuery.test.ts` — vitest unit tests (empty query, case-insensitive, non-match, null/undefined)
- `frontend/src/App.tsx` — renders `<TitleSearch />` in the header
- `frontend/tsconfig.json` — excludes `*.test.ts` from main compilation (no vitest installed)
- `app.go` — removed pre-existing duplicate `App.FetchIssueDetail` declaration (the stale second copy at line 696 which used `GetIssueDetail`/value return; kept the complete one at line 642 with fallback, local-field preservation, and pointer return)

## Verification

- **Lint/typecheck:** `npx tsc --noEmit` — exit 0
- **Build:** `wails build` — exit 0 (built in ~8s)
- **Tests:** `go test ./...` — all 9 packages pass; no frontend test runner installed (vitest not in devDependencies), test file written and ready for when vitest is added

## ⚠ No frontend tests run (no runner detected)

`matchesQuery.test.ts` is written in vitest syntax but vitest is not installed. The test file is included in the commit for future use. `tsconfig.json` now excludes `*.test.ts` to prevent tsc from erroring on the unresolved `vitest` import.

## Notes for review

- The `app.go` duplicate removal is a pre-existing bug fix, not part of the original issue scope — the build was broken before this PR due to that conflict. Both functions had the same name/args; the removed one lacked fallback-to-local-mirror and local-field preservation.
- Clear button keeps focus (per plan note: "Clear button clears the input and keeps focus").

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-76

Closes #76