### PR TITLE
feat(ui): right-click to copy card text, BLOCKED reasons, PR URLs, session lines (#90)

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -14,6 +14,7 @@ import { LabelManagePopover } from "./LabelManagePopover";
 import { MidRunQuestionModal } from "./MidRunQuestionModal";
 import { ContinueModal } from "./ContinueModal";
 import { cn } from "../lib/cn";
+import { CopyMenu, CopyAction, toQuotedBlock } from "./CopyMenu";
 
 export type CardProps = {
   issue: types.Issue;
@@ -102,6 +103,13 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
 
   const [midRunOpen, setMidRunOpen] = useState(false);
   const [continueOpen, setContinueOpen] = useState(false);
+  const [cardMenu, setCardMenu] = useState<{ x: number; y: number; actions: CopyAction[] } | null>(null);
+
+  function openCardMenu(e: React.MouseEvent, actions: CopyAction[]) {
+    e.preventDefault();
+    e.stopPropagation();
+    setCardMenu({ x: e.clientX, y: e.clientY, actions });
+  }
 
   return (
     <div
@@ -166,6 +174,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
               }}
               onMouseDown={(e) => e.stopPropagation()}
               onPointerDown={(e) => e.stopPropagation()}
+              onContextMenu={(e) => openCardMenu(e, [{ label: "Copy PR URL", text: issue.pr_url! }])}
               className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-700/40 text-emerald-200 border border-emerald-700 hover:bg-emerald-700/60"
               title={`Open ${issue.pr_url}`}
             >
@@ -175,7 +184,10 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
           {issue.priority ? <span className="text-slate-500">P{issue.priority.toFixed(2)}</span> : null}
         </span>
       </div>
-      <div className="text-sm text-slate-100 mt-1 line-clamp-2">{issue.title}</div>
+      <div
+        className="text-sm text-slate-100 mt-1 line-clamp-2"
+        onContextMenu={(e) => openCardMenu(e, [{ label: "Copy title", text: issue.title }])}
+      >{issue.title}</div>
 
       <StatusRow
         activeSession={activeSession}
@@ -220,6 +232,14 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
           workspaceID={issue.workspace_id}
           issueNumber={issue.number}
           prNumber={issue.pr_number}
+        />
+      )}
+      {cardMenu && (
+        <CopyMenu
+          x={cardMenu.x}
+          y={cardMenu.y}
+          actions={cardMenu.actions}
+          onClose={() => setCardMenu(null)}
         />
       )}
     </div>
