### PR TITLE
feat(session): clear blocked overlay without restart (#88)

### DIFF
--- a/app.go
+++ b/app.go
@@ -829,6 +829,18 @@ func (a *App) MoveIssueColumn(workspaceID string, number int, column string) err
 		"column":       column,
 	})
 
+	// Auto-acknowledge the most recent blocked/failed session when the user
+	// moves the card to TODO or PLAN — dragging it back is the explicit signal
+	// that they want to start over (issue #88).
+	if types.BoardColumn(column) == types.ColTodo || types.BoardColumn(column) == types.ColPlan {
+		if sess, err := a.store.AcknowledgeLatestFailure(workspaceID, number); err != nil {
+			log.Printf("MoveIssueColumn: acknowledge failure for #%d: %v", number, err)
+		} else if sess != nil {
+			wruntime.EventsEmit(a.ctx, "session.state", *sess)
+			log.Printf("MoveIssueColumn: acknowledged blocked session %s for #%d on move to %s", sess.ID[:8], number, column)
+		}
+	}
+
 	if types.BoardColumn(column) == types.ColPlan && a.wsReg != nil && a.mgr != nil {
 		// Auto-spawn rules:
 		//   - Skip if a plan worker is already in flight (avoid double-spawn).
@@ -876,6 +888,29 @@ func (a *App) MoveIssueColumn(workspaceID string, number int, column string) err
 				}
 			}
 		}
+	}
+	return nil
+}
+
+// ClearIssueFailure acknowledges the most recent blocked/failed session for
+// the given issue (issue #88). The session row is preserved for audit;
+// acknowledged_at is set and a session.state event is emitted so the frontend
+// immediately removes the blocked overlay without needing an app restart.
+func (a *App) ClearIssueFailure(workspaceID string, issueNumber int) error {
+	if a.store == nil {
+		return fmt.Errorf("store unavailable")
+	}
+	if a.wsReg != nil {
+		if _, ok := a.wsReg.Get(workspaceID); !ok {
+			return fmt.Errorf("unknown workspace %q", workspaceID)
+		}
+	}
+	sess, err := a.store.AcknowledgeLatestFailure(workspaceID, issueNumber)
+	if err != nil {
+		return err
+	}
+	if sess != nil {
+		wruntime.EventsEmit(a.ctx, "session.state", *sess)
 	}
 	return nil
 }

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { BrowserOpenURL } from "../../wailsjs/runtime/runtime";
-import { Replan } from "../../wailsjs/go/main/App";
+import { Replan, ClearIssueFailure } from "../../wailsjs/go/main/App";
 import { types } from "../../wailsjs/go/models";
 import { useSessionStore, SessionActivity } from "../stores/sessionStore";
 import { usePlanReadyStore } from "../stores/planReadyStore";
@@ -59,13 +59,13 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
         if (!paused || String(m.started_at ?? "") > String(paused.started_at ?? "")) {
           paused = m;
         }
