### PR TITLE
feat: replace debug row with label filter strip (#110)

### DIFF
--- a/app.go
+++ b/app.go
@@ -1108,6 +1108,34 @@ func (a *App) GetPollInterval() int {
 	return n
 }
 
+// --- Label filter (#110) ---
+
+// LabelFilterState is the shape returned by GetLabelFilter and consumed by the frontend store.
+type LabelFilterState struct {
+	Labels []string `json:"labels"`
+	Mode   string   `json:"mode"`
+}
+
+// GetLabelFilter returns the persisted label filter selection for a workspace.
+func (a *App) GetLabelFilter(workspaceID string) (LabelFilterState, error) {
+	if a.store == nil {
+		return LabelFilterState{Labels: []string{}, Mode: "or"}, nil
+	}
+	labels, mode, err := a.store.GetLabelFilter(workspaceID)
+	if err != nil {
+		return LabelFilterState{Labels: []string{}, Mode: "or"}, err
+	}
+	return LabelFilterState{Labels: labels, Mode: mode}, nil
+}
+
+// SetLabelFilter persists the label filter selection for a workspace.
+func (a *App) SetLabelFilter(workspaceID string, labels []string, mode string) error {
+	if a.store == nil {
+		return fmt.Errorf("store unavailable")
+	}
+	return a.store.SetLabelFilter(workspaceID, labels, mode)
+}
+
 // --- Labels (#14) ---
 
 // ListLabels returns the cached label set for a workspace. The poller fans

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,7 @@ import { SessionDrawer } from "./components/SessionDrawer";
 import { Settings } from "./components/Settings";
 import { PlanModal } from "./components/PlanModal";
 import { ArchivedDrawer } from "./components/ArchivedDrawer";
-import { AddIssueQuick } from "./components/AddIssueQuick";
+import { LabelFilterStrip } from "./components/LabelFilterStrip";
 import { useArchivedStore, useIssueStore } from "./stores/issueStore";
 import { useGoalStore } from "./stores/goalStore";
 import { usePlanReadyStore } from "./stores/planReadyStore";
@@ -372,10 +372,7 @@ function App() {
         onOpenArchived={() => setArchivedOpen(true)}
       />
       <GoalPane />
-      <div className="px-4 py-1 border-b border-slate-800 flex items-center gap-3">
-        <span className="text-xs text-slate-500">+ test issue:</span>
-        <AddIssueQuick />
-      </div>
+      <LabelFilterStrip />
       <main className="flex-1 overflow-hidden pt-3">
         <Board
           onCardClick={(iss) =>

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -20,6 +20,7 @@ import { useIssueStore, Column as ColumnID } from "../stores/issueStore";
 import { useIssueViewStore } from "../stores/useIssueViewStore";
 import { matchesQuery } from "../lib/matchesQuery";
 import { useWorkspaceStore } from "../stores/workspaceStore";
+import { useLabelFilterStore } from "../stores/useLabelFilterStore";
 import { Card } from "./Card";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { Column } from "./Column";
@@ -60,6 +61,7 @@ export function Board({ onCardClick }: { onCardClick?: (issue: types.Issue) => v
   const { issues, refresh, applyLocalMove, applyLocalReorder, moveColumn, reorder, searchQuery } = useIssueStore();
   const loadIssueViews = useIssueViewStore((s) => s.loadForWorkspace);
   const { workspaces, selectedID } = useWorkspaceStore();
+  const { selected: labelSelected, mode: labelMode } = useLabelFilterStore();
   const [filteredTodoNums, setFilteredTodoNums] = useState<Set<string> | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
   // Capture the source column at drag-start. onDragOver does an optimistic
@@ -113,17 +115,26 @@ export function Board({ onCardClick }: { onCardClick?: (issue: types.Issue) => v
       review: [],
       done: [],
     };
+    const labelSet = labelSelected.length > 0 ? new Set(labelSelected) : null;
     for (const i of issues) {
       const col = (i.column || "todo") as ColumnID;
       if (col === "todo" && filteredTodoNums && !filteredTodoNums.has(cardID(i))) continue;
       if (!matchesQuery(i.title, searchQuery)) continue;
+      if (labelSet) {
+        const cardLabels = i.labels ?? [];
+        const pass =
+          labelMode === "and"
+            ? [...labelSet].every((l) => cardLabels.includes(l))
+            : cardLabels.some((l) => labelSet.has(l));
+        if (!pass) continue;
+      }
       if (out[col]) out[col].push(i);
     }
     // ListIssues already returns by (column, manual_order, number). For TODO, if
     // every item shares manual_order=0 (no human reorder yet), use priority.
     out.todo = sortTodoByPriority(out.todo);
     return out;
-  }, [issues, filteredTodoNums, searchQuery]);
+  }, [issues, filteredTodoNums, searchQuery, labelSelected, labelMode]);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
 

--- a/frontend/src/components/LabelFilterStrip.tsx
+++ b/frontend/src/components/LabelFilterStrip.tsx
@@ -1,0 +1,115 @@
+import { useEffect } from "react";
+import { types } from "../../wailsjs/go/models";
+import { useLabelsStore } from "../stores/labelsStore";
+import { useWorkspaceStore } from "../stores/workspaceStore";
+import { useLabelFilterStore, toggleLabel, setFilterMode, clearFilter, LabelFilterMode } from "../stores/useLabelFilterStore";
+import { getContrastText } from "../lib/contrast";
+
+function LabelChip({ label, selected, workspaceID }: { label: types.Label; selected: boolean; workspaceID: string }) {
+  const color = label.color ?? "475569";
+  const fg = getContrastText(color);
+
+  return (
+    <button
+      role="checkbox"
+      aria-checked={selected}
+      aria-pressed={selected}
+      onClick={() => toggleLabel(workspaceID, label.name)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          toggleLabel(workspaceID, label.name);
+        }
+      }}
+      className="flex-shrink-0 px-2 py-0.5 rounded text-[11px] font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-slate-400 transition-opacity"
+      style={
+        selected
+          ? { backgroundColor: `#${color}`, color: fg, border: "1px solid transparent" }
+          : { backgroundColor: "rgba(71,85,105,0.25)", color: "#94a3b8", border: `1px solid #${color}66` }
+      }
+      title={label.description || label.name}
+    >
+      {label.name}
+    </button>
+  );
+}
+
+export function LabelFilterStrip() {
+  const { selectedID } = useWorkspaceStore();
+  const { list, refresh } = useLabelsStore();
+  const { selected, mode, loadForWorkspace } = useLabelFilterStore();
+
+  const wsID = selectedID ?? "";
+
+  useEffect(() => {
+    if (!wsID) return;
+    refresh(wsID);
+    loadForWorkspace(wsID);
+  }, [wsID, refresh, loadForWorkspace]);
+
+  const labels = [...list(wsID)].sort((a, b) => a.name.localeCompare(b.name));
+
+  if (labels.length === 0) return null;
+
+  const hasSelection = selected.length > 0;
+
+  return (
+    <div className="px-4 py-1.5 border-b border-slate-800 flex items-center gap-2 min-h-[36px]">
+      {/* AND/OR toggle — only meaningful when ≥2 labels selected */}
+      <div
+        role="group"
+        aria-label="Filter mode"
+        className="flex-shrink-0 flex rounded overflow-hidden border border-slate-700 text-[10px] font-semibold"
+      >
+        {(["or", "and"] as LabelFilterMode[]).map((m) => (
+          <button
+            key={m}
+            onClick={() => setFilterMode(wsID, m)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                setFilterMode(wsID, m);
+              }
+            }}
+            aria-pressed={mode === m}
+            className={
+              "px-1.5 py-0.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-slate-400 transition-colors " +
+              (mode === m ? "bg-slate-600 text-white" : "bg-transparent text-slate-500 hover:text-slate-300")
+            }
+          >
+            {m.toUpperCase()}
+          </button>
+        ))}
+      </div>
+
+      {/* Label chips — horizontal scroll */}
+      <div className="flex items-center gap-1.5 overflow-x-auto flex-1 min-w-0 scrollbar-hide">
+        {labels.map((lab) => (
+          <LabelChip
+            key={lab.name}
+            label={lab}
+            selected={selected.includes(lab.name)}
+            workspaceID={wsID}
+          />
+        ))}
+      </div>
+
+      {/* Clear button — only shown when a selection is active */}
+      {hasSelection && (
+        <button
+          onClick={() => clearFilter(wsID)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              clearFilter(wsID);
+            }
+          }}
+          className="flex-shrink-0 text-[10px] text-slate-500 hover:text-slate-200 px-1.5 py-0.5 rounded border border-slate-800 hover:border-slate-600 focus:outline-none focus-visible:ring-1 focus-visible:ring-slate-400"
+          aria-label="Clear label filter"
+        >
+          ✕ Clear
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/stores/useLabelFilterStore.test.ts
+++ b/frontend/src/stores/useLabelFilterStore.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock the Wails bindings before importing the store.
+vi.mock("../../wailsjs/go/main/App", () => ({
+  GetLabelFilter: vi.fn().mockResolvedValue({ labels: [], mode: "or" }),
+  SetLabelFilter: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Import after mock setup so the module uses our stubs.
+import { useLabelFilterStore, toggleLabel, setFilterMode, clearFilter } from "./useLabelFilterStore";
+import { GetLabelFilter, SetLabelFilter } from "../../wailsjs/go/main/App";
+
+const wsID = "ws-test";
+
+beforeEach(() => {
+  useLabelFilterStore.setState({ selected: [], mode: "or" });
+  vi.clearAllMocks();
+});
+
+describe("useLabelFilterStore", () => {
+  it("starts with empty selection and or mode", () => {
+    const { selected, mode } = useLabelFilterStore.getState();
+    expect(selected).toEqual([]);
+    expect(mode).toBe("or");
+  });
+
+  it("toggle adds a label", () => {
+    useLabelFilterStore.getState().toggle("bug");
+    expect(useLabelFilterStore.getState().selected).toEqual(["bug"]);
+  });
+
+  it("toggle removes a label that is already selected", () => {
+    useLabelFilterStore.setState({ selected: ["bug", "feature"] });
+    useLabelFilterStore.getState().toggle("bug");
+    expect(useLabelFilterStore.getState().selected).toEqual(["feature"]);
+  });
+
+  it("setMode changes the mode", () => {
+    useLabelFilterStore.getState().setMode("and");
+    expect(useLabelFilterStore.getState().mode).toBe("and");
+  });
+
+  it("clear resets selection and mode to or", () => {
+    useLabelFilterStore.setState({ selected: ["bug"], mode: "and" });
+    useLabelFilterStore.getState().clear();
+    expect(useLabelFilterStore.getState().selected).toEqual([]);
+    expect(useLabelFilterStore.getState().mode).toBe("or");
+  });
+
+  it("loadForWorkspace seeds state from GetLabelFilter", async () => {
+    (GetLabelFilter as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ labels: ["bug"], mode: "and" });
+    await useLabelFilterStore.getState().loadForWorkspace(wsID);
+    const { selected, mode } = useLabelFilterStore.getState();
+    expect(selected).toEqual(["bug"]);
+    expect(mode).toBe("and");
+    expect(GetLabelFilter).toHaveBeenCalledWith(wsID);
+  });
+
+  it("loadForWorkspace resets state on empty workspaceID", async () => {
+    useLabelFilterStore.setState({ selected: ["bug"], mode: "and" });
+    await useLabelFilterStore.getState().loadForWorkspace("");
+    expect(useLabelFilterStore.getState().selected).toEqual([]);
+    expect(useLabelFilterStore.getState().mode).toBe("or");
+  });
+
+  it("loadForWorkspace falls back to empty on error", async () => {
+    (GetLabelFilter as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("fail"));
+    useLabelFilterStore.setState({ selected: ["bug"], mode: "and" });
+    await useLabelFilterStore.getState().loadForWorkspace(wsID);
+    expect(useLabelFilterStore.getState().selected).toEqual([]);
+    expect(useLabelFilterStore.getState().mode).toBe("or");
+  });
+});
+
+describe("toggleLabel action helper", () => {
+  it("calls toggle and schedules SetLabelFilter", async () => {
+    vi.useFakeTimers();
+    toggleLabel(wsID, "bug");
+    expect(useLabelFilterStore.getState().selected).toEqual(["bug"]);
+    vi.advanceTimersByTime(300);
+    expect(SetLabelFilter).toHaveBeenCalledWith(wsID, ["bug"], "or");
+    vi.useRealTimers();
+  });
+});
+
+describe("clearFilter action helper", () => {
+  it("resets and persists", async () => {
+    vi.useFakeTimers();
+    useLabelFilterStore.setState({ selected: ["bug"], mode: "and" });
+    clearFilter(wsID);
+    expect(useLabelFilterStore.getState().selected).toEqual([]);
+    vi.advanceTimersByTime(300);
+    expect(SetLabelFilter).toHaveBeenCalledWith(wsID, [], "or");
+    vi.useRealTimers();
+  });
+});
+
+describe("setFilterMode action helper", () => {
+  it("changes mode and persists", () => {
+    vi.useFakeTimers();
+    setFilterMode(wsID, "and");
+    expect(useLabelFilterStore.getState().mode).toBe("and");
+    vi.advanceTimersByTime(300);
+    expect(SetLabelFilter).toHaveBeenCalledWith(wsID, [], "and");
+    vi.useRealTimers();
+  });
+});
+
+describe("board label filter logic (pure)", () => {
+  type FakeIssue = { labels: string[] };
+  function applyFilter(issues: FakeIssue[], selected: string[], mode: "and" | "or"): FakeIssue[] {
+    if (selected.length === 0) return issues;
+    const labelSet = new Set(selected);
+    return issues.filter((i) => {
+      const cardLabels = i.labels ?? [];
+      return mode === "and"
+        ? [...labelSet].every((l) => cardLabels.includes(l))
+        : cardLabels.some((l) => labelSet.has(l));
+    });
+  }
+
+  it("passthrough when no labels selected", () => {
+    const issues = [{ labels: ["bug"] }, { labels: [] }];
+    expect(applyFilter(issues, [], "or")).toHaveLength(2);
+  });
+
+  it("OR: passes card matching any selected label", () => {
+    const issues = [{ labels: ["bug"] }, { labels: ["feature"] }, { labels: [] }];
+    expect(applyFilter(issues, ["bug"], "or")).toEqual([{ labels: ["bug"] }]);
+  });
+
+  it("OR: multi-select matches either label", () => {
+    const issues = [{ labels: ["bug"] }, { labels: ["feature"] }, { labels: ["docs"] }];
+    expect(applyFilter(issues, ["bug", "feature"], "or")).toHaveLength(2);
+  });
+
+  it("AND: requires all selected labels", () => {
+    const issues = [
+      { labels: ["bug", "feature"] },
+      { labels: ["bug"] },
+      { labels: ["feature"] },
+    ];
+    expect(applyFilter(issues, ["bug", "feature"], "and")).toEqual([{ labels: ["bug", "feature"] }]);
+  });
+
+  it("AND with single label is equivalent to OR", () => {
+    const issues = [{ labels: ["bug"] }, { labels: ["feature"] }];
+    const orResult = applyFilter(issues, ["bug"], "or");
+    const andResult = applyFilter(issues, ["bug"], "and");
+    expect(orResult).toEqual(andResult);
+  });
+});

--- a/frontend/src/stores/useLabelFilterStore.ts
+++ b/frontend/src/stores/useLabelFilterStore.ts
@@ -1,0 +1,79 @@
+import { create } from "zustand";
+import { GetLabelFilter, SetLabelFilter } from "../../wailsjs/go/main/App";
+
+export type LabelFilterMode = "and" | "or";
+
+type State = {
+  selected: string[];
+  mode: LabelFilterMode;
+  toggle: (label: string) => void;
+  clear: () => void;
+  setMode: (mode: LabelFilterMode) => void;
+  loadForWorkspace: (workspaceID: string) => Promise<void>;
+};
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+function persist(workspaceID: string, selected: string[], mode: LabelFilterMode) {
+  if (debounceTimer) clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => {
+    SetLabelFilter(workspaceID, selected, mode).catch(() => {});
+  }, 250);
+}
+
+export const useLabelFilterStore = create<State>((set, get) => ({
+  selected: [],
+  mode: "or",
+
+  loadForWorkspace: async (workspaceID) => {
+    if (!workspaceID) {
+      set({ selected: [], mode: "or" });
+      return;
+    }
+    try {
+      const state = await GetLabelFilter(workspaceID);
+      set({
+        selected: state?.labels ?? [],
+        mode: (state?.mode as LabelFilterMode) ?? "or",
+      });
+    } catch {
+      set({ selected: [], mode: "or" });
+    }
+  },
+
+  toggle: (label) => {
+    set((s) => {
+      const next = s.selected.includes(label)
+        ? s.selected.filter((l) => l !== label)
+        : [...s.selected, label];
+      return { selected: next };
+    });
+  },
+
+  setMode: (mode) => {
+    set({ mode });
+  },
+
+  clear: () => {
+    set({ selected: [], mode: "or" });
+  },
+}));
+
+// Persist changes after every mutation. Callers that mutate call persist() via
+// the action wrappers below so the store itself stays framework-agnostic.
+export function toggleLabel(workspaceID: string, label: string) {
+  useLabelFilterStore.getState().toggle(label);
+  const { selected, mode } = useLabelFilterStore.getState();
+  persist(workspaceID, selected, mode);
+}
+
+export function setFilterMode(workspaceID: string, mode: LabelFilterMode) {
+  useLabelFilterStore.getState().setMode(mode);
+  const { selected } = useLabelFilterStore.getState();
+  persist(workspaceID, selected, mode);
+}
+
+export function clearFilter(workspaceID: string) {
+  useLabelFilterStore.getState().clear();
+  persist(workspaceID, [], "or");
+}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -51,6 +51,8 @@ export function GetAutoPullPaused():Promise<boolean>;
 
 export function GetIssueView(arg1:string,arg2:number):Promise<issueview.IssueView>;
 
+export function GetLabelFilter(arg1:string):Promise<main.LabelFilterState>;
+
 export function GetMidRunQuestion(arg1:string,arg2:number,arg3:string):Promise<types.Question>;
 
 export function GetNotifyPrefs():Promise<main.NotifyPrefs>;
@@ -144,6 +146,8 @@ export function SetAutoPullPaused(arg1:boolean):Promise<void>;
 export function SetGoalStatus(arg1:string,arg2:string):Promise<void>;
 
 export function SetIssueLabels(arg1:string,arg2:number,arg3:Array<string>):Promise<void>;
+
+export function SetLabelFilter(arg1:string,arg2:Array<string>,arg3:string):Promise<void>;
 
 export function SetNotifyPrefs(arg1:main.NotifyPrefs):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -82,6 +82,10 @@ export function GetIssueView(arg1, arg2) {
   return window['go']['main']['App']['GetIssueView'](arg1, arg2);
 }
 
+export function GetLabelFilter(arg1) {
+  return window['go']['main']['App']['GetLabelFilter'](arg1);
+}
+
 export function GetMidRunQuestion(arg1, arg2, arg3) {
   return window['go']['main']['App']['GetMidRunQuestion'](arg1, arg2, arg3);
 }
@@ -268,6 +272,10 @@ export function SetGoalStatus(arg1, arg2) {
 
 export function SetIssueLabels(arg1, arg2, arg3) {
   return window['go']['main']['App']['SetIssueLabels'](arg1, arg2, arg3);
+}
+
+export function SetLabelFilter(arg1, arg2, arg3) {
+  return window['go']['main']['App']['SetLabelFilter'](arg1, arg2, arg3);
 }
 
 export function SetNotifyPrefs(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -967,6 +967,20 @@ export namespace main {
 	        this.model = source["model"];
 	    }
 	}
+	export class LabelFilterState {
+	    labels: string[];
+	    mode: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new LabelFilterState(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.labels = source["labels"];
+	        this.mode = source["mode"];
+	    }
+	}
 	export class NotifyPrefs {
 	    muted: boolean;
 	    quiet_start: string;

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -1,6 +1,9 @@
 package store
 
-import "errors"
+import (
+	"encoding/json"
+	"errors"
+)
 
 // GetSetting returns the value for a key, or "" if missing.
 func (s *Store) GetSetting(key string) (string, error) {
@@ -33,6 +36,43 @@ func (s *Store) DeleteSetting(key string) error {
 	}
 	_, err := s.DB.Exec(`DELETE FROM settings WHERE key = ?`, key)
 	return err
+}
+
+// GetLabelFilter returns the persisted label filter selection for a workspace.
+// Returns empty labels slice and "or" mode when the key is absent.
+func (s *Store) GetLabelFilter(workspaceID string) (labels []string, mode string, err error) {
+	labelsStr, err := s.GetSetting("label_filter:" + workspaceID + ":labels")
+	if err != nil {
+		return []string{}, "or", err
+	}
+	mode, _ = s.GetSetting("label_filter:" + workspaceID + ":mode")
+	if labelsStr != "" {
+		if jerr := json.Unmarshal([]byte(labelsStr), &labels); jerr != nil {
+			labels = []string{}
+		}
+	}
+	if labels == nil {
+		labels = []string{}
+	}
+	if mode == "" {
+		mode = "or"
+	}
+	return labels, mode, nil
+}
+
+// SetLabelFilter persists the label filter selection for a workspace.
+func (s *Store) SetLabelFilter(workspaceID string, labels []string, mode string) error {
+	if labels == nil {
+		labels = []string{}
+	}
+	b, err := json.Marshal(labels)
+	if err != nil {
+		return err
+	}
+	if err := s.SetSetting("label_filter:"+workspaceID+":labels", string(b)); err != nil {
+		return err
+	}
+	return s.SetSetting("label_filter:"+workspaceID+":mode", mode)
 }
 
 // AllSettings returns the full kv table as a map.

--- a/internal/store/settings_test.go
+++ b/internal/store/settings_test.go
@@ -1,0 +1,76 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetLabelFilterDefaults(t *testing.T) {
+	s := newTestStore(t)
+	labels, mode, err := s.GetLabelFilter("ws1")
+	if err != nil {
+		t.Fatalf("GetLabelFilter: %v", err)
+	}
+	if mode != "or" {
+		t.Errorf("default mode = %q, want %q", mode, "or")
+	}
+	if len(labels) != 0 {
+		t.Errorf("default labels = %v, want empty", labels)
+	}
+}
+
+func TestSetAndGetLabelFilter(t *testing.T) {
+	s := newTestStore(t)
+
+	want := []string{"bug", "enhancement"}
+	if err := s.SetLabelFilter("ws1", want, "and"); err != nil {
+		t.Fatalf("SetLabelFilter: %v", err)
+	}
+
+	got, mode, err := s.GetLabelFilter("ws1")
+	if err != nil {
+		t.Fatalf("GetLabelFilter: %v", err)
+	}
+	if mode != "and" {
+		t.Errorf("mode = %q, want %q", mode, "and")
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("labels = %v, want %v", got, want)
+	}
+}
+
+func TestSetLabelFilterNilSlice(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.SetLabelFilter("ws2", nil, "or"); err != nil {
+		t.Fatalf("SetLabelFilter nil: %v", err)
+	}
+
+	got, mode, err := s.GetLabelFilter("ws2")
+	if err != nil {
+		t.Fatalf("GetLabelFilter: %v", err)
+	}
+	if mode != "or" {
+		t.Errorf("mode = %q, want or", mode)
+	}
+	if len(got) != 0 {
+		t.Errorf("labels = %v, want empty", got)
+	}
+}
+
+func TestSetLabelFilterWorkspaceIsolation(t *testing.T) {
+	s := newTestStore(t)
+
+	_ = s.SetLabelFilter("ws1", []string{"bug"}, "and")
+	_ = s.SetLabelFilter("ws2", []string{"feature"}, "or")
+
+	labels1, mode1, _ := s.GetLabelFilter("ws1")
+	labels2, mode2, _ := s.GetLabelFilter("ws2")
+
+	if !reflect.DeepEqual(labels1, []string{"bug"}) || mode1 != "and" {
+		t.Errorf("ws1 = %v/%s, want [bug]/and", labels1, mode1)
+	}
+	if !reflect.DeepEqual(labels2, []string{"feature"}) || mode2 != "or" {
+		t.Errorf("ws2 = %v/%s, want [feature]/or", labels2, mode2)
+	}
+}


### PR DESCRIPTION
## Summary

- Replaces the `+ test issue` debug row in `App.tsx` with a `<LabelFilterStrip />` component that shows clickable label chips above the board
- Users can select multiple labels and choose AND vs OR semantics; selection and mode persist per-workspace in the settings KV and survive app restarts
- Board card pipeline gets an additional `.filter()` stage (after text search) that hides cards not matching the active label selection

## Files modified

- `internal/store/settings.go` — adds `GetLabelFilter` / `SetLabelFilter` store methods with JSON-encoded labels array
- `internal/store/settings_test.go` — 4 unit tests covering defaults, round-trip, nil slice, workspace isolation
- `app.go` — adds `LabelFilterState` struct + `GetLabelFilter` / `SetLabelFilter` bound methods
- `frontend/wailsjs/go/main/App.js` + `App.d.ts` — manually updated + regenerated by `wails build` with new bindings
- `frontend/wailsjs/go/models.ts` — `main.LabelFilterState` class injected and confirmed by `wails build`
- `frontend/src/stores/useLabelFilterStore.ts` — Zustand store with toggle / clear / setMode + debounced persistence helpers
- `frontend/src/stores/useLabelFilterStore.test.ts` — 16 unit tests (store state transitions, action helpers, board filter logic)
- `frontend/src/components/LabelFilterStrip.tsx` — responsive single-row scrollable chip strip with AND/OR toggle and Clear button; chips are keyboard-focusable with `aria-pressed`
- `frontend/src/components/Board.tsx` — imports `useLabelFilterStore`; adds label filter stage to the `grouped` useMemo after the text-search stage
- `frontend/src/App.tsx` — removes debug row + unused `AddIssueQuick` import; mounts `<LabelFilterStrip />`

## Verification

| Gate | Command | Result |
|------|---------|--------|
| Go lint | `go vet ./internal/...` | ✅ pass |
| TypeScript | `tsc --noEmit` | ✅ pass (0 errors) |
| Go tests | `go test ./internal/...` | ✅ pass (all packages) |
| Frontend tests | `vitest run` | ✅ 36/36 pass (16 new) |
| Build | `wails build` | ✅ pass |
| Smoke test | `playwright test tests/e2e/startup.spec.ts` | ⚠️ skipped — requires running Wails dev server (ERR_CONNECTION_REFUSED); no dev server in worktree environment |

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-110

Closes #110