@@ -324,18 +344,36 @@ function StatusRow({
   prNumber: number | null;
   onContinue: () => void;
 }) {
+  const [menu, setMenu] = useState<{ x: number; y: number; actions: CopyAction[] } | null>(null);
+
+  function openMenu(e: React.MouseEvent, actions: CopyAction[]) {
+    e.preventDefault();
+    e.stopPropagation();
+    setMenu({ x: e.clientX, y: e.clientY, actions });
+  }
+
+  const menuEl = menu ? (
+    <CopyMenu x={menu.x} y={menu.y} actions={menu.actions} onClose={() => setMenu(null)} />
+  ) : null;
+
   if (pausedSession) {
     return (
-      <div className="text-[11px] mt-1.5 flex items-center gap-1.5 flex-wrap">
-        <Pulse className="bg-amber-400" />
-        <span className="text-amber-300">❓ awaiting answer</span>
-        <span className="text-slate-500">— click to answer</span>
-      </div>
+      <>
+        <div className="text-[11px] mt-1.5 flex items-center gap-1.5 flex-wrap">
+          <Pulse className="bg-amber-400" />
+          <span className="text-amber-300">❓ awaiting answer</span>
+          <span className="text-slate-500">— click to answer</span>
+        </div>
+        {menuEl}
+      </>
     );
   }
   if (activeSession) {
     const planMode = activeSession.mode === "plan";
     const isBlocked = activeSession.state === "blocked";
+    const blockedReason = isBlocked
+      ? (activeSession.blocked_reason || "BLOCKED: (no reason given)")
+      : null;
     const label = isBlocked
       ? "blocked"
       : activeSession.state === "waiting_for_input"
@@ -347,22 +385,29 @@ function StatusRow({
       : "working";
     const dotCls = isBlocked ? "bg-red-400" : planMode ? "bg-sky-400" : "bg-purple-400";
     const textCls = isBlocked ? "text-red-300" : planMode ? "text-sky-300" : "text-purple-300";
-    const tooltipReason = isBlocked
-      ? truncateForTooltip(activeSession.blocked_reason || "BLOCKED: (no reason given)")
-      : undefined;
     return (
-      <div className="text-[11px] mt-1.5 space-y-0.5">
-        <div className="flex items-center gap-1.5" title={tooltipReason}>
-          <Pulse className={dotCls} />
-          <span className={textCls}>{label}</span>
-          {activity && activity.tool_count > 0 && (
-            <span className="text-slate-500 ml-1">· {activity.tool_count} actions</span>
+      <>
+        <div className="text-[11px] mt-1.5 space-y-0.5">
+          <div
+            className="flex items-center gap-1.5"
+            title={blockedReason ? truncateForTooltip(blockedReason) : undefined}
+            onContextMenu={blockedReason ? (e) => openMenu(e, [
+              { label: "Copy reason", text: blockedReason },
+              { label: "Copy as quoted block", text: toQuotedBlock(blockedReason) },
+            ]) : undefined}
+          >
+            <Pulse className={dotCls} />
+            <span className={textCls}>{label}</span>
+            {activity && activity.tool_count > 0 && (
+              <span className="text-slate-500 ml-1">· {activity.tool_count} actions</span>
+            )}
+          </div>
+          {activity && activity.last_action && (
+            <ActivityHint activity={activity} />
           )}
         </div>
-        {activity && activity.last_action && (
-          <ActivityHint activity={activity} />
-        )}
-      </div>
+        {menuEl}
+      </>
     );
   }
   if (!activeSession && waitingForPool) {
@@ -373,74 +418,92 @@ function StatusRow({
         ? `waiting for an available agent pool — ${poolNames.join(", ")}`
         : "no agent pools configured — add one in Settings → Pools";
     return (
-      <div className="text-[11px] mt-1.5 flex items-center gap-1.5 flex-wrap" title={tooltip}>
-        <Pulse className="bg-pink-400" />
-        <span className="text-pink-300">waiting for available agent pool…</span>
-      </div>
+      <>
+        <div className="text-[11px] mt-1.5 flex items-center gap-1.5 flex-wrap" title={tooltip}>
+          <Pulse className="bg-pink-400" />
+          <span className="text-pink-300">waiting for available agent pool…</span>
+        </div>
+        {menuEl}
+      </>
     );
   }
   if (lastFailure) {
     const reason = lastFailure.blocked_reason || "session ended without success";
     return (
-      <div className="text-[11px] mt-1.5 space-y-0.5" title={reason}>
-        <div className="flex items-center gap-1.5">
-          <Pulse className="bg-red-400" />
-          <span className="text-red-300">blocked</span>
-          <span className="text-slate-500">· {lastFailure.mode}</span>
+      <>
+        <div
+          className="text-[11px] mt-1.5 space-y-0.5"
+          onContextMenu={(e) => openMenu(e, [
+            { label: "Copy reason", text: reason },
+            { label: "Copy as quoted block", text: toQuotedBlock(reason) },
+          ])}
+        >
+          <div className="flex items-center gap-1.5">
+            <Pulse className="bg-red-400" />
+            <span className="text-red-300">blocked</span>
+            <span className="text-slate-500">· {lastFailure.mode}</span>
+          </div>
+          <div className="text-slate-400 break-words" title={reason}>⚠ {reason}</div>
         </div>
-        <div className="text-slate-400 break-words">⚠ {reason}</div>
-      </div>
+        {menuEl}
+      </>
     );
   }
   if (planReady) {
     return (
-      <div className="text-[11px] mt-1.5 flex items-center gap-1.5 flex-wrap">
-        <span className="text-amber-300">⏸ Plan ready (rev {planReady.revision})</span>
-        <span className="text-slate-500">— click to review</span>
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            Replan(workspaceID, issueNumber).catch((err: any) => alert(String(err?.message ?? err)));
-          }}
-          onMouseDown={(e) => e.stopPropagation()}
-          onPointerDown={(e) => e.stopPropagation()}
-          className="ml-auto px-1.5 py-0.5 rounded text-[10px] border border-slate-700 text-slate-400 hover:text-slate-200 hover:border-slate-500"
-          title="Discard the current plan and start a fresh planning pass"
-        >
-          ↻ Re-plan
-        </button>
-      </div>
+      <>
+        <div className="text-[11px] mt-1.5 flex items-center gap-1.5 flex-wrap">
+          <span className="text-amber-300">⏸ Plan ready (rev {planReady.revision})</span>
+          <span className="text-slate-500">— click to review</span>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              Replan(workspaceID, issueNumber).catch((err: any) => alert(String(err?.message ?? err)));
+            }}
+            onMouseDown={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+            className="ml-auto px-1.5 py-0.5 rounded text-[10px] border border-slate-700 text-slate-400 hover:text-slate-200 hover:border-slate-500"
+            title="Discard the current plan and start a fresh planning pass"
+          >
+            ↻ Re-plan
+          </button>
+        </div>
+        {menuEl}
+      </>
     );
   }
   const showContinue = column === "review" && prNumber != null && !activeSession && !pausedSession && !waitingForPool;
   return (
-    <div className="text-[11px] text-slate-400 mt-1 flex items-center gap-1.5 flex-wrap">
-      {isPrimitive && <span className="text-emerald-400">🔴 primitive</span>}
-      {blocked && (
-        <span className="text-amber-300">
-          🚫 blocked by {dependencies.map((n) => `#${n}`).join(", ")}
-        </span>
-      )}
-      <LabelChips
-        workspaceID={workspaceID}
-        issueNumber={issueNumber}
-        labels={labels}
-      />
-      {showContinue && (
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onContinue();
-          }}
-          onMouseDown={(e) => e.stopPropagation()}
-          onPointerDown={(e) => e.stopPropagation()}
-          className="ml-auto px-1.5 py-0.5 rounded text-[10px] border border-purple-700 text-purple-300 hover:border-purple-500 hover:text-purple-200"
-          title="Continue work on this PR branch"
-        >
-          ↻ Continue
-        </button>
-      )}
-    </div>
+    <>
+      <div className="text-[11px] text-slate-400 mt-1 flex items-center gap-1.5 flex-wrap">
+        {isPrimitive && <span className="text-emerald-400">🔴 primitive</span>}
+        {blocked && (
+          <span className="text-amber-300">
+            🚫 blocked by {dependencies.map((n) => `#${n}`).join(", ")}
+          </span>
+        )}
+        <LabelChips
+          workspaceID={workspaceID}
+          issueNumber={issueNumber}
+          labels={labels}
+        />
+        {showContinue && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onContinue();
+            }}
+            onMouseDown={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+            className="ml-auto px-1.5 py-0.5 rounded text-[10px] border border-purple-700 text-purple-300 hover:border-purple-500 hover:text-purple-200"
+            title="Continue work on this PR branch"
+          >
+            ↻ Continue
+          </button>
+        )}
+      </div>
+      {menuEl}
+    </>
   );
 }
 

