### PR TITLE
feat: disable autocorrect/autocapitalize/autocomplete/spellcheck on all inputs (#144)

### DIFF
--- a/frontend/src/components/AddIssueQuick.tsx
+++ b/frontend/src/components/AddIssueQuick.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { AddManualIssue } from "../../wailsjs/go/main/App";
 import { useIssueStore } from "../stores/issueStore";
 import { useWorkspaceStore } from "../stores/workspaceStore";
+import { noAutoCorrect } from "../lib/inputs";
 
 // Lets the user create a fake issue card without waiting on the GitHub poll
 // (#2). Removed once #2 lands and real issues populate the board.
@@ -42,6 +43,7 @@ export function AddIssueQuick() {
   return (
     <div className="flex items-center gap-1 text-xs">
       <input
+        {...noAutoCorrect}
         value={num}
         onChange={(e) => setNum(e.target.value)}
         placeholder="#"
@@ -49,12 +51,14 @@ export function AddIssueQuick() {
         type="number"
       />
       <input
+        {...noAutoCorrect}
         value={title}
         onChange={(e) => setTitle(e.target.value)}
         placeholder="title"
         className="w-40 bg-slate-900 border border-slate-700 rounded px-1.5 py-0.5"
       />
       <input
+        {...noAutoCorrect}
         value={labels}
         onChange={(e) => setLabels(e.target.value)}
         placeholder="labels (csv)"

--- a/frontend/src/components/AddWorkspaceForm.tsx
+++ b/frontend/src/components/AddWorkspaceForm.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { AddWorkspace, InspectRepo, PickRepoPath } from "../../wailsjs/go/main/App";
 import { types, workspace } from "../../wailsjs/go/models";
 import { useWorkspaceStore } from "../stores/workspaceStore";
+import { noAutoCorrect } from "../lib/inputs";
 
 const COLOR_PALETTE = ["#22c55e", "#06b6d4", "#a855f7", "#f59e0b", "#ef4444", "#ec4899", "#14b8a6", "#eab308"];
 
@@ -78,6 +79,7 @@ export function AddWorkspaceForm({ onDone }: { onDone: () => void }) {
     <div className="space-y-3 text-sm">
       <div className="flex items-center gap-2">
         <input
+          {...noAutoCorrect}
           type="text"
           value={path}
           onChange={(e) => setPath(e.target.value)}
@@ -117,6 +119,7 @@ export function AddWorkspaceForm({ onDone }: { onDone: () => void }) {
             <label className="block">
               <div className="text-xs text-slate-500 mb-1">ID</div>
               <input
+                {...noAutoCorrect}
                 value={id}
                 onChange={(e) => setID(e.target.value)}
                 className="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-200"
@@ -125,6 +128,7 @@ export function AddWorkspaceForm({ onDone }: { onDone: () => void }) {
             <label className="block">
               <div className="text-xs text-slate-500 mb-1">Display name</div>
               <input
+                {...noAutoCorrect}
                 value={displayName}
                 onChange={(e) => setDisplayName(e.target.value)}
                 className="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-200"

--- a/frontend/src/components/ContinueModal.tsx
+++ b/frontend/src/components/ContinueModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { ContinueWork, FetchPRChecks } from "../../wailsjs/go/main/App";
+import { noAutoCorrect } from "../lib/inputs";
 
 export function ContinueModal({
   open,
@@ -75,6 +76,7 @@ export function ContinueModal({
             )}
           </label>
           <textarea
+            {...noAutoCorrect}
             ref={textareaRef}
             value={note}
             onChange={(e) => setNote(e.target.value)}

--- a/frontend/src/components/GoalEditor.tsx
+++ b/frontend/src/components/GoalEditor.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { types } from "../../wailsjs/go/models";
 import { useGoalStore } from "../stores/goalStore";
 import { useWorkspaceStore } from "../stores/workspaceStore";
+import { noAutoCorrect } from "../lib/inputs";
 
 export function GoalEditor({
   open,
@@ -79,13 +80,13 @@ export function GoalEditor({
         </div>
         <div className="p-4 space-y-3 text-sm overflow-y-auto">
           <Field label="Title">
-            <input value={title} onChange={(e) => setTitle(e.target.value)} className={inputCls} />
+            <input {...noAutoCorrect} value={title} onChange={(e) => setTitle(e.target.value)} className={inputCls} />
           </Field>
           <Field label="Intent (markdown)">
-            <textarea value={intent} onChange={(e) => setIntent(e.target.value)} rows={3} className={inputCls} />
+            <textarea {...noAutoCorrect} value={intent} onChange={(e) => setIntent(e.target.value)} rows={3} className={inputCls} />
           </Field>
           <Field label="Acceptance rule">
-            <textarea value={acceptance} onChange={(e) => setAcceptance(e.target.value)} rows={2} className={inputCls} />
+            <textarea {...noAutoCorrect} value={acceptance} onChange={(e) => setAcceptance(e.target.value)} rows={2} className={inputCls} />
           </Field>
           <Field label="Workspace (optional — blank = cross-workspace)">
             <select value={workspaceID} onChange={(e) => setWorkspaceID(e.target.value)} className={inputCls}>
@@ -97,14 +98,14 @@ export function GoalEditor({
           </Field>
           <div className="grid grid-cols-2 gap-2">
             <Field label="Labels (comma-separated)">
-              <input value={labels} onChange={(e) => setLabels(e.target.value)} className={inputCls} />
+              <input {...noAutoCorrect} value={labels} onChange={(e) => setLabels(e.target.value)} className={inputCls} />
             </Field>
             <Field label="Milestone">
-              <input value={milestone} onChange={(e) => setMilestone(e.target.value)} className={inputCls} />
+              <input {...noAutoCorrect} value={milestone} onChange={(e) => setMilestone(e.target.value)} className={inputCls} />
             </Field>
           </div>
           <Field label="Free-text match (title/body)">
-            <input value={freeText} onChange={(e) => setFreeText(e.target.value)} className={inputCls} />
+            <input {...noAutoCorrect} value={freeText} onChange={(e) => setFreeText(e.target.value)} className={inputCls} />
           </Field>
           {error && <div className="text-red-400 text-xs">{error}</div>}
         </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useIssueStore } from "../stores/issueStore";
+import { noAutoCorrect } from "../lib/inputs";
 
 const DEBOUNCE_MS = 200;
 
@@ -42,6 +43,7 @@ export function TitleSearch() {
   return (
     <div className="relative flex items-center">
       <input
+        {...noAutoCorrect}
         ref={inputRef}
         type="text"
         value={value}

--- a/frontend/src/components/LabelManagePopover.tsx
+++ b/frontend/src/components/LabelManagePopover.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { SetIssueLabels } from "../../wailsjs/go/main/App";
 import { useLabelsStore, EMPTY_LABELS } from "../stores/labelsStore";
 import { getContrastText } from "../lib/contrast";
+import { noAutoCorrect } from "../lib/inputs";
 
 type Props = {
   open: boolean;
@@ -92,6 +93,7 @@ export function LabelManagePopover({
     >
       <div className="px-2 py-1.5 border-b border-slate-800">
         <input
+          {...noAutoCorrect}
           autoFocus
           type="text"
           value={filter}

--- a/frontend/src/components/LabelsPanel.tsx
+++ b/frontend/src/components/LabelsPanel.tsx
@@ -3,6 +3,7 @@ import { CreateLabel, DeleteLabel, UpdateLabel } from "../../wailsjs/go/main/App
 import { types } from "../../wailsjs/go/models";
 import { useLabelsStore, EMPTY_LABELS } from "../stores/labelsStore";
 import { getContrastText, normalizeHex } from "../lib/contrast";
+import { noAutoCorrect } from "../lib/inputs";
 
 type Props = {
   workspaceID: string;
@@ -90,6 +91,7 @@ function NewLabelForm({
       <div className="text-xs text-slate-400">+ New label</div>
       <div className="flex items-center gap-2">
         <input
+          {...noAutoCorrect}
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
@@ -112,6 +114,7 @@ function NewLabelForm({
         </button>
       </div>
       <input
+        {...noAutoCorrect}
         type="text"
         value={description}
         onChange={(e) => setDescription(e.target.value)}
@@ -181,6 +184,7 @@ function LabelRow({ workspaceID, label }: { workspaceID: string; label: types.La
             className="h-7 w-10 cursor-pointer bg-slate-900 border border-slate-700 rounded"
           />
           <input
+            {...noAutoCorrect}
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -201,6 +205,7 @@ function LabelRow({ workspaceID, label }: { workspaceID: string; label: types.La
           </button>
         </div>
         <input
+          {...noAutoCorrect}
           type="text"
           value={description}
           onChange={(e) => setDescription(e.target.value)}

--- a/frontend/src/components/LogsPanel.tsx
+++ b/frontend/src/components/LogsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { RecentLogs } from "../../wailsjs/go/main/App";
 import { logbuffer } from "../../wailsjs/go/models";
+import { noAutoCorrect } from "../lib/inputs";
 
 const LEVEL_COLOR: Record<string, string> = {
   info: "text-slate-300",
@@ -39,6 +40,7 @@ export function LogsPanel() {
     <div className="space-y-2 text-sm flex flex-col h-full min-h-0">
       <div className="flex items-center gap-2">
         <input
+          {...noAutoCorrect}
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
           placeholder="filter…"

--- a/frontend/src/components/PlanModal.tsx
+++ b/frontend/src/components/PlanModal.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { noAutoCorrect } from "../lib/inputs";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ApprovePlan, LatestPlan, PlanCostEstimate, RejectPlan, SetIssueLabels, SubmitAnswers, WriteAnswersOnly } from "../../wailsjs/go/main/App";
@@ -288,6 +289,7 @@ export function PlanModal({
 
               <Section title="Refine plan (free-form)">
                 <textarea
+                  {...noAutoCorrect}
                   value={refineText}
                   onChange={(e) => setRefineText(e.target.value)}
                   rows={3}

--- a/frontend/src/components/PoolEditModal.tsx
+++ b/frontend/src/components/PoolEditModal.tsx
@@ -4,6 +4,7 @@ import {
   SavePool,
 } from "../../wailsjs/go/main/App";
 import { main, types } from "../../wailsjs/go/models";
+import { noAutoCorrect } from "../lib/inputs";
 
 type Role = "plan" | "work" | "orchestrator";
 
@@ -248,6 +249,7 @@ export function PoolEditModal({
             <div>
               <div className="text-xs text-slate-500 mb-1">Endpoint URL</div>
               <input
+                {...noAutoCorrect}
                 value={endpoint}
                 onChange={(e) => setEndpoint(e.target.value)}
                 onBlur={onEndpointBlur}
@@ -261,6 +263,7 @@ export function PoolEditModal({
             <div>
               <div className="text-xs text-slate-500 mb-1">API key (optional)</div>
               <input
+                {...noAutoCorrect}
                 type="password"
                 value={apiKey}
                 onChange={(e) => setApiKey(e.target.value)}
@@ -287,6 +290,7 @@ export function PoolEditModal({
               </select>
             ) : (
               <input
+                {...noAutoCorrect}
                 value={model}
                 onChange={(e) => setModel(e.target.value)}
                 placeholder="model id (free text)"
@@ -335,6 +339,7 @@ export function PoolEditModal({
           <div>
             <div className="text-xs text-slate-500 mb-1">Name</div>
             <input
+              {...noAutoCorrect}
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder={`${providerKind}-${modelTail(model) || "pool"}`}
@@ -345,6 +350,7 @@ export function PoolEditModal({
           <div>
             <div className="text-xs text-slate-500 mb-1">Temperature (optional)</div>
             <input
+              {...noAutoCorrect}
               type="number"
               min={0}
               max={2}
@@ -380,6 +386,7 @@ export function PoolEditModal({
                   <div>
                     <div className="text-xs text-slate-500 mb-1">Max turns</div>
                     <input
+                      {...noAutoCorrect}
                       type="number"
                       min={1}
                       step={1}
@@ -392,6 +399,7 @@ export function PoolEditModal({
                   <div>
                     <div className="text-xs text-slate-500 mb-1">Max input tokens</div>
                     <input
+                      {...noAutoCorrect}
                       type="number"
                       min={1}
                       step={1}
@@ -404,6 +412,7 @@ export function PoolEditModal({
                   <div>
                     <div className="text-xs text-slate-500 mb-1">Bash timeout (seconds)</div>
                     <input
+                      {...noAutoCorrect}
                       type="number"
                       min={1}
                       step={1}
@@ -416,6 +425,7 @@ export function PoolEditModal({
                   <div>
                     <div className="text-xs text-slate-500 mb-1">Output cap (KB)</div>
                     <input
+                      {...noAutoCorrect}
                       type="number"
                       min={1}
                       step={1}

--- a/frontend/src/components/QuestionForm.tsx
+++ b/frontend/src/components/QuestionForm.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { types } from "../../wailsjs/go/models";
 import { CopyMenu, CopyAction } from "./CopyMenu";
+import { noAutoCorrect } from "../lib/inputs";
 
 export type AnswerState = {
   single: Record<string, string>;
@@ -174,6 +175,7 @@ export function QuestionForm({
             {q.type === "free_text" && (
               <>
                 <textarea
+                  {...noAutoCorrect}
                   value={state.single[q.id] ?? ""}
                   onChange={(e) => setSingle(q.id, e.target.value)}
                   rows={3}

--- a/frontend/src/components/SessionDrawer.tsx
+++ b/frontend/src/components/SessionDrawer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { KillSession, ReadTranscript, SendInput } from "../../wailsjs/go/main/App";
 import { useSessionStore } from "../stores/sessionStore";
 import { CopyMenu, CopyAction } from "./CopyMenu";
+import { noAutoCorrect } from "../lib/inputs";
 
 const STATE_COLOR: Record<string, string> = {
   running: "text-emerald-400",
@@ -159,6 +160,7 @@ export function SessionDrawer({ open, onClose }: { open: boolean; onClose: () =>
 
       <div className="px-3 py-2 border-t border-slate-800 flex items-center gap-2">
         <input
+          {...noAutoCorrect}
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && send()}

--- a/frontend/src/components/SkillProfileEditor.tsx
+++ b/frontend/src/components/SkillProfileEditor.tsx
@@ -3,6 +3,7 @@ import { DiscoverWorkspaceSkills, ListPools, UpdateWorkspace } from "../../wails
 import { types, workerpool } from "../../wailsjs/go/models";
 import { useWorkspaceStore } from "../stores/workspaceStore";
 import { SkillDropdown } from "./SkillDropdown";
+import { noAutoCorrect } from "../lib/inputs";
 
 type SkillMode = "bundled" | "hybrid" | "native";
 const MODES: SkillMode[] = ["bundled", "hybrid", "native"];
@@ -209,6 +210,7 @@ function NativeRow({
     <label className="flex items-center gap-2">
       <span className="w-16 text-xs text-slate-500">{label}</span>
       <input
+        {...noAutoCorrect}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder="/start-issue"

--- a/frontend/src/components/WorkspacesPanel.tsx
+++ b/frontend/src/components/WorkspacesPanel.tsx
@@ -5,6 +5,7 @@ import { useWorkspaceStore } from "../stores/workspaceStore";
 import { AddWorkspaceForm } from "./AddWorkspaceForm";
 import { SkillProfileEditor } from "./SkillProfileEditor";
 import { LabelsPanel } from "./LabelsPanel";
+import { noAutoCorrect } from "../lib/inputs";
 
 function AutoArchiveEditor({ workspace, onSave }: { workspace: types.Workspace; onSave: () => void }) {
   const cfg = workspace.auto_archive ?? { enabled: false, days_closed: 7 };
@@ -53,6 +54,7 @@ function AutoArchiveEditor({ workspace, onSave }: { workspace: types.Workspace; 
           <label className="flex items-center gap-2 text-xs text-slate-400">
             After
             <input
+              {...noAutoCorrect}
               type="number"
               min={1}
               max={365}

--- a/frontend/src/lib/inputs.ts
+++ b/frontend/src/lib/inputs.ts
@@ -1,0 +1,6 @@
+export const noAutoCorrect = {
+  autoCorrect: "off",
+  autoCapitalize: "off",
+  autoComplete: "off",
+  spellCheck: false,
+} as const;


### PR DESCRIPTION
## Summary

- Add `noAutoCorrect` props bag (`frontend/src/lib/inputs.ts`) with `autoCorrect="off"`, `autoCapitalize="off"`, `autoComplete="off"`, `spellCheck={false}`
- Spread `{...noAutoCorrect}` onto every `<input>` and `<textarea>` for technical fields across 15 components — mechanical sweep covering Settings, AddIssueQuick, PlanModal, QuestionForm, WorkspaceSwitcher areas, Labels, GoalEditor, ContinueModal, SessionDrawer, LogsPanel, and Header search

## Files modified

- `frontend/src/lib/inputs.ts` — new shared props bag
- `frontend/src/components/AddIssueQuick.tsx`
- `frontend/src/components/AddWorkspaceForm.tsx`
- `frontend/src/components/ContinueModal.tsx`
- `frontend/src/components/GoalEditor.tsx`
- `frontend/src/components/Header.tsx`
- `frontend/src/components/LabelManagePopover.tsx`
- `frontend/src/components/LabelsPanel.tsx`
- `frontend/src/components/LogsPanel.tsx`
- `frontend/src/components/PlanModal.tsx`
- `frontend/src/components/PoolEditModal.tsx`
- `frontend/src/components/QuestionForm.tsx`
- `frontend/src/components/SessionDrawer.tsx`
- `frontend/src/components/SkillProfileEditor.tsx`
- `frontend/src/components/WorkspacesPanel.tsx`

## Verification

| Check | Command | Result |
|-------|---------|--------|
| Lint/typecheck | `node_modules/.bin/tsc --noEmit` (from `frontend/`) | ✅ pass (0 errors) |
| Go vet | `go vet ./internal/...` | ✅ pass |
| Go tests | `go test ./internal/...` | ✅ pass (all 15 test packages) |
| Smoke test | `playwright test tests/e2e/startup.spec.ts` | ⚠️ skipped — `ERR_CONNECTION_REFUSED`; the Wails dev server is not running in the worktree environment. This is an infrastructure constraint, not a code failure. The change adds only HTML attributes (`autoCorrect`, `autoCapitalize`, `autoComplete`, `spellCheck`) to existing elements and cannot affect app startup or React mounting. |

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-144

Closes #144