### PR TITLE
feat: auto-refresh and select workspace on add (#108)

### DIFF
--- a/app.go
+++ b/app.go
@@ -653,7 +653,8 @@ func (a *App) PickRepoPath() (string, error) {
 	})
 }
 
-// AddWorkspace registers a new workspace.
+// AddWorkspace registers a new workspace, then triggers an immediate issue fetch
+// and emits EvtWorkspaceAdded so the frontend can auto-select and show a toast.
 func (a *App) AddWorkspace(ws types.Workspace) error {
 	if a.wsReg == nil {
 		return fmt.Errorf("workspace registry unavailable")
@@ -661,7 +662,19 @@ func (a *App) AddWorkspace(ws types.Workspace) error {
 	if !ws.Enabled {
 		ws.Enabled = true
 	}
-	return a.wsReg.Add(ws)
+	if err := a.wsReg.Add(ws); err != nil {
+		return err
+	}
+	if a.bus != nil {
+		a.bus.Publish(eventbus.EvtWorkspaceAdded, map[string]any{
+			"workspace_id":   ws.ID,
+			"workspace_name": ws.DisplayName,
+		})
+	}
+	if a.poller != nil {
+		go a.poller.FetchNow(a.ctx, ws)
+	}
+	return nil
 }
 
 // UpdateWorkspace replaces a workspace's record.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -217,7 +217,56 @@ function App() {
       refreshArchivedCount();
     });
     const pushToast = useToastStore.getState().push;
+    const dismissToast = useToastStore.getState().dismiss;
     const offToast = EventsOn("toast", (t: ToastT) => pushToast(t));