--- a/frontend/src/components/CopyMenu.test.ts
+++ b/frontend/src/components/CopyMenu.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { toQuotedBlock } from "./CopyMenu";
+
+describe("toQuotedBlock", () => {
+  it("prefixes single-line text with '> '", () => {
+    expect(toQuotedBlock("hello")).toBe("> hello");
+  });
+
+  it("prefixes each line of multi-line text", () => {
+    expect(toQuotedBlock("line1\nline2\nline3")).toBe("> line1\n> line2\n> line3");
+  });
+
+  it("trims leading/trailing whitespace before quoting", () => {
+    expect(toQuotedBlock("  hello  ")).toBe("> hello");
+  });
+
+  it("preserves internal whitespace in each line", () => {
+    expect(toQuotedBlock("BLOCKED: tool denied: wails build\n  detail here")).toBe(
+      "> BLOCKED: tool denied: wails build\n>   detail here",
+    );
+  });
+
+  it("handles empty string after trim", () => {
+    expect(toQuotedBlock("")).toBe("> ");
+  });
+});

--- a/frontend/src/components/CopyMenu.tsx
+++ b/frontend/src/components/CopyMenu.tsx
@@ -1,0 +1,66 @@
+import { useEffect } from "react";
+import { ClipboardSetText } from "../../wailsjs/runtime/runtime";
+
+export type CopyAction = { label: string; text: string };
+
+export function toQuotedBlock(text: string): string {
+  return text
+    .trim()
+    .split("\n")
+    .map((l) => `> ${l}`)
+    .join("\n");
+}
+
+export function CopyMenu({
+  x,
+  y,
+  actions,
+  onClose,
+}: {
+  x: number;
+  y: number;
+  actions: CopyAction[];
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const dismiss = () => onClose();
+    window.addEventListener("pointerdown", dismiss, { capture: true, once: true });
+    window.addEventListener("keydown", dismiss, { once: true });
+    return () => {
+      window.removeEventListener("pointerdown", dismiss, { capture: true });
+      window.removeEventListener("keydown", dismiss);
+    };
+  }, [onClose]);
+
+  async function copy(text: string) {
+    try {
+      await ClipboardSetText(text);
+    } catch {
+      await navigator.clipboard?.writeText(text).catch(() => {});
+    }
+    onClose();
+  }
+
+  return (
+    <div
+      className="fixed bg-slate-800 border border-slate-600 rounded shadow-xl py-1 min-w-[160px]"
+      style={{
+        left: Math.min(x, window.innerWidth - 180),
+        top: Math.min(y, window.innerHeight - actions.length * 32 - 8),
+        zIndex: 9999,
+      }}
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {actions.map((action, i) => (
+        <button
+          key={i}
+          className="block w-full text-left px-3 py-1.5 text-xs text-slate-200 hover:bg-slate-700 whitespace-nowrap"
+          onClick={() => copy(action.text)}
+        >
+          {action.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/IssueSection.tsx
+++ b/frontend/src/components/IssueSection.tsx
@@ -6,9 +6,11 @@ import { FetchIssueDetail } from "../../wailsjs/go/main/App";
 import { types } from "../../wailsjs/go/models";
 import { useLabelsStore } from "../stores/labelsStore";
 import { getContrastText } from "../lib/contrast";
+import { CopyMenu, CopyAction } from "./CopyMenu";
 
 export function IssueSection({ issue }: { issue: types.Issue }) {
   const [detail, setDetail] = useState<types.Issue>(issue);
+  const [titleMenu, setTitleMenu] = useState<{ x: number; y: number; actions: CopyAction[] } | null>(null);
 
   useEffect(() => {
     setDetail(issue);
@@ -24,9 +26,19 @@ export function IssueSection({ issue }: { issue: types.Issue }) {
   return (
     <div className="space-y-3">
       <div className="flex items-start justify-between gap-2">
-        <h2 className="text-base font-semibold text-slate-100 leading-snug">
+        <h2
+          className="text-base font-semibold text-slate-100 leading-snug"
+          onContextMenu={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setTitleMenu({ x: e.clientX, y: e.clientY, actions: [{ label: "Copy title", text: `#${detail.number} — ${detail.title}` }] });
+          }}
+        >
           #{detail.number} — {detail.title}
         </h2>
+        {titleMenu && (
+          <CopyMenu x={titleMenu.x} y={titleMenu.y} actions={titleMenu.actions} onClose={() => setTitleMenu(null)} />
+        )}
         {detail.url && (
           <button
             type="button"

--- a/frontend/src/components/QuestionForm.tsx
+++ b/frontend/src/components/QuestionForm.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { types } from "../../wailsjs/go/models";
+import { CopyMenu, CopyAction } from "./CopyMenu";
 
 export type AnswerState = {
   single: Record<string, string>;
@@ -69,6 +71,8 @@ export function QuestionForm({
   state: AnswerState;
   onChange: (next: AnswerState) => void;
 }) {
+  const [qMenu, setQMenu] = useState<{ x: number; y: number; actions: CopyAction[] } | null>(null);
+
   function setSingle(id: string, value: string) {
     onChange({ ...state, single: { ...state.single, [id]: value } });
   }
@@ -77,8 +81,14 @@ export function QuestionForm({
     const next = cur.includes(value) ? cur.filter((v) => v !== value) : [...cur, value];
     onChange({ ...state, multi: { ...state.multi, [id]: next } });
   }
+  function openQMenu(e: React.MouseEvent, actions: CopyAction[]) {
+    e.preventDefault();
+    e.stopPropagation();
+    setQMenu({ x: e.clientX, y: e.clientY, actions });
+  }
 
   return (
+    <>
     <ol className="space-y-4 list-none p-0">
       {questions.map((q, idx) => {
         const { prompt, expanded } = expandLetterOptions(q.prompt, q.options ?? []);
@@ -89,7 +99,10 @@ export function QuestionForm({
           >
             <div className="flex items-baseline gap-2 mb-2">
               <span className="text-xs font-mono text-slate-500 mt-0.5">{idx + 1}.</span>
-              <div className="flex-1 prose prose-sm prose-invert max-w-none prose-p:my-0 prose-code:text-amber-200 prose-code:bg-slate-950 prose-code:px-1 prose-code:rounded prose-code:before:content-[''] prose-code:after:content-['']">
+              <div
+                className="flex-1 prose prose-sm prose-invert max-w-none prose-p:my-0 prose-code:text-amber-200 prose-code:bg-slate-950 prose-code:px-1 prose-code:rounded prose-code:before:content-[''] prose-code:after:content-['']"
+                onContextMenu={(e) => openQMenu(e, [{ label: "Copy prompt", text: prompt }])}
+              >
                 <ReactMarkdown remarkPlugins={[remarkGfm]}>{prompt}</ReactMarkdown>
               </div>
               {q.required && !q.default && (
@@ -120,6 +133,7 @@ export function QuestionForm({
                           ? "border-sky-600 bg-sky-950/30"
                           : "border-slate-800 hover:border-slate-600 hover:bg-slate-900/60")
                       }
+                      onContextMenu={(e) => openQMenu(e, [{ label: "Copy option", text: opt.label }])}
                     >
                       <input
                         type={q.type === "multi_choice" ? "checkbox" : "radio"}
@@ -212,6 +226,10 @@ export function QuestionForm({
         );
       })}
     </ol>
+    {qMenu && (
+      <CopyMenu x={qMenu.x} y={qMenu.y} actions={qMenu.actions} onClose={() => setQMenu(null)} />
+    )}
+    </>
   );
 }
 

--- a/frontend/src/components/SessionDrawer.tsx
+++ b/frontend/src/components/SessionDrawer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { KillSession, ReadTranscript, SendInput } from "../../wailsjs/go/main/App";
 import { useSessionStore } from "../stores/sessionStore";
+import { CopyMenu, CopyAction } from "./CopyMenu";
 
 const STATE_COLOR: Record<string, string> = {
   running: "text-emerald-400",
@@ -38,6 +39,7 @@ export function SessionDrawer({ open, onClose }: { open: boolean; onClose: () =>
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
   const [verbose, setVerbose] = useState(false);
+  const [lineMenu, setLineMenu] = useState<{ x: number; y: number; actions: CopyAction[] } | null>(null);
   const sess = activeId ? sessions[activeId] : null;
   const noisyRoles = new Set<Role>(["tool", "res", "sys"]);
   const visibleLines = (sess?.lines ?? []).filter((raw) => {
@@ -124,6 +126,11 @@ export function SessionDrawer({ open, onClose }: { open: boolean; onClose: () =>
               <div
                 key={i}
                 className={`rounded px-2 py-1 ${meta.bg} flex gap-2`}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setLineMenu({ x: e.clientX, y: e.clientY, actions: [{ label: "Copy line", text }] });
+                }}
               >
                 {meta.label && (
                   <span className={`shrink-0 font-mono text-[10px] uppercase tracking-wider ${meta.cls} pt-0.5`}>
@@ -139,6 +146,14 @@ export function SessionDrawer({ open, onClose }: { open: boolean; onClose: () =>
           <span className="text-slate-600 px-2">
             {sess?.lines.length ? "all output filtered — toggle verbose to show tool calls" : "no output yet…"}
           </span>
+        )}
+        {lineMenu && (
+          <CopyMenu
+            x={lineMenu.x}
+            y={lineMenu.y}
+            actions={lineMenu.actions}
+            onClose={() => setLineMenu(null)}
+          />
         )}
       </div>
 


### PR DESCRIPTION
## Summary

- Adds `CopyMenu.tsx` — a reusable fixed-position dropdown that writes text to the clipboard via `ClipboardSetText` (Wails runtime) with a fallback to `navigator.clipboard`
- Wires right-click (`onContextMenu`) handlers across five components: **Card** (title, PR chip URL), **StatusRow** (BLOCKED reason + quoted block), **SessionDrawer** (transcript lines), **IssueSection** (issue title), **QuestionForm** (prompt text, option labels)
- BLOCKED reasons get two actions: _Copy reason_ (full untruncated text) and _Copy as quoted block_ (`> ` prefix per line), per user answer to Q2
- All other surfaces get a single _Copy_ action, consistent with user answer to Q1 (native-style, minimal overlay)
- Menu dismisses on click-outside or keydown; position clamped to viewport edges

## Files modified

| File | Intent |
|---|---|
| `frontend/src/components/CopyMenu.tsx` | add — reusable menu + `toQuotedBlock` util |
| `frontend/src/components/CopyMenu.test.ts` | add — unit tests for `toQuotedBlock` |
| `frontend/src/components/Card.tsx` | modify — title, PR chip, BLOCKED status rows |
| `frontend/src/components/SessionDrawer.tsx` | modify — transcript line context menu |
| `frontend/src/components/IssueSection.tsx` | modify — issue title context menu |
| `frontend/src/components/QuestionForm.tsx` | modify — prompt + option context menus |

## Verification

| Step | Command | Result |
|---|---|---|
| Go lint | `go vet ./internal/...` | ✅ pass |
| TypeScript typecheck | `tsc --noEmit` | ✅ pass (0 errors) |
| Build | `wails build` | ✅ pass (11.6s) |
| Smoke test | `npx --prefix tests playwright test ...` | ⚠ skipped — Playwright not installed in tests/ (runner absent) |
| Unit tests | `vitest` | ⚠ vitest not installed in devDependencies — tests written but runner absent; `toQuotedBlock` tests in `CopyMenu.test.ts` will run once vitest is added |

## ⚠ No tests run (no runner detected)

Vitest is referenced in the existing test suite (`matchesQuery.test.ts`) but is not listed in `package.json` devDependencies and not present in `node_modules`. Unit tests for `toQuotedBlock` are written in `CopyMenu.test.ts` and are correct but cannot be executed in this environment.

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-90

Closes #90