### PR TITLE
feat: surface estimated and actual LLM token costs in PlanModal and Card (#47)

### DIFF
--- a/cost.go
+++ b/cost.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"prismconductor/internal/llm"
+	"prismconductor/internal/types"
+)
+
+// CostEstimate is the estimated execute-cost payload returned by PlanCostEstimate
+// (issue #47). HasRate is false when no rate is configured for the model; in
+// that case CostUSD is 0 and the UI should display '-'.
+type CostEstimate struct {
+	Tokens  int64   `json:"tokens"`
+	CostUSD float64 `json:"cost_usd"`
+	HasRate bool    `json:"has_rate"`
+	Model   string  `json:"model"`
+}
+
+// IssueCost returns the cumulative persisted LLM cost_usd for an issue.
+func (a *App) IssueCost(workspaceID string, issueNumber int) (float64, error) {
+	if a.store == nil {
+		return 0, nil
+	}
+	iss, err := a.store.LoadIssue(workspaceID, issueNumber)
+	if err != nil {
+		return 0, err
+	}
+	return iss.CostUSD, nil
+}
+
+// PlanCostEstimate returns an estimated execute cost for the latest plan of an
+// issue. The estimate uses the Q1=A heuristic: 5000 base tokens + 80 tokens per
+// LOC across files_to_modify + 5 tokens per plan_markdown word.
+func (a *App) PlanCostEstimate(workspaceID string, issueNumber int) (CostEstimate, error) {
+	if a.store == nil {
+		return CostEstimate{}, nil
+	}
+	plan, err := a.store.LatestPlan(workspaceID, issueNumber)
+	if err != nil || plan == nil {
+		return CostEstimate{}, err
+	}
+
+	model := resolveWorkPoolModel(a, workspaceID)
+
+	// Count lines across all files_to_modify. Files that can't be read
+	// (not yet created, outside the repo) fall back to 100 lines each.
+	var ws types.Workspace
+	if a.wsReg != nil {
+		ws, _ = a.wsReg.Get(workspaceID)
+	}
+	totalLines := 0
+	for _, fi := range plan.FilesToModify {
+		path := filepath.Join(ws.RepoPath, fi.Path)
+		if b, err := os.ReadFile(path); err == nil {
+			totalLines += bytes.Count(b, []byte("\n"))
+		} else {
+			totalLines += 100
+		}
+	}
+
+	planWords := len(strings.Fields(plan.PlanMarkdown))
+	tokens := llm.EstimateTokens(totalLines, planWords)
+
+	rates, hasRate := llm.LookupRates(model)
+	var costUSD float64
+	if hasRate {
+		costUSD = llm.EstimateCostUSD(tokens, rates)
+	}
+
+	return CostEstimate{
+		Tokens:  tokens,
+		CostUSD: costUSD,
+		HasRate: hasRate,
+		Model:   model,
+	}, nil
+}
+
+// resolveWorkPoolModel finds the model string for the workspace's preferred
+// work pool, or the first enabled work pool if no preference is set.
+func resolveWorkPoolModel(a *App, workspaceID string) string {
+	if a.store == nil {
+		return ""
+	}
+	pools, err := a.store.ListPools()
+	if err != nil {
+		return ""
+	}
+	var ws types.Workspace
+	if a.wsReg != nil {
+		ws, _ = a.wsReg.Get(workspaceID)
+	}
+	preferredID := ws.SkillProfile.PreferredWorkPoolID
+	first := ""
+	for _, p := range pools {
+		if !p.Enabled {
+			continue
+		}
+		if preferredID != "" && p.ID == preferredID {
+			return p.Model
+		}
+		if p.Role == types.RoleWork && first == "" {
+			first = p.Model
+		}
+	}
+	return first
+}

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -226,7 +226,10 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
         onContinue={() => setContinueOpen(true)}
         onClearFailure={() => ClearIssueFailure(issue.workspace_id, issue.number).catch((err: any) => alert(String(err?.message ?? err)))}
       />
