### PR TITLE
feat(skills): per-stage skill picker replaces global run-mode (#92)

### DIFF
--- a/app.go
+++ b/app.go
@@ -30,6 +30,7 @@ import (
 	"prismconductor/internal/llm"
 	"prismconductor/internal/orchestrator"
 	"prismconductor/internal/session"
+	"prismconductor/internal/skills"
 	"prismconductor/internal/skills/bundle"
 	"prismconductor/internal/store"
 	"prismconductor/internal/types"
@@ -155,6 +156,8 @@ func (a *App) startup(ctx context.Context) {
 		log.Printf("workspace registry: %v\n", err)
 	} else {
 		a.wsReg = r
+		// Issue #92: one-time migration of legacy Mode/UseConductor* → PerStage.
+		a.migrateWorkspaceSkillProfiles()
 	}
 
 	// Issue #22: prune any orphan worktrees from prior conductor sessions, then
@@ -1496,6 +1499,36 @@ func (a *App) SetAutoPullPaused(paused bool) error {
 		a.orch.KickAutoPull("resumed")
 	}
 	return nil
+}
+
+// --- Skills (§15.7, issue #92) ---
+
+// migrateWorkspaceSkillProfiles runs the one-time migration that synthesizes
+// PerStage from legacy Mode/UseConductor* fields for every workspace.
+func (a *App) migrateWorkspaceSkillProfiles() {
+	if a.wsReg == nil {
+		return
+	}
+	for _, ws := range a.wsReg.List() {
+		if skills.MigrateSkillProfile(&ws.SkillProfile) {
+			if err := a.wsReg.Update(ws); err != nil {
+				log.Printf("skill profile migration for workspace %s: %v", ws.ID, err)
+			}
+		}
+	}
+}
+
+// DiscoverWorkspaceSkills returns all available skills for the given workspace:
+// bundled defaults plus any markdown files discovered in the repo.
+func (a *App) DiscoverWorkspaceSkills(workspaceID string) ([]types.SkillRef, error) {
+	if a.wsReg == nil {
+		return nil, fmt.Errorf("workspace registry not ready")
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return nil, fmt.Errorf("workspace %q not found", workspaceID)
+	}
+	return skills.Discover(ws.RepoPath, bundle.FS)
 }
 
 // --- Bundled skills (§15.7) ---

--- a/frontend/src/components/SkillDropdown.tsx
+++ b/frontend/src/components/SkillDropdown.tsx
@@ -1,0 +1,50 @@
+import { types } from "../../wailsjs/go/models";
+
+const STAGE_LABELS: Record<string, string> = {
+  plan: "Plan",
+  execute: "Execute",
+  continue: "Continue",
+  close: "Close",
+};
+
+export function SkillDropdown({
+  stage,
+  skills,
+  selected,
+  onChange,
+}: {
+  stage: string;
+  skills: types.SkillRef[];
+  selected: types.SkillRef | undefined;
+  onChange: (ref: types.SkillRef) => void;
+}) {
+  const label = STAGE_LABELS[stage] ?? stage;
+  const selectedPath = selected?.path ?? "";
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const ref = skills.find((s) => s.path === e.target.value);
+    if (ref) onChange(ref);
+  }
+
+  return (
+    <label className="flex items-center gap-2">
+      <span className="w-20 text-xs text-slate-400 shrink-0">{label}</span>
+      <select
+        value={selectedPath}
+        onChange={handleChange}
+        className="flex-1 bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-200 text-xs"
+      >
+        {skills.map((s) => (
+          <option key={s.path} value={s.path}>
+            {s.display_name}
+          </option>
+        ))}
+      </select>
+      {selected?.source === "repo" && (
+        <span className="text-[10px] text-amber-400 shrink-0" title={selected.path}>
+          repo
+        </span>
+      )}
+    </label>
+  );
+}

--- a/frontend/src/components/SkillProfileEditor.tsx
+++ b/frontend/src/components/SkillProfileEditor.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
-import { ListPools, UpdateWorkspace } from "../../wailsjs/go/main/App";
+import { DiscoverWorkspaceSkills, ListPools, UpdateWorkspace } from "../../wailsjs/go/main/App";
 import { types, workerpool } from "../../wailsjs/go/models";
 import { useWorkspaceStore } from "../stores/workspaceStore";
+import { SkillDropdown } from "./SkillDropdown";
 
 type SkillMode = "bundled" | "hybrid" | "native";
 const MODES: SkillMode[] = ["bundled", "hybrid", "native"];
@@ -12,15 +13,24 @@ const MODE_DESC: Record<SkillMode, string> = {
   native: "Use only the repo's own skills (PrismEngine pattern).",
 };
 
