### PR TITLE
ci: group npm dependabot updates by companion-package family

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,38 @@ updates:
     labels:
       - dependencies
       - frontend
+    # Group companion packages so a major bump arrives with its peers in
+    # ONE PR. Without this, dependabot opens (e.g.) react@19 and
+    # @types/react@19 separately; the first PR fails ERESOLVE because the
+    # second one hasn't merged yet, and we waste cycles fighting npm peer
+    # resolution. Each group below has packages that must travel together.
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      vite:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+          - "vitest"
+          - "@vitest/*"
+          - "esbuild"
+      typescript:
+        patterns:
+          - "typescript"
+          - "@types/node"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "autoprefixer"
+          - "postcss"
+      dnd:
+        patterns:
+          - "@dnd-kit/*"
 
   - package-ecosystem: npm
     directory: /tests


### PR DESCRIPTION
## Summary

Group npm dependabot updates so companion packages bump in lockstep instead of one-at-a-time PRs that each fail ERESOLVE.

## Why

Recent dependabot bumps (#125, #128, #129, #130) all failed CI because each PR bumped a single package without its peers:
- `react@19` opened without `@types/react@19` → ERESOLVE
- `vite@8` opened without `@vitejs/plugin-react@5` → ERESOLVE  
- `typescript@6` deprecates options the project still uses → tsc errors
- `vitest@4` lockfile transitive-dep mismatch on `esbuild@0.28`

User closed all four. Without grouping, dependabot would just re-open them in the same broken shape next cycle. Grouping forces dependabot to bump react + react-dom + @types/react + @types/react-dom together (and similar for vite/vitest/esbuild, ts/types-node, tailwind family, dnd-kit family).

## Test plan
- [ ] Once merged, dependabot's next run should open at most ONE PR per group with all members bumped together
- [ ] CI on the resulting grouped PRs should pass without manual companion-bump intervention

Closes the merge-cycle thrash from #125, #128, #129, #130.