-      <div className="flex justify-end mt-0.5">
+      <div className="flex justify-end items-center gap-2 mt-0.5">
+        {(issue.cost_usd ?? 0) > 0 && (
+          <CostChip costUSD={issue.cost_usd!} />
+        )}
         <WorkTimerChip
           baseSecs={issue.work_seconds ?? 0}
           planBaseSecs={issue.work_seconds_plan ?? 0}
@@ -289,6 +292,17 @@ function formatWorkDuration(s: number): string {
   const d = Math.floor(s / 86400);
   const h = Math.floor((s % 86400) / 3600);
   return `${d}d${h.toString().padStart(2, "0")}h`;
+}
+
+function CostChip({ costUSD }: { costUSD: number }) {
+  return (
+    <span
+      className="text-[10px] text-slate-500 font-mono tabular-nums"
+      title={`Cumulative LLM cost: $${costUSD.toFixed(4)}`}
+    >
+      ${costUSD < 0.01 ? costUSD.toFixed(4) : costUSD.toFixed(2)}
+    </span>
+  );
 }
 
 function WorkTimerChip({

--- a/frontend/src/components/PlanModal.tsx
+++ b/frontend/src/components/PlanModal.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { ApprovePlan, LatestPlan, RejectPlan, SetIssueLabels, SubmitAnswers, WriteAnswersOnly } from "../../wailsjs/go/main/App";
+import { ApprovePlan, LatestPlan, PlanCostEstimate, RejectPlan, SetIssueLabels, SubmitAnswers, WriteAnswersOnly } from "../../wailsjs/go/main/App";
 import { main, types } from "../../wailsjs/go/models";
 import { useIssueStore } from "../stores/issueStore";
 import { useLabelsStore, EMPTY_LABELS } from "../stores/labelsStore";
@@ -34,6 +34,7 @@ export function PlanModal({
   const refreshLabels = useLabelsStore((s) => s.refresh);
   const labelsCache = useLabelsStore((s) => (issue ? s.byWorkspace[issue.workspace_id] ?? EMPTY_LABELS : EMPTY_LABELS));
   const [plan, setPlan] = useState<types.Plan | null>(null);
+  const [costEstimate, setCostEstimate] = useState<main.CostEstimate | null>(null);
   const [answers, setAnswers] = useState<AnswerState>(emptyAnswers());
   const [refineText, setRefineText] = useState("");
   const [busy, setBusy] = useState(false);
@@ -55,6 +56,7 @@ export function PlanModal({
     setError(null);
     setAnswers(emptyAnswers());
     setRefineText("");
+    setCostEstimate(null);
     LatestPlan(issue.workspace_id, issue.number)
       .then((p) => {
         setPlan(p ?? null);
@@ -64,6 +66,9 @@ export function PlanModal({
       })
       .catch((e) => setError(String(e?.message ?? e)))
       .finally(() => setLoading(false));
+    PlanCostEstimate(issue.workspace_id, issue.number)
+      .then((est) => setCostEstimate(est ?? null))
+      .catch(() => { /* non-fatal — cost estimate is best-effort */ });
     refreshLabels(issue.workspace_id);
   }, [open, issue?.workspace_id, issue?.number, refreshLabels]);
 
@@ -181,6 +186,20 @@ export function PlanModal({
               <span>Complexity: {plan.estimated_complexity || "—"}</span>
               <span>{ageMin !== null ? `Generated ${ageMin}m ago` : ""}</span>
             </>
+          )}
+          {costEstimate && (
+            <span
+              className="ml-auto text-slate-400"
+              title={
+                costEstimate.has_rate
+                  ? `Estimated execute cost (~${costEstimate.tokens.toLocaleString()} tokens × ${costEstimate.model || "unknown model"} rates). Actual cost recorded after the session ends.`
+                  : `No rate configured for model "${costEstimate.model || "(unknown)"}". Add rates in Settings to see cost estimates.`
+              }
+            >
+              {costEstimate.has_rate
+                ? `~$${costEstimate.cost_usd.toFixed(4)} est.`
+                : "cost: —"}
+            </span>
           )}
         </div>
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -63,6 +63,8 @@ export function GitHubLogout():Promise<void>;
 
 export function InspectRepo(arg1:string):Promise<workspace.Inspection>;
 
+export function IssueCost(arg1:string,arg2:number):Promise<number>;
+
 export function KillSession(arg1:string):Promise<void>;
 
 export function LatestPlan(arg1:string,arg2:number):Promise<types.Plan>;
@@ -96,6 +98,8 @@ export function OnboardCheck(arg1:string):Promise<Array<workspace.OnboardCheck>>
 export function OpenBundledSkill(arg1:string):Promise<void>;
 
 export function PickRepoPath():Promise<string>;
+
+export function PlanCostEstimate(arg1:string,arg2:number):Promise<main.CostEstimate>;
 
 export function ProbeProviderModels(arg1:types.Provider,arg2:string,arg3:string):Promise<Array<string>>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -110,6 +110,10 @@ export function InspectRepo(arg1) {
   return window['go']['main']['App']['InspectRepo'](arg1);
 }
 
+export function IssueCost(arg1, arg2) {
+  return window['go']['main']['App']['IssueCost'](arg1, arg2);
+}
+
 export function KillSession(arg1) {
   return window['go']['main']['App']['KillSession'](arg1);
 }
@@ -176,6 +180,10 @@ export function OpenBundledSkill(arg1) {
 
 export function PickRepoPath() {
   return window['go']['main']['App']['PickRepoPath']();
+}
+
+export function PlanCostEstimate(arg1, arg2) {
+  return window['go']['main']['App']['PlanCostEstimate'](arg1, arg2);
 }
 
 export function ProbeProviderModels(arg1, arg2, arg3) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -863,6 +863,24 @@ export namespace main {
 	        this.body = source["body"];
 	    }
 	}
+	export class CostEstimate {
+	    tokens: number;
+	    cost_usd: number;
+	    has_rate: boolean;
+	    model: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new CostEstimate(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.tokens = source["tokens"];
+	        this.cost_usd = source["cost_usd"];
+	        this.has_rate = source["has_rate"];
+	        this.model = source["model"];
+	    }
+	}
 	export class NotifyPrefs {
 	    muted: boolean;
 	    quiet_start: string;
@@ -1155,6 +1173,7 @@ export namespace types {
 	    work_seconds?: number;
 	    work_seconds_plan?: number;
 	    work_seconds_execute?: number;
+	    cost_usd?: number;
 	
 	    static createFrom(source: any = {}) {
 	        return new Issue(source);
@@ -1185,6 +1204,7 @@ export namespace types {
 	        this.work_seconds = source["work_seconds"];
 	        this.work_seconds_plan = source["work_seconds_plan"];
 	        this.work_seconds_execute = source["work_seconds_execute"];
+	        this.cost_usd = source["cost_usd"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -1363,11 +1383,11 @@ export namespace types {
 	    pending_question_id?: string;
 	    pool_id?: string;
 	    acknowledged_at?: number;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new Session(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];

--- a/internal/llm/pricing.go
+++ b/internal/llm/pricing.go
@@ -1,0 +1,68 @@
+package llm
+
+import (
+	"math"
+	"strings"
+)
+
+// ModelRates holds the cost per million tokens for a specific model (issue #47).
+type ModelRates struct {
+	InputPerMillion  float64 `json:"input_per_million"`
+	OutputPerMillion float64 `json:"output_per_million"`
+}
+
+// defaultModelRates is the built-in rate table keyed by model name prefix
+// (lowercase). Rates are USD per million tokens as of 2025-05.
+var defaultModelRates = map[string]ModelRates{
+	// Claude 4
+	"claude-opus-4":   {InputPerMillion: 15.0, OutputPerMillion: 75.0},
+	"claude-sonnet-4": {InputPerMillion: 3.0, OutputPerMillion: 15.0},
+	"claude-haiku-4":  {InputPerMillion: 0.25, OutputPerMillion: 1.25},
+	// Claude 3.5
+	"claude-opus-3-5":   {InputPerMillion: 15.0, OutputPerMillion: 75.0},
+	"claude-sonnet-3-5": {InputPerMillion: 3.0, OutputPerMillion: 15.0},
+	"claude-haiku-3-5":  {InputPerMillion: 0.8, OutputPerMillion: 4.0},
+	// OpenAI
+	"gpt-4.1":      {InputPerMillion: 2.0, OutputPerMillion: 8.0},
+	"gpt-4.1-mini": {InputPerMillion: 0.4, OutputPerMillion: 1.6},
+	"gpt-4.1-nano": {InputPerMillion: 0.1, OutputPerMillion: 0.4},
+	"gpt-4o":       {InputPerMillion: 2.5, OutputPerMillion: 10.0},
+	"gpt-4o-mini":  {InputPerMillion: 0.15, OutputPerMillion: 0.6},
+	"gpt-4":        {InputPerMillion: 30.0, OutputPerMillion: 60.0},
+	"o3":           {InputPerMillion: 10.0, OutputPerMillion: 40.0},
+	"o4-mini":      {InputPerMillion: 1.1, OutputPerMillion: 4.4},
+	// Gemini
+	"gemini-2.5-pro":   {InputPerMillion: 1.25, OutputPerMillion: 10.0},
+	"gemini-2.5-flash": {InputPerMillion: 0.15, OutputPerMillion: 0.6},
+	"gemini-2.0-flash": {InputPerMillion: 0.1, OutputPerMillion: 0.4},
+}
+
+// LookupRates returns the best matching rates for a model string and whether
+// a match was found. Exact match is tried first; prefix match (lowercased)
+// is the fallback.
+func LookupRates(model string) (ModelRates, bool) {
+	if r, ok := defaultModelRates[model]; ok {
+		return r, true
+	}
+	lower := strings.ToLower(model)
+	for prefix, r := range defaultModelRates {
+		if strings.HasPrefix(lower, prefix) {
+			return r, true
+		}
+	}
+	return ModelRates{}, false
+}
+
+// EstimateTokens returns an estimated token count for an execute session.
+// Heuristic (Q1=A): base 5000 + 80 tokens per LOC + 5 tokens per plan word.
+func EstimateTokens(totalLines, planWords int) int64 {
+	return int64(5000 + totalLines*80 + planWords*5)
+}
+
+// EstimateCostUSD returns the estimated USD cost for a token count and rates.
+// Treats all tokens as input (conservative, since output volume is unknown
+// before execution). Result is rounded to 4 decimal places.
+func EstimateCostUSD(tokens int64, rates ModelRates) float64 {
+	raw := float64(tokens) * rates.InputPerMillion / 1_000_000
+	return math.Round(raw*10000) / 10000
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -60,6 +60,8 @@ type Persister interface {
 	UpdateSessionTranscriptOffset(id string, off int64) error
 	// AccumulateIssueWork adds elapsed seconds to the issue's work timer (issue #46).
 	AccumulateIssueWork(workspaceID string, number int, mode types.SessionMode, seconds int64) error
+	// AccumulateIssueCost adds LLM cost to the issue's cost_usd counter (issue #47).
+	AccumulateIssueCost(workspaceID string, number int, costUSD float64) error
 }
 
 // StateChangeHandler is fired on every state transition. Used by the App layer
@@ -722,6 +724,11 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 			if secs > 0 {
 				_ = m.store.AccumulateIssueWork(rs.sess.WorkspaceID, rs.sess.IssueNumber, rs.sess.Mode, secs)
 			}
+		}
+		// Accumulate LLM cost from Claude stream-json result event (issue #47).
+		// Only Claude subprocess sessions emit this; harness sessions don't.
+		if cd := rs.parser.LastCost(); cd != nil && cd.TotalCostUSD > 0 {
+			_ = m.store.AccumulateIssueCost(rs.sess.WorkspaceID, rs.sess.IssueNumber, cd.TotalCostUSD)
 		}
 	}
 	if m.onStateChange != nil && prev != rs.sess.State {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -88,6 +88,7 @@ func (p *fakePersister) UpdateSessionTranscriptOffset(id string, off int64) erro
 func (p *fakePersister) AccumulateIssueWork(_ string, _ int, _ types.SessionMode, _ int64) error {
 	return nil
 }
+func (p *fakePersister) AccumulateIssueCost(_ string, _ int, _ float64) error { return nil }
 
 func TestMatchPatternsQuestionPending(t *testing.T) {
 	const qid = "11111111-2222-3333-4444-555555555555"

--- a/internal/session/streamjson.go
+++ b/internal/session/streamjson.go
@@ -21,6 +21,14 @@ const (
 	RoleDone      = "@done "
 )
 
+// CostData holds token counts and dollar cost captured from a Claude
+// stream-json "result" event (issue #47). Zero-value means no data yet.
+type CostData struct {
+	TotalCostUSD float64
+	InputTokens  int64
+	OutputTokens int64
+}
+
 // StreamParser is per-session state for converting the line-delimited
 // stream-json events from `claude -p --output-format stream-json` into
 // role-prefixed display lines.
@@ -28,12 +36,21 @@ type StreamParser struct {
 	mu       sync.Mutex
 	enabled  bool
 	pending  strings.Builder // in-flight assistant text (between newlines)
+	cost     *CostData       // populated when result event arrives (issue #47)
 }
 
 // NewStreamParser returns a parser that's enabled by default. If the spawn
 // fell back to non-streaming mode, the parser auto-disables on the first
 // non-JSON line.
 func NewStreamParser() *StreamParser { return &StreamParser{enabled: true} }
+
+// LastCost returns the cost data captured from the most recent "result" event,
+// or nil if no result event has been observed yet (issue #47).
+func (p *StreamParser) LastCost() *CostData {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.cost
+}
 
 // Feed processes one raw line from the PTY and returns 0+ display lines.
 func (p *StreamParser) Feed(raw string) []string {
@@ -179,6 +196,24 @@ func (p *StreamParser) Feed(raw string) []string {
 
 	case "result":
 		flushPending()
+		// Extract token counts and cost from the result event (issue #47).
+		// These fields are only present on Claude stream-json output.
+		var res struct {
+			TotalCostUSD float64 `json:"total_cost_usd"`
+			Usage        struct {
+				InputTokens  int64 `json:"input_tokens"`
+				OutputTokens int64 `json:"output_tokens"`
+			} `json:"usage"`
+		}
+		if err := json.Unmarshal([]byte(raw), &res); err == nil {
+			if res.TotalCostUSD > 0 || res.Usage.InputTokens > 0 {
+				p.cost = &CostData{
+					TotalCostUSD: res.TotalCostUSD,
+					InputTokens:  res.Usage.InputTokens,
+					OutputTokens: res.Usage.OutputTokens,
+				}
+			}
+		}
 		if generic.Result != "" {
 			// Result text is already streamed as @asst lines; add a small
 			// completion marker.

--- a/internal/store/issues.go
+++ b/internal/store/issues.go
@@ -77,6 +77,10 @@ func (s *Store) SaveIssue(iss types.Issue) (bool, error) {
 				iss.WorkSecondsPlan = prev.WorkSecondsPlan
 				iss.WorkSecondsExecute = prev.WorkSecondsExecute
 			}
+			// Preserve accumulated LLM cost (issue #47).
+			if prev.CostUSD > 0 {
+				iss.CostUSD = prev.CostUSD
+			}
 		}
 	}
 	iss.Column = col
@@ -347,6 +351,41 @@ func (s *Store) AccumulateIssueWork(workspaceID string, number int, mode types.S
 	case types.ModeExecute:
 		iss.WorkSecondsExecute += seconds
 	}
+	b, err := json.Marshal(iss)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`UPDATE issues SET json = ? WHERE workspace_id = ? AND number = ?`, string(b), workspaceID, number); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// AccumulateIssueCost adds LLM token counts and dollar cost to the issue's
+// cost_usd field (issue #47). Called when a session ends and its result event
+// carried total_cost_usd data. Zero costUSD is a no-op.
+func (s *Store) AccumulateIssueCost(workspaceID string, number int, costUSD float64) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	if costUSD <= 0 {
+		return nil
+	}
+	tx, err := s.DB.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var raw string
+	if err := tx.QueryRow(`SELECT json FROM issues WHERE workspace_id = ? AND number = ?`, workspaceID, number).Scan(&raw); err != nil {
+		return err
+	}
+	var iss types.Issue
+	if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+		return err
+	}
+	iss.CostUSD += costUSD
 	b, err := json.Marshal(iss)
 	if err != nil {
 		return err

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -223,6 +223,11 @@ type Issue struct {
 	WorkSeconds        int64 `json:"work_seconds,omitempty"`
 	WorkSecondsPlan    int64 `json:"work_seconds_plan,omitempty"`
 	WorkSecondsExecute int64 `json:"work_seconds_execute,omitempty"`
+
+	// CostUSD is the cumulative LLM spend across all sessions for this issue
+	// (issue #47). Accumulated from Claude stream-json result events; preserved
+	// across GitHub poll re-saves like WorkSeconds.
+	CostUSD float64 `json:"cost_usd,omitempty"`
 }
 
 type BoardColumn string


### PR DESCRIPTION
## Summary

- Adds a cost estimation heuristic (5000 base tokens + 80/LOC + 5/plan word) shown as `~$X.XXXX est.` in the PlanModal before the user approves
- Persists actual `total_cost_usd` from Claude stream-json result events into the issue JSON blob after each session
- Renders a `$X.XX` cost chip on the Card next to the work-timer when `cost_usd > 0`

## Files modified

- `cost.go` (new) — `App.PlanCostEstimate` and `App.IssueCost` bound methods
- `internal/llm/pricing.go` (new) — model rate table, `EstimateTokens`, `EstimateCostUSD`
- `internal/types/types.go` — `CostUSD float64` field on `Issue`
- `internal/session/streamjson.go` — parse `total_cost_usd` + `usage` from result stream events; `LastCost()` method
- `internal/session/manager.go` — call `AccumulateIssueCost` after `tailAndParse`; `Persister` interface extended
- `internal/session/manager_test.go` — stub `AccumulateIssueCost` on `fakePersister`
- `internal/store/issues.go` — `AccumulateIssueCost` (read-modify-write tx); preserve `CostUSD` in `SaveIssue`
- `frontend/wailsjs/go/models.ts` — `main.CostEstimate` class; `cost_usd` on `Issue`
- `frontend/wailsjs/go/main/App.d.ts` — `IssueCost` and `PlanCostEstimate` type declarations
- `frontend/wailsjs/go/main/App.js` — JS bridge for same
- `frontend/src/components/PlanModal.tsx` — call `PlanCostEstimate`, render estimated cost in metadata bar
- `frontend/src/components/Card.tsx` — `CostChip` component rendered when `issue.cost_usd > 0`

## Verification

- **Go vet**: `go vet ./internal/...` → pass
- **Go build**: `go build ./internal/...` → pass
- **Tests**: `go test ./internal/session/... ./internal/store/... ./internal/llm/...` → all pass
- **TypeScript**: `npx tsc --noEmit` (frontend) → pass (0 errors)
- **Smoke test**: `tests/e2e/startup.spec.ts` — wails dev compiled and started successfully (`main.CostEstimate` present in KnownStructs, dev server URL emitted, Playwright launched test); process timed out waiting for wails dev shutdown (pre-existing cleanup hang unrelated to this change)

## Notes

- Plan specified `internal/app/cost.go` but no such package exists; created `cost.go` at repo root (`package main`) matching existing `app.go` pattern
- Plan specified a new `session_cost` SQL table; not needed — cost stored in the existing issue JSON blob (same pattern as `work_seconds`), zero schema changes required
- `PrBodyTemplate.tsx` skip: PR body is generated by the worker, not React; cost is only known post-session, not at PR creation time
- No backfill of historical sessions (per Q3 answer)

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-47

Closes #47
