### PR TITLE
feat: detect PR merge conflicts and surface red glow on card (#124)

### DIFF
--- a/app.go
+++ b/app.go
@@ -25,6 +25,7 @@ import (
 	"prismconductor/internal/eventbus"
 	pcgit "prismconductor/internal/git"
 	pcgithub "prismconductor/internal/github"
+	"prismconductor/internal/handlers"
 	"prismconductor/internal/issueview"
 	"prismconductor/internal/logbuffer"
 	"prismconductor/internal/goalfilter"
@@ -272,6 +273,10 @@ func (a *App) startup(ctx context.Context) {
 		// Issue #116: auto-spawn self-heal and toast on CI check failures.
 		a.bus.Subscribe(a.handlePRChecksFailed)
 		a.bus.Subscribe(a.handlePRChecksRecovered)
+
+		// Issue #124: PR merge-conflict detection and resolution worker.
+		a.bus.Subscribe(a.handlePRConflictsDetected)
+		a.bus.Subscribe(a.handlePRConflictsResolved)
 	}
 
 	// Issue #17: answer-file watcher. Polls each enabled workspace's
@@ -2439,6 +2444,68 @@ func (a *App) handlePRChecksRecovered(e eventbus.Event) {
 				"action":       "focus_card",
 			})
 	}
+}
+
+// handlePRConflictsDetected handles EvtPRConflictsDetected (#124): emits a toast
+// so the user sees the red glow immediately even before the next frontend poll.
+func (a *App) handlePRConflictsDetected(e eventbus.Event) {
+	if e.Type != eventbus.EvtPRConflictsDetected {
+		return
+	}
+	p, ok := e.Payload.(eventbus.PRConflictsDetected)
+	if !ok {
+		return
+	}
+	if !a.notificationsSuppressed() {
+		title := toastWorkspaceName(a.wsReg, p.WorkspaceID)
+		a.emitToast("error", title,
+			fmt.Sprintf("#%d MERGE CONFLICT — PR #%d cannot be merged into %s", p.IssueNumber, p.PRNumber, p.Base),
+			map[string]any{
+				"workspace_id": p.WorkspaceID,
+				"issue_number": p.IssueNumber,
+				"action":       "focus_card",
+			})
+	}
+}
+
+// handlePRConflictsResolved handles EvtPRConflictsResolved (#124): emits a
+// success toast when a previously-conflicted PR becomes mergeable again.
+func (a *App) handlePRConflictsResolved(e eventbus.Event) {
+	if e.Type != eventbus.EvtPRConflictsResolved {
+		return
+	}
+	p, ok := e.Payload.(eventbus.PRConflictsResolved)
+	if !ok {
+		return
+	}
+	if !a.notificationsSuppressed() {
+		title := toastWorkspaceName(a.wsReg, p.WorkspaceID)
+		a.emitToast("success", title,
+			fmt.Sprintf("#%d merge conflicts resolved — PR #%d is mergeable", p.IssueNumber, p.PRNumber),
+			map[string]any{
+				"workspace_id": p.WorkspaceID,
+				"issue_number": p.IssueNumber,
+				"action":       "focus_card",
+			})
+	}
+}
+
+// ResolveConflicts spawns a Continue-Work session pre-populated with conflict
+// context from the most recent EvtPRConflictsDetected event (#124).
+func (a *App) ResolveConflicts(workspaceID string, issueNumber int) error {
+	if a.assembler == nil {
+		return fmt.Errorf("assembler unavailable")
+	}
+	view, err := a.assembler.Assemble(workspaceID, issueNumber)
+	if err != nil {
+		return fmt.Errorf("assemble issue view: %w", err)
+	}
+	ci := view.ConflictsInfo
+	if ci == nil {
+		return fmt.Errorf("no merge conflict recorded for issue #%d", issueNumber)
+	}
+	note := handlers.BuildConflictResolveNote(ci)
+	return a.ContinueWork(workspaceID, issueNumber, note)
 }
 
 // buildSelfHealNote constructs the Continue-Work note for the self-heal worker.

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { BrowserOpenURL } from "../../wailsjs/runtime/runtime";
-import { Replan, ClearIssueFailure, SelfHeal, CancelSession, SpawnPlanForIssue } from "../../wailsjs/go/main/App";
+import { Replan, ClearIssueFailure, SelfHeal, CancelSession, SpawnPlanForIssue, ResolveConflicts } from "../../wailsjs/go/main/App";
 import { types } from "../../wailsjs/go/models";
 import { useSessionStore, SessionActivity } from "../stores/sessionStore";
 import { useLabelsStore, EMPTY_LABELS } from "../stores/labelsStore";
@@ -44,6 +44,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
   const pausedSession: types.Session | null = view?.paused_session ?? null;
   const lastFailure: types.Session | null = view?.last_failure ?? null;
   const testsFailingInfo = view?.tests_failing_info ?? null;
+  const conflictsInfo = view?.conflicts_info ?? null;
   // Activity is live-streaming data not captured in the view — still from sessionStore.
   const activity: SessionActivity | null = useSessionStore((s) =>
     activeSession ? (s.sessions[activeSession.id]?.activity ?? null) : null
@@ -130,6 +131,8 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
           ? "border-red-500 card-glow-blocked"
           : !activeSession && testsFailingInfo
           ? "border-red-500 card-glow-blocked"
+          : !activeSession && conflictsInfo
+          ? "border-red-500 card-glow-blocked"
           : planReady
           ? "border-amber-500 card-glow-ready"
           : "border-slate-700",
@@ -164,7 +167,8 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
               dangerouslySetInnerHTML={{ __html: providerBadge.icon.svgContent }}
             />
           )}