+const STAGES = ["plan", "execute", "continue", "close"] as const;
+
 export function SkillProfileEditor({ workspace }: { workspace: types.Workspace }) {
   const refresh = useWorkspaceStore((s) => s.refresh);
   const [pools, setPools] = useState<workerpool.PoolStatus[]>([]);
+  const [availableSkills, setAvailableSkills] = useState<types.SkillRef[]>([]);
 
   useEffect(() => {
     ListPools()
       .then((rows) => setPools(rows ?? []))
       .catch((err) => console.error("SkillProfileEditor ListPools", err));
   }, []);
+
+  useEffect(() => {
+    DiscoverWorkspaceSkills(workspace.id)
+      .then((refs) => setAvailableSkills(refs ?? []))
+      .catch((err) => console.error("SkillProfileEditor DiscoverWorkspaceSkills", err));
+  }, [workspace.id]);
 
   async function update(patch: Partial<types.SkillProfile>) {
     const next = new types.Workspace({
@@ -29,6 +39,12 @@ export function SkillProfileEditor({ workspace }: { workspace: types.Workspace }
     });
     await UpdateWorkspace(next);
     await refresh();
+  }
+
+  async function updateStageSkill(stage: string, ref: types.SkillRef) {
+    const perStage = { ...(workspace.skill_profile.per_stage ?? {}) };
+    perStage[stage] = ref;
+    await update({ per_stage: perStage });
   }
 
   const sp = workspace.skill_profile;
@@ -76,6 +92,21 @@ export function SkillProfileEditor({ workspace }: { workspace: types.Workspace }
             value={sp.native_close_command}
             onChange={(v) => update({ native_close_command: v })}
           />
+        </div>
+      )}
+
+      {availableSkills.length > 0 && (
+        <div className="space-y-1.5">
+          <div className="text-xs text-slate-500">Skills per stage</div>
+          {STAGES.map((stage) => (
+            <SkillDropdown
+              key={stage}
+              stage={stage}
+              skills={availableSkills}
+              selected={sp.per_stage?.[stage]}
+              onChange={(ref) => updateStageSkill(stage, ref)}
+            />
+          ))}
         </div>
       )}
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -29,6 +29,8 @@ export function DeleteLabel(arg1:string,arg2:string):Promise<void>;
 
 export function DeletePool(arg1:string):Promise<void>;
 
+export function DiscoverWorkspaceSkills(arg1:string):Promise<Array<types.SkillRef>>;
+
 export function FetchIssueDetail(arg1:string,arg2:number):Promise<types.Issue>;
 
 export function FetchPRChecks(arg1:string,arg2:number):Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -42,6 +42,10 @@ export function DeletePool(arg1) {
   return window['go']['main']['App']['DeletePool'](arg1);
 }
 
+export function DiscoverWorkspaceSkills(arg1) {
+  return window['go']['main']['App']['DiscoverWorkspaceSkills'](arg1);
+}
+
 export function FetchIssueDetail(arg1, arg2) {
   return window['go']['main']['App']['FetchIssueDetail'](arg1, arg2);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1393,6 +1393,26 @@ export namespace types {
 		    return a;
 		}
 	}
+	export class SkillRef {
+	    path: string;
+	    source: string;
+	    name: string;
+	    display_name: string;
+	    description?: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new SkillRef(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.path = source["path"];
+	        this.source = source["source"];
+	        this.name = source["name"];
+	        this.display_name = source["display_name"];
+	        this.description = source["description"];
+	    }
+	}
 	export class SkillProfile {
 	    mode: string;
 	    use_conductor_plan: boolean;
@@ -1405,6 +1425,8 @@ export namespace types {
 	    auto_apply_labels?: boolean;
 	    preferred_plan_pool_id?: string;
 	    preferred_work_pool_id?: string;
+	    per_stage?: Record<string, SkillRef>;
+	    skills_migrated?: boolean;
 	
 	    static createFrom(source: any = {}) {
 	        return new SkillProfile(source);
@@ -1423,8 +1445,29 @@ export namespace types {
 	        this.auto_apply_labels = source["auto_apply_labels"];
 	        this.preferred_plan_pool_id = source["preferred_plan_pool_id"];
 	        this.preferred_work_pool_id = source["preferred_work_pool_id"];
+	        this.per_stage = this.convertValues(source["per_stage"], SkillRef, true);
+	        this.skills_migrated = source["skills_migrated"];
 	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
 	}
+	
 	export class Workspace {
 	    id: string;
 	    display_name: string;

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -33,18 +33,19 @@ import (
 // Run is the per-session input to Execute. Constructed by the session
 // manager; the harness never reads the SQLite store directly.
 type Run struct {
-	SessionID   string
-	RepoPath    string // ws.RepoPath — used for system-prompt enrichment.
-	WorktreeDir string // tool cwd; defaults to RepoPath when empty.
-	Mode        types.SessionMode
-	SkillMode   types.SkillMode
-	Pool        types.Pool
-	Provider    llm.Provider
-	UserPrompt  string  // already rendered by planPrompt / executePrompt.
-	Skills      fs.FS   // bundle.FS
-	EnvVars     []string // ws.AgentEnv flattened for the Bash tool.
-	Budget      Budget
-	Out         io.Writer // synthetic stream-json sink (the session pipe writer).
+	SessionID     string
+	RepoPath      string // ws.RepoPath — used for system-prompt enrichment.
+	WorktreeDir   string // tool cwd; defaults to RepoPath when empty.
+	Mode          types.SessionMode
+	SkillMode     types.SkillMode // DEPRECATED: use SkillMarkdown (issue #92).
+	SkillMarkdown string          // explicit skill markdown; empty falls back to Mode-based lookup.
+	Pool          types.Pool
+	Provider      llm.Provider
+	UserPrompt    string   // already rendered by planPrompt / executePrompt.
+	Skills        fs.FS    // bundle.FS
+	EnvVars       []string // ws.AgentEnv flattened for the Bash tool.
+	Budget        Budget
+	Out           io.Writer // synthetic stream-json sink (the session pipe writer).
 }
 
 // Execute drives the agent loop until: (1) the model emits a sentinel that
@@ -58,19 +59,21 @@ func Execute(ctx context.Context, r Run) error {
 	em := newEmitter(r.Out)
 	em.systemInit()
 
-	// SkillMode is a Claude-CLI-era concept: Hybrid and Native both expect a
-	// repo-side CLI binary to dispatch slash commands. Non-Claude pools have
-	// no such CLI — they run through this harness, which uses the bundled
-	// skill markdown as the system prompt regardless of mode. Silently fall
-	// back to bundled instead of BLOCKEDing the user; the issue-#92 redesign
-	// will retire the mode flag entirely. Until then, treat any non-Bundled
-	// mode as Bundled when the harness is the spawn strategy.
-	if r.SkillMode != "" && r.SkillMode != types.SkillModeBundled {
-		log.Printf("harness: workspace SkillMode=%q has no harness analog; using bundled skill (SessionID=%s, Pool=%s)",
-			r.SkillMode, r.SessionID, r.Pool.ID)
+	var system string
+	var err error
+	if r.SkillMarkdown != "" {
+		// Per-stage skill selected (issue #92): use the provided markdown directly.
+		system, err = assembleSystemPromptWithMarkdown(r.SkillMarkdown, r.RepoPath)
+	} else {
+		// Legacy path: derive skill from Mode. SkillMode is a Claude-CLI-era
+		// concept — Hybrid and Native both expect a repo-side CLI binary.
+		// Non-Claude pools have no such CLI; silently fall back to bundled.
+		if r.SkillMode != "" && r.SkillMode != types.SkillModeBundled {
+			log.Printf("harness: workspace SkillMode=%q has no harness analog; using bundled skill (SessionID=%s, Pool=%s)",
+				r.SkillMode, r.SessionID, r.Pool.ID)
+		}
+		system, err = assembleSystemPrompt(r.Skills, string(r.Mode), r.RepoPath)
 	}
-
-	system, err := assembleSystemPrompt(r.Skills, string(r.Mode), r.RepoPath)
 	if err != nil {
 		em.assistantMessage("BLOCKED: harness skill bundle missing — "+err.Error(), nil)
 		em.done()

--- a/internal/harness/prompts.go
+++ b/internal/harness/prompts.go
@@ -8,6 +8,34 @@ import (
 	"strings"
 )
 
+// assembleSystemPromptWithMarkdown builds the system prompt using an
+// explicitly provided skill markdown instead of reading from the bundle FS.
+// Repo enrichment (CLAUDE.md, .claude/rules/) is appended as before.
+func assembleSystemPromptWithMarkdown(skillMarkdown string, repoPath string) (string, error) {
+	parts := []string{skillMarkdown}
+	if repoPath != "" {
+		if b, err := os.ReadFile(filepath.Join(repoPath, "CLAUDE.md")); err == nil {
+			parts = append(parts, "# Repo CLAUDE.md\n\n"+string(b))
+		}
+		rulesDir := filepath.Join(repoPath, ".claude", "rules")
+		if entries, err := os.ReadDir(rulesDir); err == nil {
+			names := make([]string, 0, len(entries))
+			for _, e := range entries {
+				if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
+					names = append(names, e.Name())
+				}
+			}
+			sort.Strings(names)
+			for _, name := range names {
+				if b, err := os.ReadFile(filepath.Join(rulesDir, name)); err == nil {
+					parts = append(parts, "# Repo rule: "+name+"\n\n"+string(b))
+				}
+			}
+		}
+	}
+	return strings.Join(parts, "\n\n---\n\n"), nil
+}
+
 // assembleSystemPrompt builds the system prompt for a harness run.
 // In Bundled mode (the only mode v1 supports — see §10.5), it concatenates:
 //

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
@@ -23,6 +24,29 @@ import (
 	"prismconductor/internal/skills/bundle"
 	"prismconductor/internal/types"
 )
+
+// loadSkillMarkdown reads the skill markdown for the given stage from the
+// workspace's PerStage configuration. Returns empty string (not an error) when
+// no per-stage skill is configured — the harness falls through to its legacy
+// mode logic.
+func loadSkillMarkdown(ws types.Workspace, stage types.ConductorStage) string {
+	ref, ok := ws.SkillProfile.SkillForStage(stage)
+	if !ok {
+		return ""
+	}
+	switch ref.Source {
+	case "bundled":
+		name := strings.TrimPrefix(ref.Path, "bundled:")
+		if b, err := fs.ReadFile(bundle.FS, "skills/"+name+".md"); err == nil {
+			return string(b)
+		}
+	case "repo":
+		if b, err := os.ReadFile(ref.Path); err == nil {
+			return string(b)
+		}
+	}
+	return ""
+}
 
 // LineHandler receives each PTY output line as it arrives.
 type LineHandler func(sessionID string, line string)
@@ -223,7 +247,8 @@ func (m *Manager) SpawnPlan(ws types.Workspace, issue types.Issue, pool types.Po
 	if err != nil {
 		return nil, err
 	}
-	return m.spawn(ws, issue, types.ModePlan, args, prompt, pool)
+	skillMarkdown := loadSkillMarkdown(ws, types.StagePlan)
+	return m.spawn(ws, issue, types.ModePlan, args, prompt, pool, skillMarkdown)
 }
 
 // SpawnExecute launches an execute-mode worker per §10.2.
@@ -276,7 +301,8 @@ func (m *Manager) SpawnExecute(ws types.Workspace, issue types.Issue, plan types
 		_ = pcgit.Remove(ws.RepoPath, worktreeDir)
 		return nil, err
 	}
-	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool)
+	skillMarkdown := loadSkillMarkdown(ws, types.StageExecute)
+	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool, skillMarkdown)
 	if err != nil {
 		_ = pcgit.Remove(ws.RepoPath, worktreeDir)
 		return nil, err
@@ -301,7 +327,8 @@ func (m *Manager) SpawnExecuteResume(ws types.Workspace, issue types.Issue, plan
 	if err != nil {
 		return nil, err
 	}
-	return m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool)
+	skillMarkdown := loadSkillMarkdown(ws, types.StageContinue)
+	return m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool, skillMarkdown)
 }
 
 // SpawnExecuteContinue re-enters an execute worker on the existing feature
@@ -333,7 +360,8 @@ func (m *Manager) SpawnExecuteContinue(ws types.Workspace, issue types.Issue, pl
 	if err != nil {
 		return nil, err
 	}
-	return m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool)
+	skillMarkdown := loadSkillMarkdown(ws, types.StageContinue)
+	return m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool, skillMarkdown)
 }
 
 // mirrorContinueNote copies .prismconductor/notes/<num>.txt from the main
@@ -360,6 +388,13 @@ func (m *Manager) buildExecuteContinueCommand(ws types.Workspace, issue types.Is
 }
 
 func executeContinuePrompt(ws types.Workspace, issue types.Issue, plan types.Plan) string {
+	if ref, ok := ws.SkillProfile.SkillForStage(types.StageContinue); ok {
+		if ref.Source == "bundled" {
+			return fmt.Sprintf("/%s --issue %d --repo %s --revision %d", ref.Name, issue.Number, ws.RepoPath, plan.Revision)
+		}
+		return fmt.Sprintf("Continue work on issue #%d (revision %d) in repo %s", issue.Number, plan.Revision, ws.RepoPath)
+	}
+	// Legacy fallback.
 	switch ws.SkillProfile.Mode {
 	case types.SkillModeNative:
 		return fmt.Sprintf("%s %d --continue-revision %d", ws.SkillProfile.NativeExecuteCommand, issue.Number, plan.Revision)
@@ -446,11 +481,11 @@ func mirrorPlanArtifacts(repoPath, worktreeDir string, num, rev int) error {
 func (m *Manager) SpawnRaw(ws types.Workspace, name string, args []string) (*types.Session, error) {
 	demoIssue := types.Issue{Number: 0, WorkspaceID: ws.ID}
 	full := append([]string{name}, args...)
-	return m.spawn(ws, demoIssue, types.ModePlan, full, "", types.Pool{})
+	return m.spawn(ws, demoIssue, types.ModePlan, full, "", types.Pool{}, "")
 }
 
-func (m *Manager) spawn(ws types.Workspace, issue types.Issue, mode types.SessionMode, argv []string, prompt string, pool types.Pool) (*types.Session, error) {
-	return m.spawnWithDir(ws, issue, mode, argv, prompt, "", "", pool)
+func (m *Manager) spawn(ws types.Workspace, issue types.Issue, mode types.SessionMode, argv []string, prompt string, pool types.Pool, skillMarkdown string) (*types.Session, error) {
+	return m.spawnWithDir(ws, issue, mode, argv, prompt, "", "", pool, skillMarkdown)
 }
 
 // spawnWithDir is the canonical spawn path. When worktreeDir is non-empty the
@@ -470,7 +505,7 @@ func (m *Manager) spawn(ws types.Workspace, issue types.Issue, mode types.Sessio
 // goroutine drives the agent loop and writes synthesized stream-json into
 // the transcript file. tailAndParse + StreamParser see identical input
 // shape regardless of strategy.
-func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types.SessionMode, argv []string, prompt, worktreeDir, branch string, pool types.Pool) (*types.Session, error) {
+func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types.SessionMode, argv []string, prompt, worktreeDir, branch string, pool types.Pool, skillMarkdown string) (*types.Session, error) {
 	if len(argv) == 0 && prompt == "" {
 		return nil, fmt.Errorf("empty command")
 	}
@@ -557,18 +592,19 @@ func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types
 		go func() {
 			defer close(done)
 			rs.harnessErr = harness.Execute(ctx, harness.Run{
-				SessionID:   sessID,
-				RepoPath:    ws.RepoPath,
-				WorktreeDir: worktreeDir,
-				Mode:        mode,
-				SkillMode:   ws.SkillProfile.Mode,
-				Pool:        pool,
-				Provider:    prov,
-				UserPrompt:  prompt,
-				Skills:      bundle.FS,
-				EnvVars:     envSpecToSlice(ws.AgentEnv),
-				Budget:      harness.DefaultBudget(),
-				Out:         tf,
+				SessionID:     sessID,
+				RepoPath:      ws.RepoPath,
+				WorktreeDir:   worktreeDir,
+				Mode:          mode,
+				SkillMode:     ws.SkillProfile.Mode,
+				SkillMarkdown: skillMarkdown,
+				Pool:          pool,
+				Provider:      prov,
+				UserPrompt:    prompt,
+				Skills:        bundle.FS,
+				EnvVars:       envSpecToSlice(ws.AgentEnv),
+				Budget:        harness.DefaultBudget(),
+				Out:           tf,
 			})
 		}()
 	}
@@ -1021,6 +1057,14 @@ func (m *Manager) providerArgs(pool types.Pool, prompt string) ([]string, string
 }
 
 func planPrompt(ws types.Workspace, issue types.Issue) string {
+	if ref, ok := ws.SkillProfile.SkillForStage(types.StagePlan); ok {
+		if ref.Source == "bundled" {
+			return fmt.Sprintf("/%s --issue %d --repo %s", ref.Name, issue.Number, ws.RepoPath)
+		}
+		// Repo skill: metadata only; system prompt carries the skill markdown.
+		return fmt.Sprintf("Plan issue #%d in repo %s", issue.Number, ws.RepoPath)
+	}
+	// Legacy fallback.
 	switch ws.SkillProfile.Mode {
 	case types.SkillModeNative:
 		return fmt.Sprintf("%s %d --emit-plan-json", ws.SkillProfile.NativePlanCommand, issue.Number)
@@ -1032,6 +1076,13 @@ func planPrompt(ws types.Workspace, issue types.Issue) string {
 }
 
 func executePrompt(ws types.Workspace, issue types.Issue, plan types.Plan) string {
+	if ref, ok := ws.SkillProfile.SkillForStage(types.StageExecute); ok {
+		if ref.Source == "bundled" {
+			return fmt.Sprintf("/%s --issue %d --repo %s --revision %d", ref.Name, issue.Number, ws.RepoPath, plan.Revision)
+		}
+		return fmt.Sprintf("Execute plan for issue #%d (revision %d) in repo %s", issue.Number, plan.Revision, ws.RepoPath)
+	}
+	// Legacy fallback.
 	switch ws.SkillProfile.Mode {
 	case types.SkillModeNative:
 		return fmt.Sprintf("%s %d --resume-from-approved-plan %d", ws.SkillProfile.NativeExecuteCommand, issue.Number, plan.Revision)

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -160,7 +160,7 @@ func TestSpawnWritesToTranscriptFile(t *testing.T) {
 	issue := types.Issue{Number: 1, WorkspaceID: ws.ID}
 	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute,
 		[]string{"/bin/sh", "-c", "echo hello-from-worker; echo Work complete."},
-		"", "", "", types.Pool{})
+		"", "", "", types.Pool{}, "")
 	if err != nil {
 		t.Fatalf("spawnWithDir: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestSpawnPersistsPoolID(t *testing.T) {
 
 	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute,
 		[]string{"/bin/sh", "-c", "echo Work complete."},
-		"", "", "", pool)
+		"", "", "", pool, "")
 	if err != nil {
 		t.Fatalf("spawnWithDir: %v", err)
 	}

--- a/internal/skills/discover.go
+++ b/internal/skills/discover.go
@@ -1,0 +1,97 @@
+// Package skills provides skill discovery and loading helpers (issue #92).
+package skills
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"prismconductor/internal/types"
+)
+
+// repoGlobs are the directory patterns searched for repo-supplied skill files,
+// in priority order. PrismConductor's own directory is first so repo authors
+// can explicitly ship overrides there; common tool directories follow.
+var repoGlobs = []string{
+	".prismconductor/skills/*.md",
+	".claude/commands/*.md",
+	".claude/skills/*.md",
+	".cursor/rules/*.md",
+	".cursor/commands/*.md",
+	".codex/skills/*.md",
+	".codex/commands/*.md",
+}
+
+// Discover returns all available skills for the given workspace. Bundled
+// skills are always listed first. A repo file with the same basename as a
+// bundled skill shadows the bundled entry (issue #92 q2: repo overrides
+// bundled). Discovery errors inside the repo tree are silently skipped so a
+// missing or unreadable directory never blocks a spawn.
+func Discover(repoPath string, bundleFS fs.FS) ([]types.SkillRef, error) {
+	refs, err := listBundled(bundleFS)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build name→index so repo overrides can replace in-place.
+	byName := make(map[string]int, len(refs))
+	for i, r := range refs {
+		byName[r.Name] = i
+	}
+
+	if repoPath != "" {
+		for _, ref := range discoverRepo(repoPath) {
+			if idx, ok := byName[ref.Name]; ok {
+				refs[idx] = ref // repo file shadows the bundled entry
+			} else {
+				byName[ref.Name] = len(refs)
+				refs = append(refs, ref)
+			}
+		}
+	}
+
+	return refs, nil
+}
+
+func listBundled(bundleFS fs.FS) ([]types.SkillRef, error) {
+	entries, err := fs.ReadDir(bundleFS, "skills")
+	if err != nil {
+		return nil, err
+	}
+	var out []types.SkillRef
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".md")
+		out = append(out, types.SkillRef{
+			Path:        "bundled:" + name,
+			Source:      "bundled",
+			Name:        name,
+			DisplayName: name,
+		})
+	}
+	return out, nil
+}
+
+func discoverRepo(repoPath string) []types.SkillRef {
+	seen := make(map[string]bool)
+	var out []types.SkillRef
+	for _, pattern := range repoGlobs {
+		matches, _ := filepath.Glob(filepath.Join(repoPath, pattern))
+		for _, match := range matches {
+			if seen[match] {
+				continue
+			}
+			seen[match] = true
+			name := strings.TrimSuffix(filepath.Base(match), ".md")
+			out = append(out, types.SkillRef{
+				Path:        match,
+				Source:      "repo",
+				Name:        name,
+				DisplayName: name + " (repo)",
+			})
+		}
+	}
+	return out
+}

--- a/internal/skills/discover_test.go
+++ b/internal/skills/discover_test.go
@@ -1,0 +1,117 @@
+package skills_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"prismconductor/internal/skills"
+	"prismconductor/internal/skills/bundle"
+)
+
+func TestDiscover_BundledAlwaysPresent(t *testing.T) {
+	refs, err := skills.Discover("", bundle.FS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) == 0 {
+		t.Fatal("expected bundled skills, got none")
+	}
+	for _, r := range refs {
+		if r.Source != "bundled" {
+			t.Errorf("ref %q: expected source=bundled, got %q", r.Name, r.Source)
+		}
+		want := "bundled:" + r.Name
+		if r.Path != want {
+			t.Errorf("ref %q: expected path=%q, got %q", r.Name, want, r.Path)
+		}
+	}
+}
+
+func TestDiscover_RepoSkillAdded(t *testing.T) {
+	dir := t.TempDir()
+	cmdDir := filepath.Join(dir, ".claude", "commands")
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cmdDir, "my-skill.md"), []byte("# My Skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	refs, err := skills.Discover(dir, bundle.FS)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, r := range refs {
+		if r.Name == "my-skill" {
+			found = true
+			if r.Source != "repo" {
+				t.Errorf("expected source=repo, got %q", r.Source)
+			}
+		}
+	}
+	if !found {
+		t.Error("my-skill not found in discovered skills")
+	}
+}
+
+func TestDiscover_RepoOverridesShadowsBundled(t *testing.T) {
+	dir := t.TempDir()
+	skillsDir := filepath.Join(dir, ".prismconductor", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillsDir, "conductor-plan.md"), []byte("# Override"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	refs, err := skills.Discover(dir, bundle.FS)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var count int
+	for _, r := range refs {
+		if r.Name == "conductor-plan" {
+			count++
+			if r.Source != "repo" {
+				t.Errorf("expected repo override to win, got source=%q", r.Source)
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 conductor-plan entry, got %d", count)
+	}
+}
+
+func TestDiscover_NoDuplicatesFromMultipleGlobs(t *testing.T) {
+	dir := t.TempDir()
+	// Same file reachable via two different glob paths is impossible in practice
+	// (different directories), but verify that two skills with the same name
+	// from different directories results in the first-found winning.
+	for _, sub := range []string{".prismconductor/skills", ".claude/commands"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, sub, "shared.md"), []byte("# "+sub), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	refs, err := skills.Discover(dir, bundle.FS)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var count int
+	for _, r := range refs {
+		if r.Name == "shared" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 shared entry (first-found wins), got %d", count)
+	}
+}

--- a/internal/skills/migration.go
+++ b/internal/skills/migration.go
@@ -1,0 +1,35 @@
+package skills
+
+import "prismconductor/internal/types"
+
+// defaultBundledRef creates a SkillRef pointing to a bundled skill by name.
+func defaultBundledRef(name string) types.SkillRef {
+	return types.SkillRef{
+		Path:        "bundled:" + name,
+		Source:      "bundled",
+		Name:        name,
+		DisplayName: name,
+	}
+}
+
+// MigrateSkillProfile synthesizes PerStage from legacy SkillProfile fields
+// (Mode + UseConductor* booleans) if migration has not yet run. Returns true
+// when the profile was modified so the caller knows to persist the workspace.
+//
+// Policy (issue #92 q4): hybrid and native modes are "ambiguous" — their
+// native shell commands are not markdown files and cannot be expressed as a
+// SkillRef. All four stages therefore default to the canonical bundled skills.
+// The legacy Mode/NativeCommand fields remain on disk for one release.
+func MigrateSkillProfile(sp *types.SkillProfile) bool {
+	if sp.SkillsMigrated {
+		return false
+	}
+	sp.PerStage = map[string]types.SkillRef{
+		string(types.StagePlan):     defaultBundledRef("conductor-plan"),
+		string(types.StageExecute):  defaultBundledRef("conductor-execute"),
+		string(types.StageContinue): defaultBundledRef("conductor-continue"),
+		string(types.StageClose):    defaultBundledRef("conductor-close"),
+	}
+	sp.SkillsMigrated = true
+	return true
+}

--- a/internal/types/skill.go
+++ b/internal/types/skill.go
@@ -1,0 +1,27 @@
+package types
+
+// ConductorStage identifies which step in the conductor loop a skill serves.
+type ConductorStage string
+
+const (
+	StagePlan     ConductorStage = "plan"
+	StageExecute  ConductorStage = "execute"
+	StageContinue ConductorStage = "continue"
+	StageClose    ConductorStage = "close"
+)
+
+// AllStages returns the four conductor stages in canonical order.
+func AllStages() []ConductorStage {
+	return []ConductorStage{StagePlan, StageExecute, StageContinue, StageClose}
+}
+
+// SkillRef points to one skill markdown file. Source is "bundled" or "repo".
+// Bundled skills use the sentinel Path "bundled:<name>" (e.g. "bundled:conductor-plan").
+// Repo skills use the absolute filesystem path of the markdown file.
+type SkillRef struct {
+	Path        string `json:"path"`
+	Source      string `json:"source"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Description string `json:"description,omitempty"`
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -26,6 +26,7 @@ type EnvSpec struct {
 }
 
 type SkillProfile struct {
+	// Legacy fields kept for one-version migration window (issue #92).
 	Mode                 SkillMode `json:"mode"`
 	UseConductorPlan     bool      `json:"use_conductor_plan"`
 	UseConductorExecute  bool      `json:"use_conductor_execute"`
@@ -41,6 +42,22 @@ type SkillProfile struct {
 	// registry's default round-robin among role pools".
 	PreferredPlanPoolID string `json:"preferred_plan_pool_id,omitempty"`
 	PreferredWorkPoolID string `json:"preferred_work_pool_id,omitempty"`
+
+	// PerStage holds per-stage skill overrides (issue #92). A missing key
+	// falls through to the legacy Mode-based selection.
+	PerStage map[string]SkillRef `json:"per_stage,omitempty"`
+	// SkillsMigrated is set true after PerStage has been synthesized from
+	// the legacy Mode/UseConductor* fields on first launch.
+	SkillsMigrated bool `json:"skills_migrated,omitempty"`
+}
+
+// SkillForStage returns the SkillRef configured for the given stage, if any.
+func (sp SkillProfile) SkillForStage(stage ConductorStage) (SkillRef, bool) {
+	if sp.PerStage == nil {
+		return SkillRef{}, false
+	}
+	ref, ok := sp.PerStage[string(stage)]
+	return ref, ok
 }
 
 // AutoApplyLabelsEnabled returns true when the workspace opts in to auto-apply


### PR DESCRIPTION
## Summary

- Replaces the workspace-global `bundled`/`hybrid`/`native` mode flag with a per-stage `SkillRef` map on `SkillProfile`. Each conductor stage (plan, execute, continue, close) can now independently select any skill markdown from the bundled defaults or repo-discovered files.
- Non-Claude (harness) pools now load the selected skill markdown directly as the system prompt, making them fully tool-agnostic. Bundled skills are served from the embedded FS; repo skills from disk.
- A one-time migration runs on first launch to synthesize `PerStage` from the legacy `Mode`/`UseConductor*` fields (all four stages default to their canonical bundled skills).

## Files modified

| File | Change |
|---|---|
| `internal/types/skill.go` | **new** — `ConductorStage` constants, `SkillRef` struct, `AllStages()` |
| `internal/types/types.go` | Add `PerStage map[string]SkillRef`, `SkillsMigrated bool`, `SkillForStage()` to `SkillProfile` |
| `internal/skills/discover.go` | **new** — `Discover()` walks 7 repo glob patterns; repo shadows bundled on name collision |
| `internal/skills/discover_test.go` | **new** — 4 tests for bundled-always-present, repo-added, shadowing, and no-duplicate-names |
| `internal/skills/migration.go` | **new** — `MigrateSkillProfile()` one-time legacy→PerStage conversion |
| `internal/harness/harness.go` | `Run.SkillMarkdown` field; `Execute` uses it when non-empty instead of mode lookup |
| `internal/harness/prompts.go` | `assembleSystemPromptWithMarkdown()` for explicit markdown path |
| `internal/session/manager.go` | `loadSkillMarkdown()` helper; `spawnWithDir` threads `skillMarkdown` to harness; prompt builders check `PerStage` first |
| `internal/session/manager_test.go` | Fix `spawnWithDir` call sites for new signature |
| `app.go` | `DiscoverWorkspaceSkills()` Wails binding + `migrateWorkspaceSkillProfiles()` called on startup |
| `frontend/src/components/SkillDropdown.tsx` | **new** — per-stage skill picker dropdown |
| `frontend/src/components/SkillProfileEditor.tsx` | Add per-stage dropdowns above pool pickers |
| `frontend/wailsjs/go/main/App.{js,d.ts}` | Regenerated — adds `DiscoverWorkspaceSkills` binding |
| `frontend/wailsjs/go/models.ts` | Regenerated — adds `SkillRef` class, `per_stage` + `skills_migrated` on `SkillProfile` |

## Verification

| Gate | Command | Result |
|---|---|---|
| Go lint/vet | `go vet ./internal/...` | pass |
| Go build | `go build ./internal/...` | pass |
| TS typecheck | `cd frontend && ./node_modules/.bin/tsc --noEmit` | pass |
| Smoke test | `npx playwright test tests/e2e/startup.spec.ts` | skipped — requires running Wails app at localhost:34115; cannot build in worktree without `wails build` |
| Go tests | `go test ./internal/...` | pass — 4 new tests in `internal/skills`, all existing tests green |

## Notes for reviewers

- The `frontend/dist` stub created for `wails generate module` is not committed. Regenerate bindings after `wails build` if the generated files drift.
- Legacy `Mode`/`NativeCommand` fields remain on `SkillProfile` for one release as a migration safety net.
- Repo skills in `.cursor/rules/`, `.codex/skills/` etc. are discovered and shown in the picker but only benefit harness (non-Claude) pools — Claude subprocess pools still resolve skills via slash commands installed in `~/.claude/commands/`.

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-92

Closes #92