+
+    const offWsAdded = EventsOn(
+      "bus.workspace_added",
+      async (data: { workspace_id: string; workspace_name: string }) => {
+        await refreshWorkspaces();
+        useWorkspaceStore.getState().setSelected(data.workspace_id);
+        pushToast({
+          id: `ws-fetch-${data.workspace_id}`,
+          level: "info",
+          title: data.workspace_name || data.workspace_id,
+          body: "Fetching issues…",
+          workspace_id: data.workspace_id,
+          issue_number: 0,
+          action: "none",
+          persist: true,
+        });
+      },
+    );
+
+    const offWsFetchDone = EventsOn(
+      "bus.workspace_fetch_complete",
+      (data: { workspace_id: string; workspace_name: string; success: boolean; issue_count: number; error?: string }) => {
+        dismissToast(`ws-fetch-${data.workspace_id}`);
+        refreshIssues(data.workspace_id);
+        if (data.success) {
+          pushToast({
+            id: `ws-fetch-ok-${data.workspace_id}-${Date.now()}`,
+            level: "success",
+            title: data.workspace_name || data.workspace_id,
+            body: `Fetched ${data.issue_count} issue${data.issue_count === 1 ? "" : "s"}`,
+            workspace_id: data.workspace_id,
+            issue_number: 0,
+            action: "none",
+          });
+        } else {
+          pushToast({
+            id: `ws-fetch-err-${data.workspace_id}-${Date.now()}`,
+            level: "error",
+            title: data.workspace_name || data.workspace_id,
+            body: data.error ?? "Failed to fetch issues",
+            workspace_id: data.workspace_id,
+            issue_number: 0,
+            action: "none",
+          });
+        }
+      },
+    );
+
     return () => {
       if (typeof offLine === "function") offLine();
       if (typeof offState === "function") offState();
@@ -242,6 +291,8 @@ function App() {
       if (typeof offPause === "function") offPause();
       if (typeof offArchived === "function") offArchived();
       if (typeof offToast === "function") offToast();
+      if (typeof offWsAdded === "function") offWsAdded();
+      if (typeof offWsFetchDone === "function") offWsFetchDone();
     };
   }, [appendLine, setMeta, refreshWorkspaces, refreshGoals, refreshIssues, markPlanReady, clearPlanReady, selectedWorkspace, refreshArchived, refreshArchivedCount]);
 

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -37,15 +37,17 @@ function ToastItem({
   const timerRef = useRef<number | null>(null);
 
   useEffect(() => {
+    if (toast.persist) return;
     timerRef.current = window.setTimeout(() => dismiss(toast.id), AUTO_DISMISS_MS);
     return () => {
       if (timerRef.current !== null) {
         window.clearTimeout(timerRef.current);
       }
     };
-  }, [toast.id, dismiss]);
+  }, [toast.id, toast.persist, dismiss]);
 
   function pauseTimer() {
+    if (toast.persist) return;
     if (timerRef.current !== null) {
       window.clearTimeout(timerRef.current);
       timerRef.current = null;
@@ -53,6 +55,7 @@ function ToastItem({
   }
 
   function resumeTimer() {
+    if (toast.persist) return;
     if (timerRef.current === null) {
       timerRef.current = window.setTimeout(() => dismiss(toast.id), AUTO_DISMISS_MS);
     }

--- a/frontend/src/stores/toastStore.ts
+++ b/frontend/src/stores/toastStore.ts
@@ -12,6 +12,8 @@ export type Toast = {
   issue_number: number;
   pr_url?: string;
   action: ToastAction;
+  /** When true the toast will not auto-dismiss — caller must dismiss() it explicitly. */
+  persist?: boolean;
 };
 
 const MAX_VISIBLE = 3;
@@ -26,6 +28,14 @@ export const useToastStore = create<State>((set) => ({
   recent: [],
   push: (t) =>
     set((s) => {
+      // If a toast with the same id already exists replace it in place so
+      // persistent "fetching…" toasts update without position churn.
+      const idx = s.recent.findIndex((x) => x.id === t.id);
+      if (idx >= 0) {
+        const next = [...s.recent];
+        next[idx] = t;
+        return { recent: next };
+      }
       const next = [...s.recent, t];
       while (next.length > MAX_VISIBLE) next.shift();
       return { recent: next };

--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -43,6 +43,10 @@ const (
 	// Issue #124: PR merge-conflict detection and resolution worker.
 	EvtPRConflictsDetected EventType = "pr_conflicts_detected"
 	EvtPRConflictsResolved EventType = "pr_conflicts_resolved"
+
+	// Issue #108: auto-refresh issues when a workspace is added.
+	EvtWorkspaceAdded        EventType = "workspace_added"
+	EvtWorkspaceFetchComplete EventType = "workspace_fetch_complete"
 )
 
 type Event struct {
@@ -116,6 +120,16 @@ type PRConflictsResolved struct {
 	WorkspaceID string `json:"workspace_id"`
 	IssueNumber int    `json:"issue_number"`
 	PRNumber    int    `json:"pr_number"`
+}
+
+// WorkspaceFetchComplete is the payload for EvtWorkspaceFetchComplete (#108). Published
+// after an immediate fetch triggered by AddWorkspace completes (success or failure).
+type WorkspaceFetchComplete struct {
+	WorkspaceID   string `json:"workspace_id"`
+	WorkspaceName string `json:"workspace_name"`
+	Success       bool   `json:"success"`
+	IssueCount    int    `json:"issue_count"`
+	Error         string `json:"error,omitempty"`
 }
 
 type Handler func(Event)

--- a/internal/github/poll.go
+++ b/internal/github/poll.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"sort"
 	"strconv"
@@ -87,6 +88,37 @@ func NewPoller(bus *eventbus.Bus, client *Client, store Store, src WorkspaceSour
 		maxConcurrency: 4,
 		pokeCh:         make(chan struct{}, 1),
 	}
+}
+
+// FetchNow runs an immediate fetch for a single workspace (used after AddWorkspace).
+// It blocks until the fetch completes and then publishes EvtWorkspaceFetchComplete.
+// Safe to call from a goroutine.
+func (p *Poller) FetchNow(ctx context.Context, ws types.Workspace) {
+	var fetchErr error
+	if p.Client == nil {
+		fetchErr = fmt.Errorf("github client unavailable")
+	} else {
+		fetchErr = p.pollOne(ctx, ws)
+	}
+	var issueCount int
+	if fetchErr == nil {
+		if issues, e := p.Store.ListIssues(ws.ID); e == nil {
+			issueCount = len(issues)
+		}
+	}
+	if p.Bus == nil {
+		return
+	}
+	payload := eventbus.WorkspaceFetchComplete{
+		WorkspaceID:   ws.ID,
+		WorkspaceName: ws.DisplayName,
+		Success:       fetchErr == nil,
+		IssueCount:    issueCount,
+	}
+	if fetchErr != nil {
+		payload.Error = fetchErr.Error()
+	}
+	p.Bus.Publish(eventbus.EvtWorkspaceFetchComplete, payload)
 }
 
 // PokeNow asks the poll loop to fan out immediately (e.g. user clicked Refresh).

--- a/internal/github/poll_test.go
+++ b/internal/github/poll_test.go
@@ -251,6 +251,49 @@ func TestProbeConflicts_RecoveryEdge(t *testing.T) {
 	}
 }
 
+// TestFetchNow_NilClient verifies that FetchNow publishes EvtWorkspaceFetchComplete
+// with success=false when the GitHub client is unavailable (issue #108).
+func TestFetchNow_NilClient(t *testing.T) {
+	bus := eventbus.New()
+	p := &Poller{Bus: bus, Client: nil}
+
+	var mu sync.Mutex
+	var events []eventbus.Event
+	bus.Subscribe(func(e eventbus.Event) {
+		mu.Lock()
+		events = append(events, e)
+		mu.Unlock()
+	})
+
+	ws := types.Workspace{ID: "ws-new", DisplayName: "My Repo"}
+	p.FetchNow(t.Context(), ws)
+
+	import_sync_sleep(t)
+
+	mu.Lock()
+	defer mu.Unlock()
+	var found *eventbus.WorkspaceFetchComplete
+	for _, e := range events {
+		if e.Type == eventbus.EvtWorkspaceFetchComplete {
+			if p, ok := e.Payload.(eventbus.WorkspaceFetchComplete); ok {
+				found = &p
+			}
+		}
+	}
+	if found == nil {
+		t.Fatal("expected EvtWorkspaceFetchComplete, got none")
+	}
+	if found.WorkspaceID != "ws-new" {
+		t.Errorf("workspace_id: got %q, want %q", found.WorkspaceID, "ws-new")
+	}
+	if found.Success {
+		t.Error("expected success=false when client is nil")
+	}
+	if found.Error == "" {
+		t.Error("expected non-empty error when client is nil")
+	}
+}
+
 // import_sync_sleep waits briefly for async bus handlers.
 //
 // eventbus.Bus.Publish dispatches each subscriber in its own goroutine, so a


### PR DESCRIPTION
## Summary

- When a workspace is added, the app now immediately fetches its issues and auto-selects it in the workspace switcher
- A persistent spinner toast appears while the fetch runs; replaced with a success count or error message on completion

## Files modified

- `internal/eventbus/bus.go` — added EvtWorkspaceAdded, EvtWorkspaceFetchComplete event types and WorkspaceFetchComplete payload struct
- `internal/github/poll.go` — added FetchNow(ctx, ws) that calls pollOne for a single workspace and publishes EvtWorkspaceFetchComplete
- `app.go` — AddWorkspace now publishes EvtWorkspaceAdded and spawns FetchNow goroutine after saving
- `frontend/src/stores/toastStore.ts` — added persist flag; push upserts by id to prevent position churn
- `frontend/src/components/Toast.tsx` — persistent toasts skip auto-dismiss until explicitly dismissed
- `frontend/src/App.tsx` — subscribes to bus.workspace_added (auto-select + spinner toast) and bus.workspace_fetch_complete (success/error toast + issue refresh)
- `internal/github/poll_test.go` — TestFetchNow_NilClient verifies nil-client path publishes failure event

## Verification

- **Lint:** go vet ./internal/... — pass
- **Frontend typecheck:** npx tsc --noEmit — pass
- **Build:** wails build — pass (33.81s)
- **Smoke test:** npx playwright test e2e/startup.spec.ts — pass (1 test, 6.4s)
- **Tests:** go test ./internal/... — pass (25 packages, 0 failures)

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-108

Closes #108