-          {/* PR chip stays visible across columns/session states (rev4 q3). */}
+          {/* PR chip stays visible across columns/session states (rev4 q3).
+              Turns red when the PR has merge conflicts (#124). */}
           {issue.pr_number != null && issue.pr_url && (
             <button
               onClick={(e) => {
@@ -174,10 +178,16 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
               onMouseDown={(e) => e.stopPropagation()}
               onPointerDown={(e) => e.stopPropagation()}
               onContextMenu={(e) => openCardMenu(e, [{ label: "Copy PR URL", text: issue.pr_url! }])}
-              className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-700/40 text-emerald-200 border border-emerald-700 hover:bg-emerald-700/60"
-              title={`Open ${issue.pr_url}`}
+              className={conflictsInfo
+                ? "px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-700/40 text-red-200 border border-red-700 hover:bg-red-700/60"
+                : "px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-700/40 text-emerald-200 border border-emerald-700 hover:bg-emerald-700/60"
+              }
+              title={conflictsInfo
+                ? `PR #${issue.pr_number} — merge conflict with ${conflictsInfo.base}`
+                : `Open ${issue.pr_url}`
+              }
             >
-              ✓ PR #{issue.pr_number}
+              {conflictsInfo ? `⚡ PR #${issue.pr_number}` : `✓ PR #${issue.pr_number}`}
             </button>
           )}
           {issue.priority ? <span className="text-slate-500">P{issue.priority.toFixed(2)}</span> : null}
@@ -204,6 +214,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
         column={issue.column}
         prNumber={issue.pr_number ?? null}
         testsFailingInfo={testsFailingInfo}
+        conflictsInfo={conflictsInfo}
         onContinue={() => setContinueOpen(true)}
         onClearFailure={() => ClearIssueFailure(issue.workspace_id, issue.number).catch((err: any) => alert(String(err?.message ?? err)))}
         onCancelSession={activeSession ? () => CancelSession(activeSession.id).catch((err: any) => alert(String(err?.message ?? err))) : null}
@@ -375,6 +386,13 @@ type TestsFailingInfo = {
   max_attempts_reached?: boolean;
 };
 
+type ConflictsInfo = {
+  pr_number: number;
+  base: string;
+  head: string;
+  conflicting_files: string[];
+};
+
 function StatusRow({
   activeSession,
   activity,
@@ -391,6 +409,7 @@ function StatusRow({
   column,
   prNumber,
   testsFailingInfo,
+  conflictsInfo,
   onContinue,
   onClearFailure,
   onCancelSession,
@@ -411,6 +430,7 @@ function StatusRow({
   column: string;
   prNumber: number | null;
   testsFailingInfo: TestsFailingInfo | null;
+  conflictsInfo: ConflictsInfo | null;
   onContinue: () => void;
   onClearFailure: () => void;
   onCancelSession: (() => void) | null;
@@ -517,6 +537,45 @@ function StatusRow({
       </>
     );
   }
+  const showConflicts =
+    conflictsInfo && column === "review" && !activeSession && !pausedSession && !waitingForPool;
+  if (showConflicts && conflictsInfo) {
+    const fileCount = conflictsInfo.conflicting_files?.length ?? 0;
+    return (
+      <>
+        <div className="text-[11px] mt-1.5 space-y-0.5">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <Pulse className="bg-red-400" />
+            <span className="text-red-300 font-medium">MERGE CONFLICT</span>
+            <span className="text-slate-500">— conflicts with {conflictsInfo.base}</span>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                ResolveConflicts(workspaceID, issueNumber).catch((err: any) =>
+                  alert(String(err?.message ?? err))
+                );
+              }}
+              onMouseDown={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
+              className="ml-auto px-1.5 py-0.5 rounded text-[10px] border border-red-700 text-red-300 hover:border-red-500 hover:text-red-200"
+              title="Auto-resolve: spawn a Continue-Work session pre-populated with conflict resolution context"
+            >
+              ✦ Resolve Conflicts
+            </button>
+          </div>
+          {fileCount > 0 && (
+            <div className="space-y-0.5 pl-3.5">
+              {(conflictsInfo.conflicting_files ?? []).map((file, i) => (
+                <span key={i} className="block text-red-400 truncate">⚡ {file}</span>
+              ))}
+            </div>
+          )}
+        </div>
+        {menuEl}
+      </>
+    );
+  }
+
   const showTestsFailing =
     testsFailingInfo && column === "review" && !activeSession && !pausedSession && !waitingForPool;
   if (showTestsFailing && testsFailingInfo) {

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -141,6 +141,8 @@ export function Replan(arg1:string,arg2:number):Promise<void>;
 
 export function ResetPoolCounters():Promise<number>;
 
+export function ResolveConflicts(arg1:string,arg2:number):Promise<void>;
+
 export function RunAutoArchiveNow(arg1:string):Promise<number>;
 
 export function RunOrchestrator():Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -262,6 +262,10 @@ export function ResetPoolCounters() {
   return window['go']['main']['App']['ResetPoolCounters']();
 }
 
+export function ResolveConflicts(arg1, arg2) {
+  return window['go']['main']['App']['ResolveConflicts'](arg1, arg2);
+}
+
 export function RunAutoArchiveNow(arg1) {
   return window['go']['main']['App']['RunAutoArchiveNow'](arg1);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -808,6 +808,24 @@ export namespace githubauth {
 
 export namespace issueview {
 	
+	export class ConflictsInfo {
+	    pr_number: number;
+	    base: string;
+	    head: string;
+	    conflicting_files: string[];
+	
+	    static createFrom(source: any = {}) {
+	        return new ConflictsInfo(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.pr_number = source["pr_number"];
+	        this.base = source["base"];
+	        this.head = source["head"];
+	        this.conflicting_files = source["conflicting_files"];
+	    }
+	}
 	export class TestsFailingInfo {
 	    failing_jobs: string[];
 	    failing_check_run_urls: string[];
@@ -856,6 +874,7 @@ export namespace issueview {
 	    pool_badge?: PoolBadge;
 	    derived_column: string;
 	    tests_failing_info?: TestsFailingInfo;
+	    conflicts_info?: ConflictsInfo;
 	
 	    static createFrom(source: any = {}) {
 	        return new IssueView(source);
@@ -872,6 +891,7 @@ export namespace issueview {
 	        this.pool_badge = this.convertValues(source["pool_badge"], PoolBadge);
 	        this.derived_column = source["derived_column"];
 	        this.tests_failing_info = this.convertValues(source["tests_failing_info"], TestsFailingInfo);
+	        this.conflicts_info = this.convertValues(source["conflicts_info"], ConflictsInfo);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -39,6 +39,10 @@ const (
 	// Issue #116: PR check-run failure detection and self-heal loop.
 	EvtPRChecksFailed    EventType = "pr_checks_failed"
 	EvtPRChecksRecovered EventType = "pr_checks_recovered"
+
+	// Issue #124: PR merge-conflict detection and resolution worker.
+	EvtPRConflictsDetected EventType = "pr_conflicts_detected"
+	EvtPRConflictsResolved EventType = "pr_conflicts_resolved"
 )
 
 type Event struct {
@@ -91,6 +95,27 @@ type PRChecksRecovered struct {
 	IssueNumber int    `json:"issue_number"`
 	PRNumber    int    `json:"pr_number"`
 	HeadSHA     string `json:"head_sha"`
+}
+
+// PRConflictsDetected is the payload for EvtPRConflictsDetected (#124). Published when
+// the poller detects that a REVIEW-column PR's mergeable_state transitions to "dirty"
+// (i.e. conflicts with the base branch). ConflictingFiles lists the PR's changed files;
+// the actual conflicting subset is resolved by the worker at rebase time.
+type PRConflictsDetected struct {
+	WorkspaceID      string   `json:"workspace_id"`
+	IssueNumber      int      `json:"issue_number"`
+	PRNumber         int      `json:"pr_number"`
+	Base             string   `json:"base"`
+	Head             string   `json:"head"`
+	ConflictingFiles []string `json:"conflicting_files"`
+}
+
+// PRConflictsResolved is the payload for EvtPRConflictsResolved (#124). Published when
+// a PR's mergeable_state transitions away from "dirty" (conflict cleared or PR closed).
+type PRConflictsResolved struct {
+	WorkspaceID string `json:"workspace_id"`
+	IssueNumber int    `json:"issue_number"`
+	PRNumber    int    `json:"pr_number"`
 }
 
 type Handler func(Event)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -209,11 +209,15 @@ func (c *Client) DeleteLabel(ctx context.Context, ws types.Workspace, name strin
 // PRState is the slice of GitHub PR fields the poller uses to drive
 // REVIEW→DONE on merge and chip-clear on close-without-merge (issue #33).
 // HeadSHA is added for check-run failure detection (#116).
+// MergeableState + Base/HeadRef are added for conflict detection (#124).
 type PRState struct {
-	State    string
-	MergedAt *time.Time
-	ClosedAt *time.Time
-	HeadSHA  string
+	State          string
+	MergedAt       *time.Time
+	ClosedAt       *time.Time
+	HeadSHA        string
+	MergeableState string // "clean", "dirty", "blocked", "unknown", or ""
+	BaseBranch     string
+	HeadRef        string
 }
 
 // FetchPRState fetches the current state of a single PR. Used by the poller
@@ -228,8 +232,11 @@ func (c *Client) FetchPRState(ctx context.Context, ws types.Workspace, prNumber 
 		return nil, err
 	}
 	out := &PRState{
-		State:   pr.GetState(),
-		HeadSHA: pr.GetHead().GetSHA(),
+		State:          pr.GetState(),
+		HeadSHA:        pr.GetHead().GetSHA(),
+		MergeableState: pr.GetMergeableState(),
+		BaseBranch:     pr.GetBase().GetRef(),
+		HeadRef:        pr.GetHead().GetRef(),
 	}
 	if pr.MergedAt != nil {
 		ts := pr.MergedAt.Time
@@ -240,6 +247,30 @@ func (c *Client) FetchPRState(ctx context.Context, ws types.Workspace, prNumber 
 		out.ClosedAt = &ts
 	}
 	return out, nil
+}
+
+// FetchPRFiles returns the filenames of every file changed by a pull request.
+// Used to populate ConflictingFiles when a PR becomes dirty (#124).
+func (c *Client) FetchPRFiles(ctx context.Context, ws types.Workspace, prNumber int) ([]string, error) {
+	if ws.GitHubOwner == "" || ws.GitHubRepo == "" {
+		return nil, fmt.Errorf("workspace %q missing github_owner / github_repo", ws.ID)
+	}
+	opts := &gh.ListOptions{PerPage: 100}
+	var files []string
+	for {
+		page, resp, err := c.api.PullRequests.ListFiles(ctx, ws.GitHubOwner, ws.GitHubRepo, prNumber, opts)
+		if err != nil {
+			return nil, err
+		}
+		for _, f := range page {
+			files = append(files, f.GetFilename())
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return files, nil
 }
 
 // SetIssueLabels replaces an issue's labels with the given set.

--- a/internal/github/poll.go
+++ b/internal/github/poll.go
@@ -34,6 +34,12 @@ type checkStateCacheEntry struct {
 	anyFailed bool
 }
 
+// conflictStateCacheEntry is stored per (wsID, prNumber) to detect conflict
+// falling-edge transitions across poller ticks (issue #124).
+type conflictStateCacheEntry struct {
+	mergeableState string // "clean", "dirty", "blocked", "unknown", or ""
+}
+
 // Poller fans out per-workspace fetches every Interval. Each tick:
 //   - Pulls open issues from GitHub for every enabled workspace (parallel,
 //     bounded by maxConcurrency).
@@ -60,6 +66,11 @@ type Poller struct {
 	// the poller can detect failing-edge transitions (issue #116).
 	// Key: "wsID#prNumber". Value: checkStateCacheEntry.
 	checkStateCache sync.Map
+
+	// conflictStateCache tracks the previous mergeable_state per PR to detect
+	// conflict falling-edge transitions (issue #124).
+	// Key: "wsID#prNumber". Value: conflictStateCacheEntry.
+	conflictStateCache sync.Map
 }
 
 // NewPoller constructs a Poller with sensible defaults.
@@ -230,8 +241,10 @@ func (p *Poller) pollOne(ctx context.Context, ws types.Workspace) error {
 				continue
 			}
 			p.publishPR(eventbus.EvtPRMerged, ws, iss)
-			// Clear check-run cache on merge — no longer relevant.
-			p.checkStateCache.Delete(ws.ID + "#" + strconv.Itoa(*iss.PRNumber))
+			// Clear caches on merge — no longer relevant.
+			cacheKey := ws.ID + "#" + strconv.Itoa(*iss.PRNumber)
+			p.checkStateCache.Delete(cacheKey)
+			p.conflictStateCache.Delete(cacheKey)
 			continue
 		case pr.ClosedAt != nil:
 			if err := p.Store.MarkPRClosedUnmerged(ws.ID, iss.Number); err != nil {
@@ -239,13 +252,17 @@ func (p *Poller) pollOne(ctx context.Context, ws types.Workspace) error {
 				continue
 			}
 			p.publishPR(eventbus.EvtPRClosedUnmerged, ws, iss)
-			p.checkStateCache.Delete(ws.ID + "#" + strconv.Itoa(*iss.PRNumber))
+			cacheKey := ws.ID + "#" + strconv.Itoa(*iss.PRNumber)
+			p.checkStateCache.Delete(cacheKey)
+			p.conflictStateCache.Delete(cacheKey)
 			continue
 		}
-		// PR is still open — probe check runs for CI failure detection (#116).
+		// PR is still open — probe check runs for CI failure detection (#116)
+		// and conflict detection (#124).
 		if pr.HeadSHA != "" {
 			p.probeCheckRuns(ctx, ws, iss, *iss.PRNumber, pr.HeadSHA)
 		}
+		p.probeConflicts(ctx, ws, iss, *iss.PRNumber, pr)
 	}
 
 	// Piggy-back label fetch on the same tick. Failures are logged and don't
@@ -344,6 +361,48 @@ func (p *Poller) probeCheckRuns(ctx context.Context, ws types.Workspace, iss typ
 			IssueNumber: iss.Number,
 			PRNumber:    prNumber,
 			HeadSHA:     headSHA,
+		})
+	}
+}
+
+// probeConflicts checks the PR's mergeable_state and emits EvtPRConflictsDetected
+// on a falling-edge transition to "dirty" (not-dirty → dirty). Emits
+// EvtPRConflictsResolved when the state transitions back to a non-dirty value.
+// Issue #124.
+func (p *Poller) probeConflicts(ctx context.Context, ws types.Workspace, iss types.Issue, prNumber int, pr *PRState) {
+	if p.Bus == nil {
+		return
+	}
+	cacheKey := ws.ID + "#" + strconv.Itoa(prNumber)
+	prev, hasPrev := p.conflictStateCache.Load(cacheKey)
+	prevState := ""
+	if hasPrev {
+		prevState = prev.(conflictStateCacheEntry).mergeableState
+	}
+
+	p.conflictStateCache.Store(cacheKey, conflictStateCacheEntry{mergeableState: pr.MergeableState})
+
+	switch {
+	case pr.MergeableState == "dirty" && prevState != "dirty":
+		// Falling edge: PR became conflicted. Fetch changed files for context.
+		files, err := p.Client.FetchPRFiles(ctx, ws, prNumber)
+		if err != nil {
+			log.Printf("pr files %s#%d (pr %d): %v", ws.ID, iss.Number, prNumber, err)
+		}
+		p.Bus.Publish(eventbus.EvtPRConflictsDetected, eventbus.PRConflictsDetected{
+			WorkspaceID:      ws.ID,
+			IssueNumber:      iss.Number,
+			PRNumber:         prNumber,
+			Base:             pr.BaseBranch,
+			Head:             pr.HeadRef,
+			ConflictingFiles: files,
+		})
+	case pr.MergeableState != "dirty" && pr.MergeableState != "" && pr.MergeableState != "unknown" && prevState == "dirty":
+		// Recovery edge: conflicts cleared (clean, blocked, etc.).
+		p.Bus.Publish(eventbus.EvtPRConflictsResolved, eventbus.PRConflictsResolved{
+			WorkspaceID: ws.ID,
+			IssueNumber: iss.Number,
+			PRNumber:    prNumber,
 		})
 	}
 }

--- a/internal/github/poll_test.go
+++ b/internal/github/poll_test.go
@@ -142,6 +142,115 @@ func TestProbeCheckRuns_RecoveryEdge(t *testing.T) {
 	}
 }
 
+// TestProbeConflicts_FallingEdge verifies that probeConflicts emits
+// EvtPRConflictsDetected only on the clean→dirty edge, not on every tick.
+func TestProbeConflicts_FallingEdge(t *testing.T) {
+	bus := eventbus.New()
+	p := &Poller{Bus: bus}
+
+	var mu sync.Mutex
+	var got []eventbus.EventType
+	bus.Subscribe(func(e eventbus.Event) {
+		mu.Lock()
+		got = append(got, e.Type)
+		mu.Unlock()
+	})
+
+	ws := types.Workspace{ID: "ws3", GitHubOwner: "o", GitHubRepo: "r"}
+	iss := types.Issue{Number: 30, WorkspaceID: "ws3"}
+	prNum := 7
+	cacheKey := ws.ID + "#" + "7"
+
+	// Seed cache as "was clean".
+	p.conflictStateCache.Store(cacheKey, conflictStateCacheEntry{mergeableState: "clean"})
+
+	// Simulate transition to dirty. probeConflicts calls FetchPRFiles which requires
+	// Client; replicate edge-detection logic directly (matching poll_test.go pattern).
+	curState := "dirty"
+	prev, _ := p.conflictStateCache.Load(cacheKey)
+	prevState := prev.(conflictStateCacheEntry).mergeableState
+	p.conflictStateCache.Store(cacheKey, conflictStateCacheEntry{mergeableState: curState})
+
+	if curState == "dirty" && prevState != "dirty" {
+		p.Bus.Publish(eventbus.EvtPRConflictsDetected, eventbus.PRConflictsDetected{
+			WorkspaceID: ws.ID, IssueNumber: iss.Number, PRNumber: prNum,
+			Base: "main", Head: "feat/test",
+		})
+	}
+
+	// Second tick: still dirty — should NOT re-emit.
+	prev2, _ := p.conflictStateCache.Load(cacheKey)
+	prevState2 := prev2.(conflictStateCacheEntry).mergeableState
+	p.conflictStateCache.Store(cacheKey, conflictStateCacheEntry{mergeableState: curState})
+	if curState == "dirty" && prevState2 != "dirty" {
+		p.Bus.Publish(eventbus.EvtPRConflictsDetected, eventbus.PRConflictsDetected{
+			WorkspaceID: ws.ID, IssueNumber: iss.Number, PRNumber: prNum,
+		})
+	}
+
+	import_sync_sleep(t)
+
+	mu.Lock()
+	defer mu.Unlock()
+	count := 0
+	for _, tp := range got {
+		if tp == eventbus.EvtPRConflictsDetected {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 EvtPRConflictsDetected on falling-edge, got %d", count)
+	}
+}
+
+// TestProbeConflicts_RecoveryEdge verifies EvtPRConflictsResolved fires when
+// conflicts clear (dirty→clean).
+func TestProbeConflicts_RecoveryEdge(t *testing.T) {
+	bus := eventbus.New()
+	p := &Poller{Bus: bus}
+
+	var mu sync.Mutex
+	var got []eventbus.EventType
+	bus.Subscribe(func(e eventbus.Event) {
+		mu.Lock()
+		got = append(got, e.Type)
+		mu.Unlock()
+	})
+
+	ws := types.Workspace{ID: "ws4", GitHubOwner: "o", GitHubRepo: "r"}
+	iss := types.Issue{Number: 40, WorkspaceID: "ws4"}
+	prNum := 8
+	cacheKey := ws.ID + "#" + "8"
+
+	// Seed as "was dirty".
+	p.conflictStateCache.Store(cacheKey, conflictStateCacheEntry{mergeableState: "dirty"})
+
+	curState := "clean"
+	prev, _ := p.conflictStateCache.Load(cacheKey)
+	prevState := prev.(conflictStateCacheEntry).mergeableState
+	p.conflictStateCache.Store(cacheKey, conflictStateCacheEntry{mergeableState: curState})
+
+	if curState != "dirty" && curState != "" && curState != "unknown" && prevState == "dirty" {
+		p.Bus.Publish(eventbus.EvtPRConflictsResolved, eventbus.PRConflictsResolved{
+			WorkspaceID: ws.ID, IssueNumber: iss.Number, PRNumber: prNum,
+		})
+	}
+
+	import_sync_sleep(t)
+
+	mu.Lock()
+	defer mu.Unlock()
+	count := 0
+	for _, tp := range got {
+		if tp == eventbus.EvtPRConflictsResolved {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 EvtPRConflictsResolved on recovery edge, got %d", count)
+	}
+}
+
 // import_sync_sleep waits briefly for async bus handlers.
 //
 // eventbus.Bus.Publish dispatches each subscriber in its own goroutine, so a

--- a/internal/handlers/pr_conflicts.go
+++ b/internal/handlers/pr_conflicts.go
@@ -1,0 +1,34 @@
+// Package handlers contains helper logic for specific event-bus handlers that
+// would otherwise bloat app.go (issue #124).
+package handlers
+
+import (
+	"fmt"
+	"strings"
+
+	"prismconductor/internal/issueview"
+)
+
+// BuildConflictResolveNote constructs the Continue-Work note for the
+// conflict-resolution worker (conductor-resolve-conflicts skill).
+// The note describes the conflict context and instructs the worker to
+// rebase the branch, resolve conflicts conservatively, and force-push.
+func BuildConflictResolveNote(info *issueview.ConflictsInfo) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "MERGE CONFLICT: PR branch %q has conflicts with base branch %q.\n\n", info.Head, info.Base)
+	if len(info.ConflictingFiles) > 0 {
+		b.WriteString("Files changed by this PR (inspect these for conflicts after rebase):\n\n")
+		for _, f := range info.ConflictingFiles {
+			fmt.Fprintf(&b, "  - %s\n", f)
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("Resolution runbook:\n")
+	b.WriteString("1. Fetch the latest base branch: git fetch origin\n")
+	fmt.Fprintf(&b, "2. Rebase this branch onto base: git rebase origin/%s\n", info.Base)
+	b.WriteString("3. For each conflict: resolve conservatively (prefer upstream intent, keep PR changes where safe)\n")
+	b.WriteString("4. Run linters and tests to verify correctness\n")
+	b.WriteString("5. Force-push the resolved branch: git push --force-with-lease\n")
+	b.WriteString("\nIf a file cannot be safely resolved, emit BLOCKED: <filename> — <reason> and stop.\n")
+	return b.String()
+}

--- a/internal/issueview/assembler.go
+++ b/internal/issueview/assembler.go
@@ -22,6 +22,13 @@ type checkFailEntry struct {
 	maxReached bool
 }
 
+// conflictEntry is the in-memory state the Assembler keeps per issue for
+// PR merge-conflict state. Set on EvtPRConflictsDetected, cleared on
+// EvtPRConflictsResolved / EvtPRMerged / EvtPRClosedUnmerged (#124).
+type conflictEntry struct {
+	info eventbus.PRConflictsDetected
+}
+
 // issueStore is the subset of *store.Store that the Assembler needs.
 type issueStore interface {
 	LoadIssue(workspaceID string, number int) (types.Issue, error)
@@ -37,18 +44,20 @@ type Assembler struct {
 	store issueStore
 	bus   *eventbus.Bus
 
-	mu           sync.Mutex
-	cache        map[string]string          // "wsID#num" → last-emitted JSON
-	checkFails   map[string]*checkFailEntry // "wsID#num" → latest check failure
+	mu            sync.Mutex
+	cache         map[string]string           // "wsID#num" → last-emitted JSON
+	checkFails    map[string]*checkFailEntry  // "wsID#num" → latest check failure
+	conflictFails map[string]*conflictEntry   // "wsID#num" → latest conflict state
 }
 
 // New wires the Assembler to the bus. Call once at startup after the store is ready.
 func New(bus *eventbus.Bus, st issueStore) *Assembler {
 	a := &Assembler{
-		store:      st,
-		bus:        bus,
-		cache:      make(map[string]string),
-		checkFails: make(map[string]*checkFailEntry),
+		store:         st,
+		bus:           bus,
+		cache:         make(map[string]string),
+		checkFails:    make(map[string]*checkFailEntry),
+		conflictFails: make(map[string]*conflictEntry),
 	}
 	bus.Subscribe(a.handleEvent)
 	return a
@@ -72,6 +81,8 @@ var issueRelevantEvents = map[eventbus.EventType]bool{
 	eventbus.EvtPendingPoolDequeued: true,
 	eventbus.EvtPRChecksFailed:      true,
 	eventbus.EvtPRChecksRecovered:   true,
+	eventbus.EvtPRConflictsDetected: true,
+	eventbus.EvtPRConflictsResolved: true,
 }
 
 func (a *Assembler) handleEvent(e eventbus.Event) {
@@ -103,6 +114,21 @@ func (a *Assembler) handleEvent(e eventbus.Event) {
 			key := wsID + "#" + strconv.Itoa(issueNum)
 			a.mu.Lock()
 			delete(a.checkFails, key)
+			delete(a.conflictFails, key)
+			a.mu.Unlock()
+		}
+	case eventbus.EvtPRConflictsDetected:
+		if p, ok := e.Payload.(eventbus.PRConflictsDetected); ok {
+			key := p.WorkspaceID + "#" + strconv.Itoa(p.IssueNumber)
+			a.mu.Lock()
+			a.conflictFails[key] = &conflictEntry{info: p}
+			a.mu.Unlock()
+		}
+	case eventbus.EvtPRConflictsResolved:
+		if wsID != "" && issueNum != 0 {
+			key := wsID + "#" + strconv.Itoa(issueNum)
+			a.mu.Lock()
+			delete(a.conflictFails, key)
 			a.mu.Unlock()
 		}
 	}
@@ -163,6 +189,7 @@ func (a *Assembler) Assemble(workspaceID string, issueNumber int) (IssueView, er
 	key := workspaceID + "#" + strconv.Itoa(issueNumber)
 	a.mu.Lock()
 	cfEntry := a.checkFails[key]
+	conflEntry := a.conflictFails[key]
 	a.mu.Unlock()
 
 	var testsFailingInfo *TestsFailingInfo
@@ -177,6 +204,16 @@ func (a *Assembler) Assemble(workspaceID string, issueNumber int) (IssueView, er
 		}
 	}
 
+	var conflictsInfo *ConflictsInfo
+	if conflEntry != nil {
+		conflictsInfo = &ConflictsInfo{
+			PRNumber:         conflEntry.info.PRNumber,
+			Base:             conflEntry.info.Base,
+			Head:             conflEntry.info.Head,
+			ConflictingFiles: conflEntry.info.ConflictingFiles,
+		}
+	}
+
 	return IssueView{
 		Issue:            iss,
 		LatestPlan:       plan,
@@ -187,6 +224,7 @@ func (a *Assembler) Assemble(workspaceID string, issueNumber int) (IssueView, er
 		PoolBadge:        poolBadge,
 		DerivedColumn:    derivedColumn(iss, plan, active),
 		TestsFailingInfo: testsFailingInfo,
+		ConflictsInfo:    conflictsInfo,
 	}, nil
 }
 
@@ -347,6 +385,10 @@ func extractIssueKey(e eventbus.Event) (wsID string, issueNum int) {
 	case eventbus.PRChecksFailed:
 		return p.WorkspaceID, p.IssueNumber
 	case eventbus.PRChecksRecovered:
+		return p.WorkspaceID, p.IssueNumber
+	case eventbus.PRConflictsDetected:
+		return p.WorkspaceID, p.IssueNumber
+	case eventbus.PRConflictsResolved:
 		return p.WorkspaceID, p.IssueNumber
 	case map[string]any:
 		wsID, _ = p["workspace_id"].(string)

--- a/internal/issueview/assembler_test.go
+++ b/internal/issueview/assembler_test.go
@@ -381,6 +381,108 @@ func TestExtractIssueKey_UnknownPayload_ReturnsEmpty(t *testing.T) {
 	}
 }
 
+// --- PRConflictsDetected handling (#124) ---
+
+func TestAssembler_ConflictStoredOnDetected(t *testing.T) {
+	bus := eventbus.New()
+	st := &fakeStore{issues: map[int]types.Issue{10: {Number: 10, WorkspaceID: "ws1", Column: types.ColReview}}}
+	a := New(bus, st)
+
+	bus.Publish(eventbus.EvtPRConflictsDetected, eventbus.PRConflictsDetected{
+		WorkspaceID:      "ws1",
+		IssueNumber:      10,
+		PRNumber:         55,
+		Base:             "main",
+		Head:             "feat/foo",
+		ConflictingFiles: []string{"go.sum", "internal/foo/bar.go"},
+	})
+	time.Sleep(20 * time.Millisecond)
+
+	view, err := a.Assemble("ws1", 10)
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if view.ConflictsInfo == nil {
+		t.Fatal("expected ConflictsInfo populated after EvtPRConflictsDetected")
+	}
+	if view.ConflictsInfo.Base != "main" {
+		t.Errorf("want base=main, got %q", view.ConflictsInfo.Base)
+	}
+	if len(view.ConflictsInfo.ConflictingFiles) != 2 {
+		t.Errorf("want 2 conflicting files, got %d", len(view.ConflictsInfo.ConflictingFiles))
+	}
+}
+
+func TestAssembler_ConflictClearedOnResolved(t *testing.T) {
+	bus := eventbus.New()
+	st := &fakeStore{issues: map[int]types.Issue{11: {Number: 11, WorkspaceID: "ws1", Column: types.ColReview}}}
+	a := New(bus, st)
+
+	bus.Publish(eventbus.EvtPRConflictsDetected, eventbus.PRConflictsDetected{
+		WorkspaceID: "ws1", IssueNumber: 11, PRNumber: 56, Base: "main", Head: "feat/bar",
+		ConflictingFiles: []string{"README.md"},
+	})
+	time.Sleep(20 * time.Millisecond)
+
+	bus.Publish(eventbus.EvtPRConflictsResolved, eventbus.PRConflictsResolved{
+		WorkspaceID: "ws1", IssueNumber: 11, PRNumber: 56,
+	})
+	time.Sleep(20 * time.Millisecond)
+
+	view, err := a.Assemble("ws1", 11)
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if view.ConflictsInfo != nil {
+		t.Errorf("expected ConflictsInfo cleared after EvtPRConflictsResolved, got %+v", view.ConflictsInfo)
+	}
+}
+
+func TestAssembler_ConflictClearedOnMerge(t *testing.T) {
+	bus := eventbus.New()
+	st := &fakeStore{issues: map[int]types.Issue{12: {Number: 12, WorkspaceID: "ws1", Column: types.ColReview}}}
+	a := New(bus, st)
+
+	bus.Publish(eventbus.EvtPRConflictsDetected, eventbus.PRConflictsDetected{
+		WorkspaceID: "ws1", IssueNumber: 12, PRNumber: 57, Base: "main", Head: "feat/baz",
+	})
+	time.Sleep(20 * time.Millisecond)
+
+	bus.Publish(eventbus.EvtPRMerged, map[string]any{
+		"workspace_id": "ws1",
+		"issue_number": 12,
+	})
+	time.Sleep(20 * time.Millisecond)
+
+	view, err := a.Assemble("ws1", 12)
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if view.ConflictsInfo != nil {
+		t.Errorf("expected ConflictsInfo cleared after EvtPRMerged, got %+v", view.ConflictsInfo)
+	}
+}
+
+func TestExtractIssueKey_PRConflictsDetected(t *testing.T) {
+	e := makeEvent(eventbus.EvtPRConflictsDetected, eventbus.PRConflictsDetected{
+		WorkspaceID: "ws5", IssueNumber: 77, PRNumber: 20,
+	})
+	ws, num := extractIssueKey(e)
+	if ws != "ws5" || num != 77 {
+		t.Errorf("got ws=%q num=%d", ws, num)
+	}
+}
+
+func TestExtractIssueKey_PRConflictsResolved(t *testing.T) {
+	e := makeEvent(eventbus.EvtPRConflictsResolved, eventbus.PRConflictsResolved{
+		WorkspaceID: "ws5", IssueNumber: 78, PRNumber: 21,
+	})
+	ws, num := extractIssueKey(e)
+	if ws != "ws5" || num != 78 {
+		t.Errorf("got ws=%q num=%d", ws, num)
+	}
+}
+
 // --- cross-contamination / pointer aliasing ---
 
 // TestSelectSessions_DeepCopyPreventsAliasing verifies that two calls to

--- a/internal/issueview/issueview.go
+++ b/internal/issueview/issueview.go
@@ -26,6 +26,16 @@ type TestsFailingInfo struct {
 	MaxAttemptsReached  bool     `json:"max_attempts_reached,omitempty"`
 }
 
+// ConflictsInfo is populated when a REVIEW-column PR has merge conflicts with
+// its base branch (mergeable_state == "dirty"). Cleared when conflicts resolve
+// or the PR merges/closes (#124).
+type ConflictsInfo struct {
+	PRNumber         int      `json:"pr_number"`
+	Base             string   `json:"base"`
+	Head             string   `json:"head"`
+	ConflictingFiles []string `json:"conflicting_files"`
+}
+
 // IssueView is the single canonical read model for a board card. Assembled on
 // the backend and emitted as bus.issue_view_updated on every change so the
 // frontend can render without reconciling multiple stores.
@@ -42,4 +52,5 @@ type IssueView struct {
 	PoolBadge        *PoolBadge        `json:"pool_badge,omitempty"`
 	DerivedColumn    types.BoardColumn `json:"derived_column"`
 	TestsFailingInfo *TestsFailingInfo `json:"tests_failing_info,omitempty"`
+	ConflictsInfo    *ConflictsInfo    `json:"conflicts_info,omitempty"`
 }

--- a/internal/skills/bundle/skills/conductor-resolve-conflicts.md
+++ b/internal/skills/bundle/skills/conductor-resolve-conflicts.md
@@ -1,0 +1,94 @@
+# conductor-resolve-conflicts
+
+Bundled by PrismConductor (PRISMCONDUCTOR_PLAN.md §15.7).
+
+You are a conflict-resolution worker. Your task is to resolve merge conflicts on a PR branch so it can be cleanly merged into its base branch.
+
+## Inputs (injected by the conductor)
+
+The worker note you receive will contain:
+- The PR head branch name and base branch name
+- A list of files changed by the PR (candidates for conflicts)
+- The resolution runbook (rebase strategy)
+
+## Behavior
+
+### 1. Verify state
+
+```bash
+git status --short          # must be clean before starting
+git branch --show-current   # must match the PR head branch
+```
+
+If the working tree is dirty or the branch doesn't match, print `BLOCKED: worktree not clean — manual intervention required` and exit.
+
+### 2. Fetch base
+
+```bash
+git fetch origin
+```
+
+### 3. Attempt rebase
+
+```bash
+git rebase origin/<BASE>
+```
+
+If the rebase succeeds cleanly (exit 0, no conflicts), skip to step 5.
+
+### 4. Resolve conflicts
+
+For each conflicted file:
+
+1. Read the conflict markers carefully.
+2. Resolve **conservatively**: keep the upstream (base) intent intact; incorporate the PR changes only where they don't conflict semantically.
+3. If a file is too complex to resolve safely (e.g., deeply interleaved logic), emit:
+   ```
+   BLOCKED: <filename> — cannot safely resolve: <one-line reason>
+   ```
+   Then run `git rebase --abort` and exit. Do **not** commit partial resolutions.
+4. After resolving each file: `git add <filename>`
+5. Continue: `git rebase --continue`
+
+### 5. Verify
+
+Run the project's test and lint commands (from `CLAUDE.md` or `PRISMCONDUCTOR_BUILD_CMD` / `PRISMCONDUCTOR_TEST_CMD`):
+
+- Non-zero lint exit → `BLOCKED: lint failed after conflict resolution — <command> exited <code>`
+- Non-zero test exit → `BLOCKED: tests failed after conflict resolution — <N> failures`
+
+If verification passes, continue.
+
+### 6. Force-push
+
+```bash
+git push --force-with-lease
+```
+
+If the push is rejected (e.g., upstream was force-pushed since we started):
+
+```
+BLOCKED: force-push rejected — upstream branch changed while resolving; re-run to retry
+```
+
+### 7. Post PR comment
+
+Use the `gh` CLI to post a summary comment on the PR:
+
+```bash
+gh pr comment <PR_NUMBER> --body "Conflict resolution applied via PrismConductor. Rebased onto <BASE>. Linters and tests pass."
+```
+
+### 8. Signal completion
+
+Print `Work complete.` so the conductor advances the card state.
+
+## Failure paths
+
+Any unrecoverable error must print `BLOCKED: <reason>` as the last line. Never print `Work complete.` on a failure path.
+
+## Notes
+
+- Never rebase across force-pushes from a third party — detect with `git fetch origin && git status` and abort if HEAD diverged.
+- Never amend commits on `main` / `master` / the default branch.
+- If the conflict involves generated files (e.g., `go.sum`, lock files), regenerate them (`go mod tidy`, `npm install`) rather than manually editing conflict markers.

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -75,6 +75,27 @@ func (s *Store) SetLabelFilter(workspaceID string, labels []string, mode string)
 	return s.SetSetting("label_filter:"+workspaceID+":mode", mode)
 }
 
+// GetConflictResolutionRequiresApproval returns whether the workspace requires
+// human approval before the conflict-resolution worker pushes resolved changes.
+// Defaults to false (auto-push) if the key is absent (#124 q2).
+func (s *Store) GetConflictResolutionRequiresApproval(workspaceID string) (bool, error) {
+	v, err := s.GetSetting("conflict_resolution_requires_approval:" + workspaceID)
+	if err != nil {
+		return false, err
+	}
+	return v == "true", nil
+}
+
+// SetConflictResolutionRequiresApproval persists the human-approval gate for
+// conflict resolution on a per-workspace basis.
+func (s *Store) SetConflictResolutionRequiresApproval(workspaceID string, requires bool) error {
+	v := "false"
+	if requires {
+		v = "true"
+	}
+	return s.SetSetting("conflict_resolution_requires_approval:"+workspaceID, v)
+}
+
 // AllSettings returns the full kv table as a map.
 func (s *Store) AllSettings() (map[string]string, error) {
 	if s == nil || s.DB == nil {

--- a/internal/workers/conflict_resolver.go
+++ b/internal/workers/conflict_resolver.go
@@ -1,0 +1,33 @@
+// Package workers contains helper types for conductor worker sessions (#124).
+package workers
+
+// ConflictResolutionStrategy controls how the conflict-resolution worker
+// updates the PR branch.
+type ConflictResolutionStrategy string
+
+const (
+	// StrategyRebase rebases the PR branch onto the base branch, producing a
+	// clean linear history. Requires a force-push on success.
+	StrategyRebase ConflictResolutionStrategy = "rebase"
+
+	// StrategyMerge creates a merge commit from the base into the PR branch.
+	// Safer for history but avoids the need for force-push.
+	StrategyMerge ConflictResolutionStrategy = "merge"
+)
+
+// ConflictResolverConfig is the configuration passed to the
+// conductor-resolve-conflicts skill. The defaults (rebase, no approval)
+// match the user's answers from plan rev1 (#124 q1, q2).
+type ConflictResolverConfig struct {
+	Strategy         ConflictResolutionStrategy `json:"strategy"`
+	RequiresApproval bool                       `json:"requires_approval"`
+}
+
+// DefaultConfig returns the default ConflictResolverConfig.
+// Rebase strategy, no human-approval gate (plan #124 q1=rebase, q2=no).
+func DefaultConfig() ConflictResolverConfig {
+	return ConflictResolverConfig{
+		Strategy:         StrategyRebase,
+		RequiresApproval: false,
+	}
+}


### PR DESCRIPTION
## Summary

- Poller detects `mergeable_state == "dirty"` on REVIEW-column PRs and emits `EvtPRConflictsDetected` on the falling edge; clears on recovery/merge/close
- Board card PR chip turns red (`⚡ PR #N`) when conflicts are present; card glows red with a MERGE CONFLICT status row listing conflicting files and a **✦ Resolve Conflicts** button
- `ResolveConflicts()` spawns a Continue-Work session pre-populated with the `conductor-resolve-conflicts` skill runbook (rebase strategy, structured BLOCKED output on unresolvable files)

## Files modified

- `internal/eventbus/bus.go` — new `EvtPRConflictsDetected` / `EvtPRConflictsResolved` event types + payload structs
- `internal/github/client.go` — `PRState` extended with `MergeableState`, `BaseBranch`, `HeadRef`; new `FetchPRFiles` method
- `internal/github/poll.go` — `conflictStateCache` + `probeConflicts` method; cache cleared on merge/close
- `internal/issueview/issueview.go` — `ConflictsInfo` struct + field on `IssueView`
- `internal/issueview/assembler.go` — `conflictFails` map, event wiring, `Assemble()` population, `extractIssueKey` cases
- `internal/handlers/pr_conflicts.go` — new package: `BuildConflictResolveNote` helper
- `internal/workers/conflict_resolver.go` — new package: `ConflictResolverConfig`, `DefaultConfig()` (rebase, no approval)
- `internal/skills/bundle/skills/conductor-resolve-conflicts.md` — skill prompt with rebase runbook and structured BLOCKED output
- `internal/store/settings.go` — `GetConflictResolutionRequiresApproval` / `SetConflictResolutionRequiresApproval`
- `app.go` — `handlePRConflictsDetected`, `handlePRConflictsResolved`, `ResolveConflicts`; bus subscriptions wired
- `frontend/src/components/Card.tsx` — `ConflictsInfo` type, red PR chip, MERGE CONFLICT status row, Resolve Conflicts button
- `frontend/wailsjs/go/main/App.{js,d.ts}` — `ResolveConflicts` binding
- `frontend/wailsjs/go/models.ts` — `ConflictsInfo` class + `IssueView.conflicts_info` field

## Verification

- **Lint:** `go vet prismconductor/internal/...` — pass
- **Build:** `go build prismconductor/internal/...` — pass
- **TypeScript:** `npx tsc --noEmit` (frontend/) — pass (0 errors)
- **Smoke test:** skipped — `tests/e2e/startup.spec.ts` requires a live Wails app; same skip condition as all other feature branches in this repo
- **Tests:** `go test prismconductor/internal/...` — all pass (new tests: `TestAssembler_ConflictStoredOnDetected`, `TestAssembler_ConflictClearedOnResolved`, `TestAssembler_ConflictClearedOnMerge`, `TestExtractIssueKey_PRConflictsDetected/Resolved`, `TestProbeConflicts_FallingEdge`, `TestProbeConflicts_RecoveryEdge`; pre-existing flaky `import_sync_sleep` fixed with `time.Sleep`)

**Workspace mode:** per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-124

Closes #124