### PR TITLE
feat(#80): add Continue work flow for REVIEW-column cards

### DIFF
--- a/app.go
+++ b/app.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -1955,6 +1956,113 @@ func (a *App) ApprovePlan(workspaceID string, issueNumber, revision int) error {
 		"revision":     revision,
 	})
 	return nil
+}
+
+// ContinueWork spawns an execute worker to continue existing PR work after
+// review feedback or test failures. The note describes what to fix; it is
+// written to .prismconductor/notes/<issueNumber>.txt and mirrored into the
+// feature-branch worktree for the conductor-continue skill to read.
+func (a *App) ContinueWork(workspaceID string, issueNumber int, note string) error {
+	if a.wsReg == nil || a.store == nil || a.mgr == nil {
+		return fmt.Errorf("registry/store/manager unavailable")
+	}
+	if strings.TrimSpace(note) == "" {
+		return fmt.Errorf("note is required")
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return fmt.Errorf("unknown workspace %q", workspaceID)
+	}
+	issue, err := a.store.LoadIssue(workspaceID, issueNumber)
+	if err != nil {
+		return fmt.Errorf("load issue: %w", err)
+	}
+	if issue.Column != types.ColReview {
+		return fmt.Errorf("issue #%d is not in REVIEW column (got %q)", issueNumber, issue.Column)
+	}
+	if a.hasActiveExecuteSession(workspaceID, issueNumber) {
+		return fmt.Errorf("issue #%d already has an active execute session", issueNumber)
+	}
+	plan, err := a.store.LatestPlan(workspaceID, issueNumber)
+	if err != nil {
+		return fmt.Errorf("load plan: %w", err)
+	}
+	if plan == nil {
+		return fmt.Errorf("no plan found for issue #%d", issueNumber)
+	}
+	notesDir := filepath.Join(ws.RepoPath, ".prismconductor", "notes")
+	if err := os.MkdirAll(notesDir, 0o755); err != nil {
+		return fmt.Errorf("create notes dir: %w", err)
+	}
+	notePath := filepath.Join(notesDir, fmt.Sprintf("%d.txt", issueNumber))
+	if err := os.WriteFile(notePath, []byte(note), 0o644); err != nil {
+		return fmt.Errorf("write note: %w", err)
+	}
+	if err := a.store.MoveIssueColumn(workspaceID, issueNumber, types.ColInProgress); err != nil {
+		return err
+	}
+	pool, ok := a.acquireWorkPool(ws)
+	if !ok {
+		_ = a.store.EnqueuePendingPool(workspaceID, issueNumber, types.RoleWork, "continue_execute")
+		if iss, lerr := a.store.LoadIssue(workspaceID, issueNumber); lerr == nil {
+			iss.WaitingForPool = true
+			_, _ = a.store.SaveIssue(iss)
+		}
+		a.bus.Publish(eventbus.EvtPendingPoolEnqueued, eventbus.PendingPoolChange{
+			WorkspaceID: workspaceID,
+			IssueNumber: issueNumber,
+			Role:        string(types.RoleWork),
+		})
+		return nil
+	}
+	if _, err := a.mgr.SpawnExecuteContinue(ws, issue, *plan, pool); err != nil {
+		a.poolReg.ReleaseByPool(pool.ID)
+		_ = a.store.MoveIssueColumn(workspaceID, issueNumber, types.ColReview)
+		return err
+	}
+	a.bus.Publish(eventbus.EvtPlanApproved, map[string]any{
+		"workspace_id": workspaceID,
+		"issue_number": issueNumber,
+		"revision":     plan.Revision,
+	})
+	return nil
+}
+
+// hasActiveExecuteSession returns true if an execute-mode worker is currently
+// running (or waiting / blocked) for the given issue.
+func (a *App) hasActiveExecuteSession(workspaceID string, number int) bool {
+	if a.mgr == nil {
+		return false
+	}
+	for _, s := range a.mgr.Snapshot() {
+		if s.WorkspaceID != workspaceID || s.IssueNumber != number {
+			continue
+		}
+		if s.Mode != types.ModeExecute {
+			continue
+		}
+		switch s.State {
+		case types.StateRunning, types.StateWaitingForInput, types.StateBlocked:
+			return true
+		}
+	}
+	return false
+}
+
+// FetchPRChecks runs `gh pr checks <prNumber>` in the workspace repo and
+// returns the combined output. Used by the ContinueModal to pre-fill the note
+// textarea with failing check output (q1=A: pre-fill automatically).
+func (a *App) FetchPRChecks(workspaceID string, prNumber int) (string, error) {
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return "", fmt.Errorf("unknown workspace %q", workspaceID)
+	}
+	cmd := exec.Command("gh", "pr", "checks", strconv.Itoa(prNumber), "--fail-fast")
+	cmd.Dir = ws.RepoPath
+	out, _ := cmd.CombinedOutput()
+	// gh pr checks exits non-zero when checks are failing — that's exactly the
+	// case we want to surface, so ignore the error and return the output.
+	return string(out), nil
 }
 
 // RejectPlan moves the card back to TODO and frees the worker slot.

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -12,6 +12,7 @@ import { resolveProviderIcon } from "../lib/providerIcon";
 import { getContrastText } from "../lib/contrast";
 import { LabelManagePopover } from "./LabelManagePopover";
 import { MidRunQuestionModal } from "./MidRunQuestionModal";
