### PR TITLE
feat(pools): omit temperature by default, add per-pool override (#85)

### DIFF
--- a/frontend/src/components/PoolEditModal.tsx
+++ b/frontend/src/components/PoolEditModal.tsx
@@ -57,6 +57,9 @@ export function PoolEditModal({
   const [model, setModel] = useState<string>(initial?.model ?? "");
   const [capacity, setCapacity] = useState<number>(initial?.capacity ?? 1);
   const [enabled, setEnabled] = useState<boolean>(initial?.enabled ?? true);
+  const [temperatureStr, setTemperatureStr] = useState<string>(
+    initial?.temperature != null ? String(initial.temperature) : "",
+  );
   const [models, setModels] = useState<string[]>([]);
   const [probing, setProbing] = useState(false);
   const [testResult, setTestResult] = useState<{ ok: boolean; msg: string } | null>(null);
@@ -145,6 +148,7 @@ export function PoolEditModal({
       const finalName = name.trim() || `${providerKind}-${modelTail(model) || "pool"}`;
       // Orchestrator runs are per-call HTTP, capacity is irrelevant. Persist 1.
       const finalCapacity = role === "orchestrator" ? 1 : capacity;
+      const parsedTemp = temperatureStr.trim() === "" ? undefined : parseFloat(temperatureStr);
       const pool = types.Pool.createFrom({
         id: initial?.id ?? "",
         name: finalName,
@@ -156,6 +160,7 @@ export function PoolEditModal({
         api_key: apiKey,
         role,
         created_at: initial?.created_at ?? new Date().toISOString(),
+        temperature: (parsedTemp != null && !isNaN(parsedTemp)) ? parsedTemp : undefined,
       });
       await SavePool(pool);
       onSaved();
@@ -312,6 +317,23 @@ export function PoolEditModal({
               placeholder={`${providerKind}-${modelTail(model) || "pool"}`}
               className="w-full bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-100 font-mono text-xs"
             />
+          </div>
+
+          <div>
+            <div className="text-xs text-slate-500 mb-1">Temperature (optional)</div>
+            <input
+              type="number"
+              min={0}
+              max={2}
+              step={0.01}
+              value={temperatureStr}
+              onChange={(e) => setTemperatureStr(e.target.value)}
+              placeholder="leave empty to use provider default"
+              className="w-full bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-100 font-mono text-xs"
+            />
+            <div className="text-[11px] text-slate-500 mt-1">
+              Leave empty for models that reject explicit temperature (e.g. gpt-5-codex). Set 0.0 for deterministic output.
+            </div>
           </div>
 
           <label className="flex items-center gap-2 text-xs text-slate-300">

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1252,11 +1252,12 @@ export namespace types {
 	    // Go type: time
 	    created_at: any;
 	    priority: number;
-	
+	    temperature?: number;
+
 	    static createFrom(source: any = {}) {
 	        return new Pool(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -1270,6 +1271,7 @@ export namespace types {
 	        this.role = source["role"];
 	        this.created_at = this.convertValues(source["created_at"], null);
 	        this.priority = source["priority"];
+	        this.temperature = source["temperature"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/llm/litellm.go
+++ b/internal/llm/litellm.go
@@ -72,7 +72,7 @@ func (litellmProvider) SpawnArgs(_ types.Pool, _ string) ([]string, error) {
 
 func (l litellmProvider) ChatJSON(ctx context.Context, p types.Pool, system, user string) (string, error) {
 	endpoint, key := l.resolve(p)
-	return openAICompatChat(ctx, l.client, endpoint, key, p.Model, system, user, nil)
+	return openAICompatChat(ctx, l.client, endpoint, key, p.Model, system, user, p.Temperature, nil)
 }
 
 // ToolChat drives a tool-using turn through LiteLLM's OpenAI-compat endpoint
@@ -80,7 +80,7 @@ func (l litellmProvider) ChatJSON(ctx context.Context, p types.Pool, system, use
 // model emits tool_calls depends on the backend.
 func (l litellmProvider) ToolChat(ctx context.Context, p types.Pool, req ChatRequest) (ChatResponse, error) {
 	endpoint, key := l.resolve(p)
-	return openAIToolChat(ctx, l.client, endpoint, key, p.Model, req, nil)
+	return openAIToolChat(ctx, l.client, endpoint, key, p.Model, req, p.Temperature, nil)
 }
 
 func (l litellmProvider) resolve(p types.Pool) (string, string) {

--- a/internal/llm/lmstudio.go
+++ b/internal/llm/lmstudio.go
@@ -74,7 +74,7 @@ func (lmstudioProvider) SpawnArgs(_ types.Pool, _ string) ([]string, error) {
 
 func (l lmstudioProvider) ChatJSON(ctx context.Context, p types.Pool, system, user string) (string, error) {
 	endpoint := l.resolveEndpoint(p)
-	return openAICompatChat(ctx, l.client, endpoint, p.APIKey, p.Model, system, user, nil)
+	return openAICompatChat(ctx, l.client, endpoint, p.APIKey, p.Model, system, user, p.Temperature, nil)
 }
 
 // ToolChat drives a tool-using turn through LM Studio's OpenAI-compat endpoint
@@ -83,7 +83,7 @@ func (l lmstudioProvider) ChatJSON(ctx context.Context, p types.Pool, system, us
 // harness treats that as a clean stop.
 func (l lmstudioProvider) ToolChat(ctx context.Context, p types.Pool, req ChatRequest) (ChatResponse, error) {
 	endpoint := l.resolveEndpoint(p)
-	return openAIToolChat(ctx, l.client, endpoint, p.APIKey, p.Model, req, nil)
+	return openAIToolChat(ctx, l.client, endpoint, p.APIKey, p.Model, req, p.Temperature, nil)
 }
 
 func (l lmstudioProvider) resolveEndpoint(p types.Pool) string {

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -67,7 +67,7 @@ func (ollamaProvider) SpawnArgs(_ types.Pool, _ string) ([]string, error) {
 // deadline (the orchestrator gives 5 minutes).
 func (o ollamaProvider) ChatJSON(ctx context.Context, p types.Pool, system, user string) (string, error) {
 	endpoint := o.resolveEndpoint(p)
-	return openAICompatChat(ctx, o.client, endpoint, p.APIKey, p.Model, system, user, nil)
+	return openAICompatChat(ctx, o.client, endpoint, p.APIKey, p.Model, system, user, p.Temperature, nil)
 }
 
 // ToolChat drives a tool-using turn through Ollama's OpenAI-compat endpoint
@@ -76,7 +76,7 @@ func (o ollamaProvider) ChatJSON(ctx context.Context, p types.Pool, system, user
 // stop.
 func (o ollamaProvider) ToolChat(ctx context.Context, p types.Pool, req ChatRequest) (ChatResponse, error) {
 	endpoint := o.resolveEndpoint(p)
-	return openAIToolChat(ctx, o.client, endpoint, p.APIKey, p.Model, req, nil)
+	return openAIToolChat(ctx, o.client, endpoint, p.APIKey, p.Model, req, p.Temperature, nil)
 }
 
 func (o ollamaProvider) resolveEndpoint(p types.Pool) string {

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -72,7 +72,7 @@ func (openaiProvider) SpawnArgs(_ types.Pool, _ string) ([]string, error) {
 func (o openaiProvider) ChatJSON(ctx context.Context, p types.Pool, system, user string) (string, error) {
 	endpoint, key := o.resolve(p)
 	onHeaders := o.headerCallback(p)
-	return openAICompatChat(ctx, o.client, endpoint, key, p.Model, system, user, onHeaders)
+	return openAICompatChat(ctx, o.client, endpoint, key, p.Model, system, user, p.Temperature, onHeaders)
 }
 
 // ToolChat drives a tool-using turn against OpenAI's /v1/chat/completions
@@ -80,7 +80,7 @@ func (o openaiProvider) ChatJSON(ctx context.Context, p types.Pool, system, user
 func (o openaiProvider) ToolChat(ctx context.Context, p types.Pool, req ChatRequest) (ChatResponse, error) {
 	endpoint, key := o.resolve(p)
 	onHeaders := o.headerCallback(p)
-	return openAIToolChat(ctx, o.client, endpoint, key, p.Model, req, onHeaders)
+	return openAIToolChat(ctx, o.client, endpoint, key, p.Model, req, p.Temperature, onHeaders)
 }
 
 func (o openaiProvider) resolve(p types.Pool) (string, string) {

--- a/internal/llm/orchestrator_chat.go
+++ b/internal/llm/orchestrator_chat.go
@@ -46,21 +46,27 @@ func openAICompatPath(baseURL, leaf string) string {
 // every provider whose orchestrator path goes through OpenAI-compat (OpenAI,
 // LM Studio, LiteLLM, Ollama).
 //
+// temperature, when non-nil, is sent verbatim. When nil the field is omitted
+// so the provider uses its own default (required for models that reject an
+// explicit temperature, e.g. gpt-5-codex style models).
+//
 // onHeaders, if non-nil, is called with the HTTP response headers so callers
 // can harvest rate-limit metadata (e.g. x-ratelimit-*). Pass nil to skip.
-func openAICompatChat(ctx context.Context, client *http.Client, baseURL, apiKey, model, system, user string, onHeaders func(http.Header)) (string, error) {
+func openAICompatChat(ctx context.Context, client *http.Client, baseURL, apiKey, model, system, user string, temperature *float64, onHeaders func(http.Header)) (string, error) {
 	if model == "" {
 		return "", fmt.Errorf("orchestrator chat: model required")
 	}
 	url := chatCompletionsURL(baseURL)
 	reqBody := map[string]any{
-		"model":       model,
-		"temperature": 0.0,
-		"stream":      false,
+		"model":  model,
+		"stream": false,
 		"messages": []map[string]string{
 			{"role": "system", "content": system},
 			{"role": "user", "content": user},
 		},
+	}
+	if temperature != nil {
+		reqBody["temperature"] = *temperature
 	}
 	body, _ := json.Marshal(reqBody)
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
@@ -146,9 +152,12 @@ func isPaddingOnly(b []byte) bool {
 // Studio, LiteLLM); each provider's ToolChat method resolves endpoint + auth
 // then delegates here.
 //
+// temperature, when non-nil, is sent verbatim. When nil the field is omitted
+// so the provider uses its own default.
+//
 // onHeaders, if non-nil, is called with the HTTP response headers so callers
 // can harvest rate-limit metadata. Pass nil to skip.
-func openAIToolChat(ctx context.Context, client *http.Client, baseURL, apiKey, model string, req ChatRequest, onHeaders func(http.Header)) (ChatResponse, error) {
+func openAIToolChat(ctx context.Context, client *http.Client, baseURL, apiKey, model string, req ChatRequest, temperature *float64, onHeaders func(http.Header)) (ChatResponse, error) {
 	if model == "" {
 		return ChatResponse{}, fmt.Errorf("tool chat: model required")
 	}
@@ -202,10 +211,12 @@ func openAIToolChat(ctx context.Context, client *http.Client, baseURL, apiKey, m
 	}
 
 	body := map[string]any{
-		"model":       model,
-		"temperature": 0.0,
-		"stream":      false,
-		"messages":    msgs,
+		"model":    model,
+		"stream":   false,
+		"messages": msgs,
+	}
+	if temperature != nil {
+		body["temperature"] = *temperature
 	}
 	if len(req.Tools) > 0 {
 		tools := make([]map[string]any, len(req.Tools))

--- a/internal/llm/temperature_test.go
+++ b/internal/llm/temperature_test.go
@@ -1,0 +1,165 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"prismconductor/internal/types"
+)
+
+// captureBody is a minimal httptest.Server that records the last request body
+// and returns a valid chat-completions response.
+func temperatureTestServer(t *testing.T) (*httptest.Server, *[]byte) {
+	t.Helper()
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{}}`))
+	}))
+	return srv, &captured
+}
+
+// TestOpenAICompatChatOmitsTemperatureWhenNil asserts that when Pool.Temperature
+// is nil, the outgoing JSON body does not contain a "temperature" key.
+func TestOpenAICompatChatOmitsTemperatureWhenNil(t *testing.T) {
+	srv, body := temperatureTestServer(t)
+	defer srv.Close()
+
+	client := srv.Client()
+	_, err := openAICompatChat(context.Background(), client, srv.URL, "", "model-x", "sys", "user", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var req map[string]any
+	if err := json.Unmarshal(*body, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := req["temperature"]; ok {
+		t.Errorf("temperature key present in request when Pool.Temperature is nil; body: %s", *body)
+	}
+}
+
+// TestOpenAICompatChatIncludesTemperatureWhenSet asserts that when
+// Pool.Temperature is non-nil, its exact value appears in the request JSON.
+func TestOpenAICompatChatIncludesTemperatureWhenSet(t *testing.T) {
+	srv, body := temperatureTestServer(t)
+	defer srv.Close()
+
+	client := srv.Client()
+	temp := 0.0
+	_, err := openAICompatChat(context.Background(), client, srv.URL, "", "model-x", "sys", "user", &temp, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var req map[string]any
+	if err := json.Unmarshal(*body, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, ok := req["temperature"]
+	if !ok {
+		t.Fatalf("temperature key missing in request; body: %s", *body)
+	}
+	if got != 0.0 {
+		t.Errorf("temperature = %v, want 0.0", got)
+	}
+}
+
+// TestOpenAICompatChatIncludesTemperatureOne asserts temperature=1 round-trips correctly.
+func TestOpenAICompatChatIncludesTemperatureOne(t *testing.T) {
+	srv, body := temperatureTestServer(t)
+	defer srv.Close()
+
+	client := srv.Client()
+	temp := 1.0
+	_, err := openAICompatChat(context.Background(), client, srv.URL, "", "model-x", "sys", "user", &temp, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var req map[string]any
+	if err := json.Unmarshal(*body, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, ok := req["temperature"]
+	if !ok {
+		t.Fatalf("temperature key missing; body: %s", *body)
+	}
+	if got != 1.0 {
+		t.Errorf("temperature = %v, want 1.0", got)
+	}
+}
+
+// TestOpenAIToolChatOmitsTemperatureWhenNil mirrors the CompatChat test for
+// the tool-chat path.
+func TestOpenAIToolChatOmitsTemperatureWhenNil(t *testing.T) {
+	srv, body := temperatureTestServer(t)
+	defer srv.Close()
+
+	client := srv.Client()
+	_, err := openAIToolChat(context.Background(), client, srv.URL, "", "model-x", ChatRequest{System: "s"}, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var req map[string]any
+	if err := json.Unmarshal(*body, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := req["temperature"]; ok {
+		t.Errorf("temperature key present in tool-chat request when nil; body: %s", *body)
+	}
+}
+
+// TestOpenAIToolChatIncludesTemperatureZero asserts temperature=0.0 reaches
+// the wire in the tool-chat path (preserving determinism opt-in).
+func TestOpenAIToolChatIncludesTemperatureZero(t *testing.T) {
+	srv, body := temperatureTestServer(t)
+	defer srv.Close()
+
+	client := srv.Client()
+	temp := 0.0
+	_, err := openAIToolChat(context.Background(), client, srv.URL, "", "model-x", ChatRequest{System: "s"}, &temp, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var req map[string]any
+	if err := json.Unmarshal(*body, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, ok := req["temperature"]
+	if !ok {
+		t.Fatalf("temperature missing in tool-chat request; body: %s", *body)
+	}
+	if got != 0.0 {
+		t.Errorf("tool-chat temperature = %v, want 0.0", got)
+	}
+}
+
+// TestPoolTemperatureRoundTrip asserts that types.Pool.Temperature pointer
+// semantics work as expected: nil vs explicit 0.0.
+func TestPoolTemperatureRoundTrip(t *testing.T) {
+	p1 := types.Pool{Model: "m"}
+	if p1.Temperature != nil {
+		t.Error("Temperature should be nil by default")
+	}
+
+	zero := 0.0
+	p2 := types.Pool{Model: "m", Temperature: &zero}
+	if p2.Temperature == nil || *p2.Temperature != 0.0 {
+		t.Error("Temperature should be 0.0")
+	}
+
+	one := 1.0
+	p3 := types.Pool{Model: "m", Temperature: &one}
+	if p3.Temperature == nil || *p3.Temperature != 1.0 {
+		t.Error("Temperature should be 1.0")
+	}
+}

--- a/internal/store/pools.go
+++ b/internal/store/pools.go
@@ -23,7 +23,7 @@ func (s *Store) ListPools() ([]types.Pool, error) {
 		return nil, errors.New("store unavailable")
 	}
 	rows, err := s.DB.Query(`
-SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority
+SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature
 FROM pools
 ORDER BY priority ASC, created_at ASC, id ASC`)
 	if err != nil {
@@ -47,7 +47,7 @@ func (s *Store) ListPoolsByRole(role types.Role) ([]types.Pool, error) {
 		return nil, errors.New("store unavailable")
 	}
 	rows, err := s.DB.Query(`
-SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority
+SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature
 FROM pools
 WHERE role = ?
 ORDER BY priority ASC, created_at ASC, id ASC`, string(role))
@@ -72,7 +72,7 @@ func (s *Store) GetPool(id string) (types.Pool, error) {
 		return types.Pool{}, errors.New("store unavailable")
 	}
 	row := s.DB.QueryRow(`
-SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority
+SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature
 FROM pools WHERE id = ?`, id)
 	return scanPool(row)
 }
@@ -117,8 +117,8 @@ func (s *Store) SavePool(p types.Pool) error {
 		enabled = 1
 	}
 	_, err := s.DB.Exec(`
-INSERT INTO pools (id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO pools (id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     name = excluded.name,
     provider = excluded.provider,
@@ -128,9 +128,10 @@ ON CONFLICT(id) DO UPDATE SET
     enabled = excluded.enabled,
     api_key = excluded.api_key,
     role = excluded.role,
-    priority = excluded.priority`,
+    priority = excluded.priority,
+    temperature = excluded.temperature`,
 		p.ID, p.Name, string(p.Provider), p.Endpoint, p.Model,
-		p.Capacity, enabled, p.APIKey, string(p.Role), p.CreatedAt.Unix(), p.Priority)
+		p.Capacity, enabled, p.APIKey, string(p.Role), p.CreatedAt.Unix(), p.Priority, p.Temperature)
 	return err
 }
 
@@ -167,8 +168,9 @@ func scanPool(r rowScanner) (types.Pool, error) {
 	var role string
 	var enabled int
 	var createdAt int64
+	var temperature sql.NullFloat64
 	if err := r.Scan(&p.ID, &p.Name, &provider, &p.Endpoint, &p.Model,
-		&p.Capacity, &enabled, &p.APIKey, &role, &createdAt, &p.Priority); err != nil {
+		&p.Capacity, &enabled, &p.APIKey, &role, &createdAt, &p.Priority, &temperature); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return types.Pool{}, fmt.Errorf("pool not found")
 		}
@@ -181,5 +183,8 @@ func scanPool(r rowScanner) (types.Pool, error) {
 	}
 	p.Enabled = enabled != 0
 	p.CreatedAt = time.Unix(createdAt, 0)
+	if temperature.Valid {
+		p.Temperature = &temperature.Float64
+	}
 	return p, nil
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -194,6 +194,13 @@ CREATE TABLE IF NOT EXISTS pools (
 )`); err != nil {
 		return err
 	}
+	// Issue #85: optional per-pool temperature override. NULL = omit from request
+	// (provider uses its default). Non-null = send verbatim (including 0.0).
+	if _, err := s.DB.Exec(`ALTER TABLE pools ADD COLUMN temperature REAL`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column name") {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -83,6 +83,10 @@ type Pool struct {
 	// Lower value = higher preference. Default 0. Pools with equal priority
 	// are tried in ascending created_at order.
 	Priority int `json:"priority"`
+	// Temperature, when non-nil, is sent verbatim in the outgoing chat-completions
+	// request. When nil the field is omitted and the provider uses its default.
+	// This unblocks models that reject an explicit temperature (e.g. gpt-5-codex).
+	Temperature *float64 `json:"temperature,omitempty"`
 }
 
 // PendingPoolRequest is a persisted "waiting for pool" request. Created when


### PR DESCRIPTION
## Summary

- Temperature is no longer hardcoded to `0.0` in OpenAI-compat chat requests. When `Pool.Temperature` is `nil`, the field is omitted entirely so the provider uses its own default — unblocking models like gpt-5-codex that reject an explicit temperature.
- A new optional `Temperature *float64` field on `Pool` lets operators pin a value (including `0.0` for determinism) per pool via the Pool editor.
- DB migration adds a nullable `REAL temperature` column to the `pools` table (idempotent `ALTER TABLE`).

## Files modified

- `internal/types/types.go` — `Temperature *float64` added to `Pool`
- `internal/llm/orchestrator_chat.go` — `openAICompatChat` / `openAIToolChat` accept `temperature *float64`, omit when nil
- `internal/llm/openai.go`, `litellm.go`, `lmstudio.go`, `ollama.go` — pass `p.Temperature` to shared helpers
- `internal/store/sqlite.go` — idempotent `ALTER TABLE pools ADD COLUMN temperature REAL` migration
- `internal/store/pools.go` — SQL read/write includes `temperature`; `scanPool` uses `sql.NullFloat64`
- `frontend/wailsjs/go/models.ts` — `Pool.temperature?: number` added
- `frontend/src/components/PoolEditModal.tsx` — optional numeric temperature input with hint text
- `internal/llm/temperature_test.go` (new) — 6 tests covering nil-omit and explicit-value paths for both `openAICompatChat` and `openAIToolChat`

## Verification

- **Lint:** `go vet ./internal/...` — clean
- **Typecheck:** `node_modules/.bin/tsc --noEmit` — clean
- **Build:** `go build ./internal/...` — clean
- **Tests:** `go test ./internal/...` — all pass (18 packages, 0 failures)

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-85

Closes #85