### PR TITLE
feat(smoke): add Playwright startup smoke test + CI workflow (#19)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -19,16 +19,20 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: "20" }
       - name: install wails system deps
-        # Wails on Linux links against GTK3 + WebKit2GTK at build time. The
-        # Ubuntu runner doesn't have these by default; without them `wails dev`
-        # fails before serving the app and Playwright waits the full timeout.
+        # Wails on Linux links against GTK3 + WebKit2GTK at build time AND
+        # initializes GTK at runtime to open a desktop window — even in
+        # `wails dev` mode. The headless GitHub runner has no X display, so
+        # `wails dev` panics with "failed to init GTK" the moment it tries
+        # to create the window. xvfb provides a virtual X server so the
+        # window-init succeeds and the dev URL stays up for the smoke test.
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             libgtk-3-dev \
             libwebkit2gtk-4.0-dev \
             build-essential \
-            pkg-config
+            pkg-config \
+            xvfb
       - name: install wails
         run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
       - name: install frontend deps

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   smoke:
-    runs-on: ubuntu-latest
+    # ubuntu-22.04 ships libwebkit2gtk-4.0-dev in its default apt repos; on
+    # 24.04 only 4.1 is available and Wails v2's default build expects 4.0.
+    # Pin until upstream Wails fully supports 4.1 in the default profile.
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -15,6 +18,17 @@ jobs:
         with: { go-version: "1.25" }
       - uses: actions/setup-node@v4
         with: { node-version: "20" }
+      - name: install wails system deps
+        # Wails on Linux links against GTK3 + WebKit2GTK at build time. The
+        # Ubuntu runner doesn't have these by default; without them `wails dev`
+        # fails before serving the app and Playwright waits the full timeout.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.0-dev \
+            build-essential \
+            pkg-config
       - name: install wails
         run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
       - name: install frontend deps

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,37 @@
+name: smoke
+on:
+  push:
+    branches: ["feat/issue-*", "main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: "1.22" }
+      - uses: actions/setup-node@v4
+        with: { node-version: "20" }
+      - name: install wails
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+      - name: install frontend deps
+        working-directory: frontend
+        run: npm ci
+      - name: install test deps + chromium
+        working-directory: tests
+        run: |
+          npm ci
+          npx playwright install chromium --with-deps
+      - name: smoke
+        run: npx --prefix tests playwright test tests/e2e/startup.spec.ts
+        env:
+          CI: "true"
+      - name: upload trace on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-trace
+          path: test-results/

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
-        with: { go-version: "1.22" }
+        with: { go-version: "1.25" }
       - uses: actions/setup-node@v4
         with: { node-version: "20" }
       - name: install wails

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -43,11 +43,42 @@ jobs:
         run: |
           npm ci
           npx playwright install chromium --with-deps
+      - name: start wails dev
+        # Run wails dev under xvfb-run in the background. We manage the
+        # process here instead of letting Playwright's webServer block
+        # handle it — Playwright's cleanup doesn't reliably traverse the
+        # xvfb-run process tree to kill the inner wails process, and the
+        # job hangs until the 15-minute job timeout fires.
+        run: |
+          set -m
+          xvfb-run --auto-servernum --server-args='-screen 0 1280x800x24' \
+            wails dev -loglevel error > /tmp/wails-dev.log 2>&1 &
+          echo "WAILS_PID=$!" >> "$GITHUB_ENV"
+          # Wait for the dev server to come up. Cap at 4 minutes — first
+          # build pulls deps + compiles cgo + bundles the frontend.
+          for i in $(seq 1 240); do
+            if curl -fsS -o /dev/null http://localhost:34115; then
+              echo "wails dev ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "wails dev did not come up in 240s; tail of log:"
+          tail -100 /tmp/wails-dev.log
+          exit 1
       - name: smoke
         working-directory: tests
         run: npx playwright test e2e/startup.spec.ts
         env:
           CI: "true"
+      - name: stop wails dev
+        if: always()
+        run: |
+          # Kill the wails dev background process and any lingering
+          # Xvfb / wails children. `|| true` because steps with no
+          # matching processes shouldn't fail the job.
+          pkill -9 -f 'wails dev' || true
+          pkill -9 Xvfb || true
       - name: upload trace on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -26,7 +26,8 @@ jobs:
           npm ci
           npx playwright install chromium --with-deps
       - name: smoke
-        run: npx --prefix tests playwright test tests/e2e/startup.spec.ts
+        working-directory: tests
+        run: npx playwright test e2e/startup.spec.ts
         env:
           CI: "true"
       - name: upload trace on failure

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ frontend/dist
 .DS_Store
 *.log
 .prismconductor/
+test-results/

--- a/PRISMCONDUCTOR_PLAN.md
+++ b/PRISMCONDUCTOR_PLAN.md
@@ -1036,6 +1036,8 @@ The conductor ships four universal skills with the binary:
 
 **Authoring stability**: bundled skills are hand-curated and stable. Do NOT use the Phase 7 skill-authoring skills to regenerate them. The recursion stops at one level (Phase 7 authors per-repo skills, not bundled ones).
 
+**Smoke gate (issue #19)**: `conductor-execute` step 10b runs `npx --prefix tests playwright test tests/e2e/startup.spec.ts` after build if the spec exists; prints `⚠ smoke test skipped` and continues (non-blocking) if the spec is absent.
+
 ### 15.8 Graceful Degradation for Bare Repos
 
 The conductor handles missing repo enrichments silently — no warnings, no blocking gates:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ wails dev      # hot-reloading dev server
 wails build    # produces build/bin/prismconductor.app
 ```
 
+## Tests
+
+```bash
+cd tests && npm install && npm run smoke:install && npm run smoke
+```
+
+Playwright smoke test: boots the app via `wails dev`, asserts React mounts into `#root`, and checks for console errors. Runs automatically in CI on every push to `feat/issue-*` and `main`.
+
 ## Status
 
 Day 1 of Phase 1 complete: scaffold + bound demo (`SpawnDemo` calls `claude --version` via PTY and streams output to the SessionDrawer). See open issues for remaining phases.

--- a/internal/skills/bundle/skills/conductor-execute.md
+++ b/internal/skills/bundle/skills/conductor-execute.md
@@ -66,6 +66,7 @@ These run before commit. Failures here are **stop-the-world** events: print `BLO
     - For Go-only: `go build ./...`.
     - For Node-only: `npm run build` (or pnpm/yarn equivalent).
     Non-zero exit → `BLOCKED: build failed — <command> exited <code>` and exit.
+10b. **Smoke test (UI runtime regression gate):** if `tests/e2e/startup.spec.ts` exists in the repo, run `npx --prefix tests playwright test tests/e2e/startup.spec.ts`. Non-zero exit → `BLOCKED: smoke test failed — UI did not mount cleanly; transcript above` and exit, leaving the branch in place. If the spec file does NOT exist (older feature branches / non-Wails workspaces), print `⚠ smoke test skipped — tests/e2e/startup.spec.ts not present in this repo` to the PTY (visible to the user and surfaced in the PR body's verification section) and continue with step 11. Do NOT block.
 11. **Run tests**:
     - If `PRISMCONDUCTOR_TEST_CMD` is set, run it. Else fall back to `go test ./...` for Go projects, `npm test` (or vitest/jest) for Node, `pytest` for Python.
     - Non-zero exit → `BLOCKED: tests failed — <N> failures; full output below` then dump the last 50 lines of test output and exit.
@@ -79,7 +80,7 @@ These run before commit. Failures here are **stop-the-world** events: print `BLO
 15. **Single-PR enforcement (#17, Q6):** before `gh pr create`, run `gh pr list --head <branch> --json number,url`. If non-empty, an earlier resume already opened the PR — append a follow-up comment via `gh pr comment <num> --body-file -` summarizing this leg's work, capture the existing URL, and SKIP `gh pr create`. Otherwise: `gh pr create --draft --base <BASE> --title "<short subject> (#<num>)" --body-file -`. The body should contain:
     - A 1-2 sentence summary
     - The list of files modified
-    - **Verification:** lint command + result, build command + result, test command + result with pass/fail counts
+    - **Verification:** lint command + result, build command + result, smoke command + result (`pass` / `fail` with first console error / `skipped — spec not present`), test command + result with pass/fail counts
     - Anything skipped or flagged for human review
     - `Workspace mode: per-execute worktree at <pwd>` — surfaces the conductor isolation mode for reviewers (run `pwd` to fill the path).
     - The literal trailer line `Closes #<num>`

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  use: { trace: "retain-on-failure" },
+  webServer: {
+    command: "wails dev -loglevel error",
+    url: "http://localhost:34115",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    cwd: ".",
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/tests/e2e/startup.spec.ts
+++ b/tests/e2e/startup.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect, ConsoleMessage } from "@playwright/test";
+
+const BASE_URL = process.env.PRISMCONDUCTOR_DEV_URL ?? "http://localhost:34115";
+const SETTLE_MS = Number(process.env.PRISMCONDUCTOR_SMOKE_SETTLE_MS ?? 5000);
+
+test("app boots, React mounts, no console errors", async ({ page }) => {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+
+  page.on("console", (msg: ConsoleMessage) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+  page.on("pageerror", (err) => pageErrors.push(err.message));
+
+  await page.goto(BASE_URL, { waitUntil: "domcontentloaded" });
+
+  // React must mount something into #root within SETTLE_MS
+  await page.waitForFunction(
+    () => {
+      const root = document.getElementById("root");
+      return !!root && root.children.length > 0;
+    },
+    { timeout: SETTLE_MS },
+  );
+
+  // Soak the rest of the window to catch infinite-render loops + late throws
+  await page.waitForTimeout(SETTLE_MS);
+
+  expect.soft(consoleErrors, `console.error: ${consoleErrors.join(" | ")}`).toEqual([]);
+  expect.soft(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+});

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "prismconductor-tests",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "prismconductor-tests",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "prismconductor-tests",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "smoke": "playwright test tests/e2e/startup.spec.ts",
+    "smoke:install": "playwright install chromium --with-deps"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0"
+  }
+}

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
-  testDir: "./tests/e2e",
+  // testDir is relative to this config (tests/playwright.config.ts), so the
+  // spec at tests/e2e/startup.spec.ts is one segment down.
+  testDir: "./e2e",
   timeout: 30_000,
   expect: { timeout: 10_000 },
   reporter: process.env.CI ? [["github"], ["list"]] : "list",
@@ -11,7 +13,10 @@ export default defineConfig({
     url: "http://localhost:34115",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
-    cwd: ".",
+    // wails dev needs to run from the repo root, which is one level up from
+    // this config file. Without this override, playwright would launch wails
+    // from tests/ and the build would fail on missing wails.json.
+    cwd: "..",
     stdout: "pipe",
     stderr: "pipe",
   },

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -9,10 +9,20 @@ export default defineConfig({
   reporter: process.env.CI ? [["github"], ["list"]] : "list",
   use: { trace: "retain-on-failure" },
   webServer: {
-    command: "wails dev -loglevel error",
+    // On CI (headless Linux) wrap wails dev in xvfb-run so the GTK
+    // window-init succeeds without a real X display. Locally the user's
+    // own Xorg/Quartz handles it natively. Detection via CI=true (set by
+    // GitHub Actions and the same env Playwright already keys on).
+    command: process.env.CI
+      ? "xvfb-run --auto-servernum --server-args=-screen 0 1280x800x24 wails dev -loglevel error"
+      : "wails dev -loglevel error",
     url: "http://localhost:34115",
     reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
+    // First-time build of the Go + frontend bundle on a cold CI runner
+    // can take a while (npm install + go build + bindings). 240s gives
+    // headroom; locally the rebuild is much faster so this is mostly a
+    // CI-only ceiling.
+    timeout: 240_000,
     // wails dev needs to run from the repo root, which is one level up from
     // this config file. Without this override, playwright would launch wails
     // from tests/ and the build would fail on missing wails.json.

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -29,5 +29,11 @@ export default defineConfig({
     cwd: "..",
     stdout: "pipe",
     stderr: "pipe",
+    // Force-shutdown the dev server when tests finish. Without this,
+    // xvfb-run's process tree on CI doesn't relay SIGTERM to wails, so
+    // playwright hangs after the smoke test passes and the job runs out
+    // the 15-minute job timeout. SIGKILL is brutal but acceptable for a
+    // dev process we don't need to flush state from.
+    gracefulShutdown: { signal: "SIGKILL", timeout: 5_000 },
   },
 });

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     // own Xorg/Quartz handles it natively. Detection via CI=true (set by
     // GitHub Actions and the same env Playwright already keys on).
     command: process.env.CI
-      ? "xvfb-run --auto-servernum --server-args=-screen 0 1280x800x24 wails dev -loglevel error"
+      ? "xvfb-run --auto-servernum --server-args='-screen 0 1280x800x24' wails dev -loglevel error"
       : "wails dev -loglevel error",
     url: "http://localhost:34115",
     reuseExistingServer: !process.env.CI,

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -8,32 +8,20 @@ export default defineConfig({
   expect: { timeout: 10_000 },
   reporter: process.env.CI ? [["github"], ["list"]] : "list",
   use: { trace: "retain-on-failure" },
-  webServer: {
-    // On CI (headless Linux) wrap wails dev in xvfb-run so the GTK
-    // window-init succeeds without a real X display. Locally the user's
-    // own Xorg/Quartz handles it natively. Detection via CI=true (set by
-    // GitHub Actions and the same env Playwright already keys on).
-    command: process.env.CI
-      ? "xvfb-run --auto-servernum --server-args='-screen 0 1280x800x24' wails dev -loglevel error"
-      : "wails dev -loglevel error",
-    url: "http://localhost:34115",
-    reuseExistingServer: !process.env.CI,
-    // First-time build of the Go + frontend bundle on a cold CI runner
-    // can take a while (npm install + go build + bindings). 240s gives
-    // headroom; locally the rebuild is much faster so this is mostly a
-    // CI-only ceiling.
-    timeout: 240_000,
-    // wails dev needs to run from the repo root, which is one level up from
-    // this config file. Without this override, playwright would launch wails
-    // from tests/ and the build would fail on missing wails.json.
-    cwd: "..",
-    stdout: "pipe",
-    stderr: "pipe",
-    // Force-shutdown the dev server when tests finish. Without this,
-    // xvfb-run's process tree on CI doesn't relay SIGTERM to wails, so
-    // playwright hangs after the smoke test passes and the job runs out
-    // the 15-minute job timeout. SIGKILL is brutal but acceptable for a
-    // dev process we don't need to flush state from.
-    gracefulShutdown: { signal: "SIGKILL", timeout: 5_000 },
-  },
+  // No webServer block on CI: the workflow starts wails dev under xvfb-run
+  // explicitly and kills it afterward. Playwright's webServer cleanup
+  // doesn't reliably propagate SIGTERM through xvfb-run's process tree on
+  // GitHub runners, leaving the job hanging until the 15-minute kill.
+  // Locally we still launch wails dev via webServer for ergonomics.
+  webServer: process.env.CI
+    ? undefined
+    : {
+        command: "wails dev -loglevel error",
+        url: "http://localhost:34115",
+        reuseExistingServer: true,
+        timeout: 240_000,
+        cwd: "..",
+        stdout: "pipe",
+        stderr: "pipe",
+      },
 });


### PR DESCRIPTION
Wires up a Playwright smoke test that boots the app via `wails dev`, asserts React mounts into `#root`, and checks for console/page errors. Inserts as step 10b in `conductor-execute` (post-build, pre-unit-tests). CI workflow runs on every push to `feat/issue-*` and `main` on ubuntu-latest.

## Files modified

- `tests/e2e/startup.spec.ts` — Playwright spec (new)
- `tests/package.json` — separate test package with `@playwright/test` (new)
- `playwright.config.ts` — Playwright config with `webServer: wails dev` (new)
- `.github/workflows/smoke.yml` — CI workflow, ubuntu-latest only (new)
- `internal/skills/bundle/skills/conductor-execute.md` — inserted step 10b smoke gate + updated PR body Verification bullet
- `PRISMCONDUCTOR_PLAN.md` — one-line note in §15.7
- `README.md` — `### Tests` subsection
- `.gitignore` — added `test-results/`

## Verification

- **Lint:** `go vet ./...` — pre-existing failure (`all:frontend/dist` embed pattern, `main.go:11` requires built frontend; not introduced by this change, confirmed by stash test)
- **Build:** `wails build` — ✅ exit 0 (9.6s)
- **Smoke:** spec not yet installed in CI; local `playwright.config.ts` present and correct; `tests/package.json` configures `npm run smoke`
- **Tests:** `go test ./...` — ✅ all 10 packages pass (exit 0)

## Notes for human review

- `tests/package-lock.json` is absent (no `npm install` run here — CI uses `npm ci` which requires it). First `npm install` in `tests/` will generate it; that commit should follow this PR.
- The `go vet` failure on `main.go:11` is pre-existing and unrelated to this change.

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-19

Closes #19