-      } else if (m.state === "running" || m.state === "waiting_for_input" || m.state === "blocked") {
+      } else if ((m.state === "running" || m.state === "waiting_for_input" || (m.state === "blocked" && !m.acknowledged_at))) {
         if (!active) {
           active = m;
           activeAct = view.activity ?? null;
         }
-      } else if ((m.state === "failed" || m.state === "blocked") && m.blocked_reason) {
-        // Newest failed-with-reason session, regardless of column.
+      } else if ((m.state === "failed" || m.state === "blocked") && m.blocked_reason && !m.acknowledged_at) {
+        // Newest failed-with-reason unacknowledged session, regardless of column.
         if (!lastFail || String(m.started_at ?? "") > String(lastFail.started_at ?? "")) {
           lastFail = m;
         }
@@ -210,6 +210,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
         column={issue.column}
         prNumber={issue.pr_number ?? null}
         onContinue={() => setContinueOpen(true)}
+        onClearFailure={() => ClearIssueFailure(issue.workspace_id, issue.number).catch((err: any) => alert(String(err?.message ?? err)))}
       />
       <div className="flex justify-end mt-0.5">
         <WorkTimerChip
@@ -330,6 +331,7 @@ function StatusRow({
   column,
   prNumber,
   onContinue,
+  onClearFailure,
 }: {
   activeSession: types.Session | null;
   activity: SessionActivity | null;
@@ -347,6 +349,7 @@ function StatusRow({
   column: string;
   prNumber: number | null;
   onContinue: () => void;
+  onClearFailure: () => void;
 }) {
   const [menu, setMenu] = useState<{ x: number; y: number; actions: CopyAction[] } | null>(null);
 
@@ -433,6 +436,7 @@ function StatusRow({
   }
   if (lastFailure) {
     const reason = lastFailure.blocked_reason || "session ended without success";
+    const showClear = column === "todo" || column === "plan" || column === "in_progress";
     return (
       <>
         <div
@@ -446,6 +450,20 @@ function StatusRow({
             <Pulse className="bg-red-400" />
             <span className="text-red-300">blocked</span>
             <span className="text-slate-500">· {lastFailure.mode}</span>
+            {showClear && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClearFailure();
+                }}
+                onMouseDown={(e) => e.stopPropagation()}
+                onPointerDown={(e) => e.stopPropagation()}
+                className="ml-auto px-1.5 py-0.5 rounded text-[10px] border border-red-800 text-red-400 hover:border-red-600 hover:text-red-300"
+                title="Clear failure — marks the most recent blocked session as acknowledged and clears the card's blocked overlay."
+              >
+                ✕ Clear failure
+              </button>
+            )}
           </div>
           <div className="text-slate-400 break-words" title={reason}>⚠ {reason}</div>
         </div>

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -19,6 +19,8 @@ export function ApprovePlan(arg1:string,arg2:number,arg3:number):Promise<void>;
 
 export function ArchiveDone(arg1:string):Promise<number>;
 
+export function ClearIssueFailure(arg1:string,arg2:number):Promise<void>;
+
 export function ContinueWork(arg1:string,arg2:number,arg3:string):Promise<void>;
 
 export function CreateLabel(arg1:string,arg2:types.Label):Promise<types.Label>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -22,6 +22,10 @@ export function ArchiveDone(arg1) {
   return window['go']['main']['App']['ArchiveDone'](arg1);
 }
 
+export function ClearIssueFailure(arg1, arg2) {
+  return window['go']['main']['App']['ClearIssueFailure'](arg1, arg2);
+}
+
 export function ContinueWork(arg1, arg2, arg3) {
   return window['go']['main']['App']['ContinueWork'](arg1, arg2, arg3);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1362,11 +1362,12 @@ export namespace types {
 	    blocked_reason?: string;
 	    pending_question_id?: string;
 	    pool_id?: string;
-	
+	    acknowledged_at?: number;
+
 	    static createFrom(source: any = {}) {
 	        return new Session(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -1381,6 +1382,7 @@ export namespace types {
 	        this.blocked_reason = source["blocked_reason"];
 	        this.pending_question_id = source["pending_question_id"];
 	        this.pool_id = source["pool_id"];
+	        this.acknowledged_at = source["acknowledged_at"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -78,11 +78,13 @@ func nullableString(s string) any {
 // LoadRunningSessions returns sessions that were running at last shutdown.
 // Used for re-attach on startup (§15.3). Includes paused_for_question rows so
 // the answer-file watcher can pick them up post-restart (#17).
+// Acknowledged blocked/failed sessions (issue #88) are excluded — they were
+// cleared by the user and should not resurrect the red overlay on restart.
 func (s *Store) LoadRunningSessions() ([]types.Session, string, error) {
 	if s == nil || s.DB == nil {
 		return nil, "", nil
 	}
-	rows, err := s.DB.Query(`SELECT json, transcript_path, pending_question_id, transcript_offset FROM sessions WHERE state IN ('running','waiting_for_input','blocked','paused_for_question')`)
+	rows, err := s.DB.Query(`SELECT json, transcript_path, pending_question_id, transcript_offset FROM sessions WHERE state IN ('running','waiting_for_input','blocked','paused_for_question') AND (acknowledged_at IS NULL OR acknowledged_at = 0)`)
 	if err != nil {
 		return nil, "", err
 	}
@@ -174,6 +176,7 @@ func (s *Store) HasRecentFailedPlanSession(workspaceID string, issueNumber int, 
 		FROM sessions
 		WHERE workspace_id = ? AND issue_number = ?
 		  AND json_extract(json, '$.mode') = 'plan'
+		  AND (acknowledged_at IS NULL OR acknowledged_at = 0)
 		ORDER BY json_extract(json, '$.started_at') DESC
 		LIMIT 1`, workspaceID, issueNumber)
 	var endedAt sql.NullString
@@ -256,4 +259,44 @@ func (s *Store) SessionTranscriptPath(id string) (string, error) {
 	var path string
 	err := s.DB.QueryRow(`SELECT transcript_path FROM sessions WHERE id = ?`, id).Scan(&path)
 	return path, err
+}
+
+// AcknowledgeLatestFailure marks the most recent unacknowledged blocked/failed
+// session for the given issue as acknowledged (issue #88). The session row is
+// preserved for audit; only acknowledged_at is set so the UI stops showing the
+// blocked overlay. Returns nil session (no error) when no matching row exists.
+func (s *Store) AcknowledgeLatestFailure(workspaceID string, issueNumber int) (*types.Session, error) {
+	if s == nil || s.DB == nil {
+		return nil, errors.New("store unavailable")
+	}
+	now := time.Now().Unix()
+	var id, raw string
+	err := s.DB.QueryRow(`
+		SELECT id, json FROM sessions
+		WHERE workspace_id = ? AND issue_number = ?
+		  AND state IN ('blocked','failed')
+		  AND (acknowledged_at IS NULL OR acknowledged_at = 0)
+		ORDER BY json_extract(json, '$.started_at') DESC
+		LIMIT 1`, workspaceID, issueNumber).Scan(&id, &raw)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var sess types.Session
+	if err := json.Unmarshal([]byte(raw), &sess); err != nil {
+		return nil, err
+	}
+	sess.AcknowledgedAt = &now
+	updated, err := json.Marshal(&sess)
+	if err != nil {
+		return nil, err
+	}
+	_, err = s.DB.Exec(`UPDATE sessions SET acknowledged_at = ?, json = ? WHERE id = ?`,
+		now, string(updated), id)
+	if err != nil {
+		return nil, err
+	}
+	return &sess, nil
 }

--- a/internal/store/sessions_test.go
+++ b/internal/store/sessions_test.go
@@ -1,0 +1,132 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"prismconductor/internal/types"
+)
+
+func saveBlockedSession(t *testing.T, s *Store, wsID string, issueNum int, id string) {
+	t.Helper()
+	now := time.Now()
+	ended := now.Add(-1 * time.Minute)
+	sess := &types.Session{
+		ID:            id,
+		WorkspaceID:   wsID,
+		IssueNumber:   issueNum,
+		Mode:          types.ModePlan,
+		State:         types.StateBlocked,
+		StartedAt:     now.Add(-5 * time.Minute),
+		EndedAt:       &ended,
+		BlockedReason: "BLOCKED: something went wrong",
+	}
+	if err := s.SaveSession(sess, ""); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+	if err := s.UpdateSessionState(id, types.StateBlocked); err != nil {
+		t.Fatalf("UpdateSessionState: %v", err)
+	}
+}
+
+func TestAcknowledgeLatestFailure_SetsAcknowledgedAt(t *testing.T) {
+	s := newTestStore(t)
+	saveBlockedSession(t, s, "ws1", 10, "sess-1")
+
+	got, err := s.AcknowledgeLatestFailure("ws1", 10)
+	if err != nil {
+		t.Fatalf("AcknowledgeLatestFailure: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected a session back, got nil")
+	}
+	if got.AcknowledgedAt == nil {
+		t.Fatal("AcknowledgedAt should be set")
+	}
+	if *got.AcknowledgedAt <= 0 {
+		t.Fatalf("AcknowledgedAt should be a positive Unix epoch, got %d", *got.AcknowledgedAt)
+	}
+}
+
+func TestAcknowledgeLatestFailure_NoRowReturnsNil(t *testing.T) {
+	s := newTestStore(t)
+	got, err := s.AcknowledgeLatestFailure("ws1", 99)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil session for unknown issue, got %+v", got)
+	}
+}
+
+func TestAcknowledgeLatestFailure_IdempotentSecondCall(t *testing.T) {
+	s := newTestStore(t)
+	saveBlockedSession(t, s, "ws1", 10, "sess-1")
+
+	if _, err := s.AcknowledgeLatestFailure("ws1", 10); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	// Second call should find no unacknowledged row and return nil.
+	got, err := s.AcknowledgeLatestFailure("ws1", 10)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("second call should return nil (already acknowledged), got %+v", got)
+	}
+}
+
+func TestAcknowledgeLatestFailure_MostRecentOnly(t *testing.T) {
+	s := newTestStore(t)
+	saveBlockedSession(t, s, "ws1", 10, "sess-old")
+
+	// Add a newer blocked session.
+	now := time.Now()
+	ended := now.Add(-30 * time.Second)
+	newer := &types.Session{
+		ID:            "sess-new",
+		WorkspaceID:   "ws1",
+		IssueNumber:   10,
+		Mode:          types.ModeExecute,
+		State:         types.StateBlocked,
+		StartedAt:     now.Add(-2 * time.Minute),
+		EndedAt:       &ended,
+		BlockedReason: "BLOCKED: newer failure",
+	}
+	if err := s.SaveSession(newer, ""); err != nil {
+		t.Fatalf("SaveSession newer: %v", err)
+	}
+	if err := s.UpdateSessionState("sess-new", types.StateBlocked); err != nil {
+		t.Fatalf("UpdateSessionState: %v", err)
+	}
+
+	got, err := s.AcknowledgeLatestFailure("ws1", 10)
+	if err != nil {
+		t.Fatalf("AcknowledgeLatestFailure: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected a session")
+	}
+	if got.ID != "sess-new" {
+		t.Fatalf("expected newest session sess-new, got %s", got.ID)
+	}
+}
+
+func TestLoadRunningSessions_SkipsAcknowledged(t *testing.T) {
+	s := newTestStore(t)
+	saveBlockedSession(t, s, "ws1", 10, "sess-ack")
+
+	if _, err := s.AcknowledgeLatestFailure("ws1", 10); err != nil {
+		t.Fatalf("AcknowledgeLatestFailure: %v", err)
+	}
+
+	sessions, _, err := s.LoadRunningSessions()
+	if err != nil {
+		t.Fatalf("LoadRunningSessions: %v", err)
+	}
+	for _, sess := range sessions {
+		if sess.ID == "sess-ack" {
+			t.Fatal("acknowledged session should not appear in LoadRunningSessions")
+		}
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -214,6 +214,14 @@ CREATE TABLE IF NOT EXISTS pools (
 			}
 		}
 	}
+	// Issue #88: acknowledged_at records when the user cleared a blocked/failed
+	// session. NULL = not yet acknowledged; non-null = Unix epoch of the clear.
+	// The session row is preserved for audit; the UI ignores acknowledged rows.
+	if _, err := s.DB.Exec(`ALTER TABLE sessions ADD COLUMN acknowledged_at INTEGER`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column name") {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -308,6 +308,12 @@ type Session struct {
 	// rows spawned before the field was introduced.
 	PoolID string `json:"pool_id,omitempty"`
 
+	// AcknowledgedAt is set (Unix epoch) when the user explicitly clears a
+	// blocked/failed session via ClearIssueFailure or by dragging the card to
+	// TODO/PLAN. The session row is preserved for audit; the UI ignores
+	// acknowledged sessions when computing lastFailure/activeSession overlays.
+	AcknowledgedAt *int64 `json:"acknowledged_at,omitempty"`
+
 	// TranscriptOffset is the byte offset into the transcript file of the
 	// last fully-processed line (issue #54). Lives on the sessions column,
 	// excluded from the JSON blob to keep external snapshots schema-stable.


### PR DESCRIPTION
## Summary

- Blocked/failed cards showed a persistent red overlay only dismissable by restarting the app. Users moving a blocked card back to TODO or PLAN (or clicking "Clear failure") now clears the overlay immediately without a restart.
- Sessions are preserved for audit — only `acknowledged_at` is set, nothing is deleted.

## Files modified

- `internal/types/types.go` — add `AcknowledgedAt *int64` field to `Session`
- `internal/store/sqlite.go` — idempotent migration adding `acknowledged_at INTEGER` column to sessions
- `internal/store/sessions.go` — `AcknowledgeLatestFailure` method; `LoadRunningSessions` and `HasRecentFailedPlanSession` filter acknowledged rows
- `internal/store/sessions_test.go` — 5 new tests covering acknowledge logic
- `app.go` — `ClearIssueFailure` Wails method; `MoveIssueColumn` auto-acknowledges on move to TODO or PLAN
- `frontend/wailsjs/go/main/App.js` — add `ClearIssueFailure` binding
- `frontend/wailsjs/go/main/App.d.ts` — add `ClearIssueFailure` type declaration
- `frontend/wailsjs/go/models.ts` — add `acknowledged_at?: number` to Session model
- `frontend/src/components/Card.tsx` — skip acknowledged sessions in `activeSession`/`lastFailure` computation; add "✕ Clear failure" chip for TODO/PLAN/IN_PROGRESS columns

## Verification

- **lint:** `go vet prismconductor/internal/...` — pass (0 issues)
- **build:** `go build prismconductor/internal/...` — pass
- **smoke test:** skipped — `@playwright/test` not installed in worktree environment (spec present at `tests/e2e/startup.spec.ts`)
- **tests:** `go test prismconductor/internal/...` — pass (all packages, 5 new store tests)
  - `TestAcknowledgeLatestFailure_SetsAcknowledgedAt` PASS
  - `TestAcknowledgeLatestFailure_NoRowReturnsNil` PASS
  - `TestAcknowledgeLatestFailure_IdempotentSecondCall` PASS
  - `TestAcknowledgeLatestFailure_MostRecentOnly` PASS
  - `TestLoadRunningSessions_SkipsAcknowledged` PASS

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-88

Closes #88