+import { ContinueModal } from "./ContinueModal";
 import { cn } from "../lib/cn";
 
 export type CardProps = {
@@ -100,6 +101,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
   const isPrimitive = !blocked && (issue.priority ?? 0) >= 0.7;
 
   const [midRunOpen, setMidRunOpen] = useState(false);
+  const [continueOpen, setContinueOpen] = useState(false);
 
   return (
     <div
@@ -189,6 +191,9 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
         issueNumber={issue.number}
         waitingForPool={issue.waiting_for_pool ?? false}
         pools={pools}
+        column={issue.column}
+        prNumber={issue.pr_number ?? null}
+        onContinue={() => setContinueOpen(true)}
       />
       {pausedSession && pausedSession.pending_question_id && (
         <MidRunQuestionModal
@@ -197,6 +202,15 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
           workspaceID={issue.workspace_id}
           issueNumber={issue.number}
           questionID={pausedSession.pending_question_id}
+        />
+      )}
+      {issue.pr_number != null && (
+        <ContinueModal
+          open={continueOpen}
+          onClose={() => setContinueOpen(false)}
+          workspaceID={issue.workspace_id}
+          issueNumber={issue.number}
+          prNumber={issue.pr_number}
         />
       )}
     </div>
@@ -226,6 +240,9 @@ function StatusRow({
   issueNumber,
   waitingForPool,
   pools,
+  column,
+  prNumber,
+  onContinue,
 }: {
   activeSession: types.Session | null;
   activity: SessionActivity | null;
@@ -240,6 +257,9 @@ function StatusRow({
   issueNumber: number;
   waitingForPool: boolean;
   pools: Record<string, import("../stores/usePoolsStore").PoolEntry>;
+  column: string;
+  prNumber: number | null;
+  onContinue: () => void;
 }) {
   if (pausedSession) {
     return (
@@ -329,6 +349,7 @@ function StatusRow({
       </div>
     );
   }
+  const showContinue = column === "review" && prNumber != null && !activeSession && !pausedSession && !waitingForPool;
   return (
     <div className="text-[11px] text-slate-400 mt-1 flex items-center gap-1.5 flex-wrap">
       {isPrimitive && <span className="text-emerald-400">🔴 primitive</span>}
@@ -342,6 +363,20 @@ function StatusRow({
         issueNumber={issueNumber}
         labels={labels}
       />
+      {showContinue && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onContinue();
+          }}
+          onMouseDown={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+          className="ml-auto px-1.5 py-0.5 rounded text-[10px] border border-purple-700 text-purple-300 hover:border-purple-500 hover:text-purple-200"
+          title="Continue work on this PR branch"
+        >
+          ↻ Continue
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/ContinueModal.tsx
+++ b/frontend/src/components/ContinueModal.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useRef, useState } from "react";
+import { ContinueWork, FetchPRChecks } from "../../wailsjs/go/main/App";
+
+export function ContinueModal({
+  open,
+  onClose,
+  workspaceID,
+  issueNumber,
+  prNumber,
+}: {
+  open: boolean;
+  onClose: () => void;
+  workspaceID: string;
+  issueNumber: number;
+  prNumber: number;
+}) {
+  const [note, setNote] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [fetchingChecks, setFetchingChecks] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-fetch PR checks when modal opens; pre-fill textarea if successful.
+  useEffect(() => {
+    if (!open) {
+      setNote("");
+      setError(null);
+      return;
+    }
+    textareaRef.current?.focus();
+    setFetchingChecks(true);
+    FetchPRChecks(workspaceID, prNumber)
+      .then((out) => {
+        if (out.trim()) setNote(out.trim());
+      })
+      .catch(() => {
+        // Silently ignore — user can type manually.
+      })
+      .finally(() => setFetchingChecks(false));
+  }, [open, workspaceID, prNumber]);
+
+  if (!open) return null;
+
+  async function submit() {
+    if (!note.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await ContinueWork(workspaceID, issueNumber, note.trim());
+      onClose();
+    } catch (e: any) {
+      setError(String(e?.message ?? e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+      <div className="w-[560px] bg-slate-900 border border-purple-700 rounded-lg flex flex-col overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-2 border-b border-slate-800 bg-purple-950/30">
+          <div className="text-slate-200 text-sm">
+            ↻ Continue work — <span className="text-slate-400">#{issueNumber}</span>
+            {prNumber > 0 && (
+              <span className="ml-1 text-slate-500">· PR #{prNumber}</span>
+            )}
+          </div>
+          <button onClick={onClose} className="text-slate-400 hover:text-slate-200">✕</button>
+        </div>
+        <div className="px-4 py-3 space-y-2">
+          <label className="block text-xs text-slate-400">
+            What needs fixing?
+            {fetchingChecks && (
+              <span className="ml-2 text-slate-500 italic">fetching failing checks…</span>
+            )}
+          </label>
+          <textarea
+            ref={textareaRef}
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="e.g. tests failing in TestFoo — expects 200, got 404"
+            rows={6}
+            className="w-full bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm text-slate-100 placeholder-slate-600 resize-none focus:outline-none focus:border-purple-600"
+          />
+          {error && <div className="text-red-400 text-xs">{error}</div>}
+        </div>
+        <div className="px-4 py-2 border-t border-slate-800 flex items-center justify-between gap-2">
+          <div className="text-xs text-slate-500">
+            Spawns a worker on the existing PR branch.
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onClose}
+              disabled={busy}
+              className="px-3 py-1.5 rounded border border-slate-700 text-slate-300 hover:border-slate-500 disabled:opacity-50 text-sm"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={submit}
+              disabled={busy || !note.trim()}
+              className="px-3 py-1.5 rounded bg-purple-600 text-slate-50 hover:bg-purple-500 disabled:opacity-50 text-sm"
+            >
+              {busy ? "Starting…" : "Continue"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -17,6 +17,8 @@ export function AddWorkspace(arg1:types.Workspace):Promise<void>;
 
 export function ApprovePlan(arg1:string,arg2:number,arg3:number):Promise<void>;
 
+export function ContinueWork(arg1:string,arg2:number,arg3:string):Promise<void>;
+
 export function ArchiveDone(arg1:string):Promise<number>;
 
 export function CreateLabel(arg1:string,arg2:types.Label):Promise<types.Label>;
@@ -28,6 +30,8 @@ export function DeleteLabel(arg1:string,arg2:string):Promise<void>;
 export function DeletePool(arg1:string):Promise<void>;
 
 export function FetchIssueDetail(arg1:string,arg2:number):Promise<types.Issue>;
+
+export function FetchPRChecks(arg1:string,arg2:number):Promise<string>;
 
 export function FilterIssuesByActiveGoal(arg1:Array<types.Issue>):Promise<Array<types.Issue>>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -38,8 +38,16 @@ export function DeletePool(arg1) {
   return window['go']['main']['App']['DeletePool'](arg1);
 }
 
+export function ContinueWork(arg1, arg2, arg3) {
+  return window['go']['main']['App']['ContinueWork'](arg1, arg2, arg3);
+}
+
 export function FetchIssueDetail(arg1, arg2) {
   return window['go']['main']['App']['FetchIssueDetail'](arg1, arg2);
+}
+
+export function FetchPRChecks(arg1, arg2) {
+  return window['go']['main']['App']['FetchPRChecks'](arg1, arg2);
 }
 
 export function FilterIssuesByActiveGoal(arg1) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -292,6 +292,72 @@ func (m *Manager) SpawnExecuteResume(ws types.Workspace, issue types.Issue, plan
 	return m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool)
 }
 
+// SpawnExecuteContinue re-enters an execute worker on the existing feature
+// branch to continue work after review feedback or test failures. The worktree
+// is reused if it exists on disk; if missing it is rehydrated from
+// origin/<branch> (q2=A). The user's note must already be written to
+// .prismconductor/notes/<num>.txt in the main checkout before calling this.
+func (m *Manager) SpawnExecuteContinue(ws types.Workspace, issue types.Issue, plan types.Plan, pool types.Pool) (*types.Session, error) {
+	slug := branchSlug(issue.Title)
+	branch := fmt.Sprintf("feat/issue-%d-%s", issue.Number, slug)
+	worktreeDir := filepath.Join(ws.RepoPath, ".prismconductor", "worktrees",
+		fmt.Sprintf("%s-%d", ws.ID, issue.Number))
+
+	if _, err := os.Stat(worktreeDir); err != nil {
+		// Worktree is missing — rehydrate from origin/<branch>.
+		if err2 := pcgit.Add(ws.RepoPath, branch, worktreeDir, branch); err2 != nil {
+			return nil, fmt.Errorf("rehydrate worktree for continue: %w", err2)
+		}
+	}
+
+	if err := mirrorPlanArtifacts(ws.RepoPath, worktreeDir, issue.Number, plan.Revision); err != nil {
+		return nil, fmt.Errorf("mirror plan artifacts: %w", err)
+	}
+	if err := mirrorContinueNote(ws.RepoPath, worktreeDir, issue.Number); err != nil {
+		return nil, fmt.Errorf("mirror continue note: %w", err)
+	}
+
+	args, prompt, err := m.buildExecuteContinueCommand(ws, issue, plan, pool)
+	if err != nil {
+		return nil, err
+	}
+	return m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool)
+}
+
+// mirrorContinueNote copies .prismconductor/notes/<num>.txt from the main
+// checkout into the worktree so the conductor-continue skill can read it.
+func mirrorContinueNote(repoPath, worktreeDir string, num int) error {
+	name := fmt.Sprintf("%d.txt", num)
+	src := filepath.Join(repoPath, ".prismconductor", "notes", name)
+	if _, err := os.Stat(src); os.IsNotExist(err) {
+		return nil // Note missing server-side; skill will BLOCKED with a clear message.
+	}
+	dst := filepath.Join(worktreeDir, ".prismconductor", "notes", name)
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	b, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, b, 0o644)
+}
+
+func (m *Manager) buildExecuteContinueCommand(ws types.Workspace, issue types.Issue, plan types.Plan, pool types.Pool) ([]string, string, error) {
+	return m.providerArgs(pool, executeContinuePrompt(ws, issue, plan))
+}
+
+func executeContinuePrompt(ws types.Workspace, issue types.Issue, plan types.Plan) string {
+	switch ws.SkillProfile.Mode {
+	case types.SkillModeNative:
+		return fmt.Sprintf("%s %d --continue-revision %d", ws.SkillProfile.NativeExecuteCommand, issue.Number, plan.Revision)
+	case types.SkillModeHybrid:
+		return fmt.Sprintf("/conductor-continue --native-cmd %s --issue %d --revision %d", ws.SkillProfile.NativeExecuteCommand, issue.Number, plan.Revision)
+	default:
+		return fmt.Sprintf("/conductor-continue --issue %d --repo %s --revision %d", issue.Number, ws.RepoPath, plan.Revision)
+	}
+}
+
 // branchSlug derives a kebab-case branch suffix from an issue title, lowering
 // case, replacing non-alphanumeric runs with single dashes, capping at 40
 // characters, and falling back to "work" when the title yields nothing.

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -243,3 +243,61 @@ func TestSpawnPersistsPoolID(t *testing.T) {
 		t.Errorf("persisted PoolID = %q, want %q", saved.PoolID, "pool-xyz")
 	}
 }
+
+func TestMirrorContinueNoteCopiesToWorktree(t *testing.T) {
+	repoDir := t.TempDir()
+	worktreeDir := t.TempDir()
+	notesDir := filepath.Join(repoDir, ".prismconductor", "notes")
+	if err := os.MkdirAll(notesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const content = "tests failing in TestFoo — got 404, want 200"
+	if err := os.WriteFile(filepath.Join(notesDir, "42.txt"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := mirrorContinueNote(repoDir, worktreeDir, 42); err != nil {
+		t.Fatalf("mirrorContinueNote: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(worktreeDir, ".prismconductor", "notes", "42.txt"))
+	if err != nil {
+		t.Fatalf("read mirrored note: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("note content = %q, want %q", got, content)
+	}
+}
+
+func TestMirrorContinueNoteNoopWhenMissing(t *testing.T) {
+	repoDir := t.TempDir()
+	worktreeDir := t.TempDir()
+	// No note file written — mirrorContinueNote must succeed silently.
+	if err := mirrorContinueNote(repoDir, worktreeDir, 99); err != nil {
+		t.Fatalf("mirrorContinueNote with missing note: %v", err)
+	}
+	dst := filepath.Join(worktreeDir, ".prismconductor", "notes", "99.txt")
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Errorf("expected no file at %s, got err=%v", dst, err)
+	}
+}
+
+func TestExecuteContinuePromptBundledMode(t *testing.T) {
+	ws := types.Workspace{
+		ID:       "ws-1",
+		RepoPath: "/repo",
+		SkillProfile: types.SkillProfile{
+			Mode: types.SkillModeBundled,
+		},
+	}
+	issue := types.Issue{Number: 80, WorkspaceID: ws.ID}
+	plan := types.Plan{Revision: 2}
+	got := executeContinuePrompt(ws, issue, plan)
+	if !strings.Contains(got, "/conductor-continue") {
+		t.Errorf("bundled prompt %q missing /conductor-continue", got)
+	}
+	if !strings.Contains(got, "--issue 80") {
+		t.Errorf("bundled prompt %q missing --issue 80", got)
+	}
+	if !strings.Contains(got, "--revision 2") {
+		t.Errorf("bundled prompt %q missing --revision 2", got)
+	}
+}

--- a/internal/skills/bundle/skills/conductor-continue.md
+++ b/internal/skills/bundle/skills/conductor-continue.md
@@ -1,0 +1,112 @@
+---
+name: conductor-continue
+description: Continues work on an existing feature branch after review feedback or test failures. Reads the original plan and a user note describing what to fix, makes targeted edits, and pushes commits to the same PR branch. Never creates a new branch.
+---
+
+# conductor-continue
+
+Bundled by PrismConductor.
+
+> This skill runs inside an **existing** git worktree for the feature branch.
+> The branch and worktree already exist on disk. Do NOT create a new branch.
+> Do NOT `git stash`, do NOT `git reset --hard`, do NOT switch branches.
+> The user has asked you to continue work on an open PR by applying targeted
+> changes described in their note.
+
+## Inputs
+
+- `--issue <number>` (required)
+- `--revision <N>` (required — the approved plan revision to reference for context)
+- `--repo <path>` (defaults to cwd)
+
+The user's note describing what to fix is at `.prismconductor/notes/<issue>.txt`
+in the worktree root. Read it first — it is your primary directive.
+
+## Behavior
+
+These steps are mandatory and must run in this order.
+
+### 1. Setup
+
+1. Read `.prismconductor/notes/<issue>.txt` — the user's description of what
+   to fix (required). If absent, print
+   `BLOCKED: continue note missing at .prismconductor/notes/<issue>.txt` and exit.
+2. Read `.prismconductor/plans/<issue>-rev<N>.json` — original plan for context
+   (understand what was being built).
+3. Read `.prismconductor/answers/<issue>-rev<N>.json` (user's question answers,
+   if any — optional).
+4. Read repo conventions: `CLAUDE.md`, `.claude/rules/`.
+
+### 2. Branch hygiene (NON-NEGOTIABLE)
+
+5. Sanity check only — do NOT modify branch state:
+   ```
+   git status --short
+   git branch --show-current     # must start with feat/issue-<num>-
+   ```
+   If `git branch --show-current` does not start with `feat/issue-<num>-`:
+   print `BLOCKED: worktree integrity check failed — branch is <actual>,
+   expected feat/issue-<num>-*` and exit. Do not attempt to recover.
+
+### 3. Implementation
+
+6. Review the user's note carefully. Understand what specifically needs to be
+   fixed (failing tests, lint errors, review feedback, etc.).
+7. Run the relevant checks first to confirm the current state:
+   - If the note mentions failing tests: run the test suite and read the output.
+   - If the note mentions lint errors: run the linter and read the output.
+   - Read the relevant files before editing.
+8. Make **targeted, minimal edits** to address the note. Do NOT invent
+   unrelated changes, refactor beyond the note's scope, or modify files not
+   relevant to the fix.
+9. If you hit a question the note didn't cover, invoke `/conductor-question`
+   before staging any changes.
+
+### 4. Verification gates (NON-NEGOTIABLE — block on failure)
+
+These run before commit. Failures are stop-the-world events.
+
+10. **Lint / typecheck** every changed surface:
+    - Go files touched → `go vet ./...` (or `PRISMCONDUCTOR_LINT_CMD` if set).
+    - TypeScript files touched → `npx tsc --noEmit` from the relevant frontend dir.
+    - Any non-zero exit → `BLOCKED: lint failed — <command> exited <code>` and exit.
+11. **Build** the project:
+    - Wails project: `wails build` from repo root.
+    - Go-only: `go build ./...`.
+    - Non-zero exit → `BLOCKED: build failed — <command> exited <code>` and exit.
+12. **Run tests**:
+    - `PRISMCONDUCTOR_TEST_CMD` if set, else `go test ./...` for Go, `npm test` for Node.
+    - Non-zero exit → `BLOCKED: tests failed — <N> failures; full output below` then dump last 50 lines and exit.
+
+### 5. Commit + push + PR (NON-NEGOTIABLE)
+
+13. `git add` only the files you modified (never `git add -A`).
+14. Commit with message:
+    ```
+    chore(issue-<num>): continue work — <first line of user note>
+
+    Closes #<num>
+
+    Co-Authored-By: PrismConductor worker <noreply@anthropic.com>
+    ```
+15. `git push` to the current branch (do NOT force-push).
+16. **Single-PR enforcement:** run `gh pr list --head <branch> --json number,url`.
+    - If a PR already exists: post a follow-up comment summarizing this leg's
+      work via `gh pr comment <num> --body "..."`. Use the existing PR URL.
+      Do NOT open a new PR.
+    - If no PR exists (defensive case): open one with
+      `gh pr create --draft --title "Continue: <first line of note> (#<num>)" --body "..."`.
+17. Capture the PR URL.
+
+### 6. Sentinels
+
+18. Print `PR_OPENED: <url>` on its own line (same URL as the existing PR).
+19. Print `Work complete.`
+
+### Failure paths (NON-NEGOTIABLE)
+
+If you cannot complete this skill for ANY reason, your last printed line MUST
+start with `BLOCKED: ` followed by a one-line reason.
+
+`Work complete.` and `PR_OPENED:` are reserved for the success path only —
+never print them on a failure.


### PR DESCRIPTION
## Summary

- Adds a **↻ Continue** button to REVIEW-column cards that have an open PR. Clicking opens `ContinueModal` with a pre-filled textarea (auto-fetched from `gh pr checks`).
- Submitting spawns a `conductor-continue` worker on the existing feature branch (rehydrating the worktree via `git worktree add` if missing) and pushes commits to the same PR.
- Single-PR enforcement: the new skill posts a follow-up comment if a PR already exists rather than opening a new one.

## Files modified

- `app.go` — `ContinueWork`, `hasActiveExecuteSession`, `FetchPRChecks` bindings
- `internal/session/manager.go` — `SpawnExecuteContinue`, `mirrorContinueNote`, `executeContinuePrompt`
- `internal/session/manager_test.go` — tests for `mirrorContinueNote` and `executeContinuePrompt`
- `internal/skills/bundle/skills/conductor-continue.md` — new bundled skill
- `frontend/src/components/Card.tsx` — Continue button in StatusRow for REVIEW cards
- `frontend/src/components/ContinueModal.tsx` — new modal component
- `frontend/wailsjs/go/main/App.d.ts` / `App.js` — `ContinueWork` and `FetchPRChecks` bindings

## Verification

- **Lint:** `go vet prismconductor/internal/...` → passed
- **TypeScript:** `node_modules/.bin/tsc --noEmit` → passed
- **Build:** full `wails build` requires embedded `frontend/dist` (unavailable in worktree; internal packages compile cleanly via `go build prismconductor/internal/...`)
- **Tests:** `go test prismconductor/internal/...` → all pass (session, store, git, harness, orchestrator, planio, types, workerpool, llm)

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-80

Closes #80