### PR TITLE
feat: pool scoping — shared vs workspace-specific (#109)

### DIFF
--- a/app.go
+++ b/app.go
@@ -685,10 +685,20 @@ func (a *App) UpdateWorkspace(ws types.Workspace) error {
 	return a.wsReg.Update(ws)
 }
 
-// RemoveWorkspace removes a workspace by ID.
+// RemoveWorkspace removes a workspace by ID. Any pools bound to this workspace
+// are silently rebound to shared so capacity isn't orphaned (issue #109, q1).
 func (a *App) RemoveWorkspace(id string) error {
 	if a.wsReg == nil {
 		return fmt.Errorf("workspace registry unavailable")
+	}
+	if a.store != nil {
+		if err := a.store.RebindWorkspacePools(id); err != nil {
+			log.Printf("RemoveWorkspace: rebind pools for %s: %v", id, err)
+		} else if a.poolReg != nil {
+			if rows, err := a.store.ListPools(); err == nil {
+				a.poolReg.Sync(rows)
+			}
+		}
 	}
 	return a.wsReg.Remove(id)
 }

--- a/frontend/src/components/PoolEditModal.tsx
+++ b/frontend/src/components/PoolEditModal.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
 import {
+  ListWorkspaces,
   ProbeProviderModels,
   SavePool,
 } from "../../wailsjs/go/main/App";
 import { main, types } from "../../wailsjs/go/models";
 
 type Role = "plan" | "work" | "orchestrator";
+type Scope = "shared" | "workspace";
 
 const ROLE_OPTIONS: { value: Role; label: string; help: string }[] = [
   {
@@ -48,6 +50,9 @@ export function PoolEditModal({
 }: Props) {
   const fallbackProvider = (providers[0]?.kind ?? "claude") as string;
   const [role, setRole] = useState<Role>(((initial?.role as Role) || "work") as Role);
+  const [scope, setScope] = useState<Scope>(((initial?.scope as Scope) || "shared") as Scope);
+  const [scopeWorkspaceID, setScopeWorkspaceID] = useState<string>(initial?.workspace_id ?? "");
+  const [workspaces, setWorkspaces] = useState<types.Workspace[]>([]);
   const [providerKind, setProviderKind] = useState<string>(
     initial?.provider ?? fallbackProvider,
   );
@@ -97,6 +102,13 @@ export function PoolEditModal({
         p.id !== (initial?.id ?? ""),
     );
   }, [role, existingPools, initial]);
+
+  // Disable Save when workspace-specific scope is chosen but no workspace selected (q3).
+  const workspaceScopeBlock = scope === "workspace" && !scopeWorkspaceID;
+
+  useEffect(() => {
+    ListWorkspaces().then((ws) => setWorkspaces(ws ?? [])).catch(() => {});
+  }, []);
 
   useEffect(() => {
     if (initial) return;
@@ -156,7 +168,7 @@ export function PoolEditModal({
 
   async function onSave() {
     if (!providerInfo) return;
-    if (orchestratorBlock) return;
+    if (orchestratorBlock || workspaceScopeBlock) return;
     setBusy(true);
     setSaveErr("");
     try {
@@ -184,6 +196,8 @@ export function PoolEditModal({
         max_input_tokens: (parsedMaxInputTokens != null && !isNaN(parsedMaxInputTokens)) ? parsedMaxInputTokens : undefined,
         bash_timeout: (parsedBashTimeoutSec != null && !isNaN(parsedBashTimeoutSec)) ? parsedBashTimeoutSec * 1e9 : undefined,
         output_cap: (parsedOutputCapKB != null && !isNaN(parsedOutputCapKB)) ? parsedOutputCapKB * 1024 : undefined,
+        scope,
+        workspace_id: scope === "workspace" ? scopeWorkspaceID : "",
       });
       await SavePool(pool);
       onSaved();
@@ -221,6 +235,43 @@ export function PoolEditModal({
             <div className="text-[11px] text-slate-500 mt-1">
               {ROLE_OPTIONS.find((o) => o.value === role)?.help}
             </div>
+          </div>
+
+          <div>
+            <div className="text-xs text-slate-500 mb-1">Scope</div>
+            <div className="flex items-center gap-4">
+              {(["shared", "workspace"] as Scope[]).map((s) => (
+                <label key={s} className="flex items-center gap-1.5 text-xs text-slate-300 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="pool-scope"
+                    value={s}
+                    checked={scope === s}
+                    onChange={() => {
+                      setScope(s);
+                      if (s === "shared") setScopeWorkspaceID("");
+                    }}
+                  />
+                  {s === "shared" ? "Shared (all workspaces)" : "Workspace-specific"}
+                </label>
+              ))}
+            </div>
+            {scope === "workspace" && (
+              <div className="mt-2">
+                <select
+                  value={scopeWorkspaceID}
+                  onChange={(e) => setScopeWorkspaceID(e.target.value)}
+                  className="w-full bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-100 text-xs"
+                >
+                  <option value="">— pick a workspace —</option>
+                  {workspaces.map((ws) => (
+                    <option key={ws.id} value={ws.id}>
+                      {ws.display_name || ws.id}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
           </div>
 
           <div>
@@ -446,6 +497,12 @@ export function PoolEditModal({
             </div>
           )}
 
+          {workspaceScopeBlock && (
+            <div className="text-xs text-amber-300">
+              Select a workspace to save a workspace-specific pool.
+            </div>
+          )}
+
           {saveErr && <div className="text-xs text-rose-300">{saveErr}</div>}
         </div>
 
@@ -458,7 +515,7 @@ export function PoolEditModal({
           </button>
           <button
             onClick={onSave}
-            disabled={busy || orchestratorBlock}
+            disabled={busy || orchestratorBlock || workspaceScopeBlock}
             className="text-xs px-3 py-1 bg-slate-700 hover:bg-slate-600 text-slate-100 rounded disabled:opacity-50"
           >
             {busy ? "Saving…" : "Save"}

--- a/frontend/src/components/PoolsPanel.tsx
+++ b/frontend/src/components/PoolsPanel.tsx
@@ -17,6 +17,7 @@ import { CSS } from "@dnd-kit/utilities";
 import {
   ListPools,
   ListProviders,
+  ListWorkspaces,
   SavePool,
   DeletePool,
   ResetPoolCounters,
@@ -39,6 +40,7 @@ const ROLE_LABEL: Record<Role, string> = {
 export function PoolsPanel() {
   const [pools, setPools] = useState<workerpool.PoolStatus[]>([]);
   const [providers, setProviders] = useState<main.ProviderInfo[]>([]);
+  const [workspaces, setWorkspaces] = useState<types.Workspace[]>([]);
   const [editing, setEditing] = useState<types.Pool | null>(null);
   const [adding, setAdding] = useState(false);
   const [deleteErr, setDeleteErr] = useState<Record<string, string>>({});
@@ -47,9 +49,10 @@ export function PoolsPanel() {
 
   async function refresh() {
     try {
-      const [ps, pv] = await Promise.all([ListPools(), ListProviders()]);
+      const [ps, pv, ws] = await Promise.all([ListPools(), ListProviders(), ListWorkspaces()]);
       setPools(ps ?? []);
       setProviders(pv ?? []);
+      setWorkspaces(ws ?? []);
       // Fetch spend for each pool in parallel.
       const ids = (ps ?? []).map((r) => r.pool.id);
       if (ids.length > 0) {
@@ -82,6 +85,7 @@ export function PoolsPanel() {
   }, []);
 
   const providerByKind = new Map(providers.map((p) => [p.kind, p]));
+  const workspaceByID = new Map(workspaces.map((w) => [w.id, w]));
 
   function poolRole(p: types.Pool): Role {
     return ((p.role as Role) || "work") as Role;
@@ -205,6 +209,7 @@ export function PoolsPanel() {
                       isFirst={idx === 0}
                       isLast={idx === rows.length - 1}
                       providerByKind={providerByKind}
+                      workspaceByID={workspaceByID}
                       deleteErr={deleteErr[row.pool.id]}
                       spendToday={spendToday[row.pool.id] ?? 0}
                       spendWeek={spendWeek[row.pool.id] ?? 0}
@@ -224,6 +229,7 @@ export function PoolsPanel() {
                     row={row}
                     role={role}
                     providerByKind={providerByKind}
+                    workspaceByID={workspaceByID}
                     deleteErr={err}
                     dragHandle={null}
                     spendToday={spendToday[row.pool.id] ?? 0}
@@ -284,6 +290,7 @@ function SortablePoolRow({
   isFirst,
   isLast,
   providerByKind,
+  workspaceByID,
   deleteErr,
   spendToday,
   spendWeek,
@@ -296,6 +303,7 @@ function SortablePoolRow({
   isFirst: boolean;
   isLast: boolean;
   providerByKind: Map<string, main.ProviderInfo>;
+  workspaceByID: Map<string, types.Workspace>;
   deleteErr?: string;
   spendToday: number;
   spendWeek: number;
@@ -328,6 +336,7 @@ function SortablePoolRow({
         row={row}
         role={role}
         providerByKind={providerByKind}
+        workspaceByID={workspaceByID}
         deleteErr={deleteErr}
         dragHandle={dragHandle}
         preferenceHint={hint ?? undefined}
@@ -341,10 +350,24 @@ function SortablePoolRow({
   );
 }
 
+function poolScopeBadge(pool: types.Pool, workspaceByID: Map<string, types.Workspace>): React.ReactNode {
+  if (!pool.scope || pool.scope === "shared") {
+    return <span className="text-[10px] text-slate-600 font-normal">(shared)</span>;
+  }
+  const ws = pool.workspace_id ? workspaceByID.get(pool.workspace_id) : undefined;
+  const label = ws ? (ws.display_name || ws.id) : (pool.workspace_id || "?");
+  return (
+    <span className="text-[10px] font-normal px-1 py-0.5 rounded bg-slate-800 text-slate-400">
+      workspace: {label}
+    </span>
+  );
+}
+
 function PoolRow({
   row,
   role,
   providerByKind,
+  workspaceByID,
   deleteErr,
   dragHandle,
   preferenceHint,
@@ -357,6 +380,7 @@ function PoolRow({
   row: workerpool.PoolStatus;
   role: Role;
   providerByKind: Map<string, main.ProviderInfo>;
+  workspaceByID: Map<string, types.Workspace>;
   deleteErr?: string;
   dragHandle: React.ReactNode;
   preferenceHint?: string;
@@ -377,6 +401,7 @@ function PoolRow({
             <span className="text-slate-500">
               ({info?.display_name ?? row.pool.provider})
             </span>
+            {poolScopeBadge(row.pool, workspaceByID)}
             {preferenceHint && (
               <span className="text-slate-600 font-normal">{preferenceHint}</span>
             )}

--- a/frontend/src/components/WorkspacesPanel.tsx
+++ b/frontend/src/components/WorkspacesPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { GCWorktrees, RemoveWorkspace, RunAutoArchiveNow, UpdateWorkspace } from "../../wailsjs/go/main/App";
-import { types } from "../../wailsjs/go/models";
+import { GCWorktrees, ListPools, RemoveWorkspace, RunAutoArchiveNow, UpdateWorkspace } from "../../wailsjs/go/main/App";
+import { types, workerpool } from "../../wailsjs/go/models";
 import { useWorkspaceStore } from "../stores/workspaceStore";
 import { AddWorkspaceForm } from "./AddWorkspaceForm";
 import { SkillProfileEditor } from "./SkillProfileEditor";
@@ -73,6 +73,31 @@ function AutoArchiveEditor({ workspace, onSave }: { workspace: types.Workspace; 
         </button>
       </div>
     </div>
+  );
+}
+
+function PoolBindings({ workspaceID }: { workspaceID: string }) {
+  const [pools, setPools] = useState<workerpool.PoolStatus[]>([]);
+
+  useEffect(() => {
+    ListPools()
+      .then((ps) => setPools((ps ?? []).filter((r) => r.pool.scope === "workspace" && r.pool.workspace_id === workspaceID)))
+      .catch(() => {});
+  }, [workspaceID]);
+
+  if (pools.length === 0) {
+    return <div className="text-xs text-slate-500">No workspace-specific pools. Assign a pool from the Pools tab.</div>;
+  }
+  return (
+    <ul className="space-y-1">
+      {pools.map((r) => (
+        <li key={r.pool.id} className="flex items-center gap-2 text-xs">
+          <span className="text-slate-200 font-mono">{r.pool.name}</span>
+          <span className="text-slate-500">({r.pool.role})</span>
+          <span className="font-mono text-slate-400">{r.active}/{r.pool.capacity}</span>
+        </li>
+      ))}
+    </ul>
   );
 }
 
@@ -190,6 +215,10 @@ export function WorkspacesPanel() {
                     <div>
                       <div className="text-xs text-slate-400 mb-2">Labels</div>
                       <LabelsPanel workspaceID={ws.id} />
+                    </div>
+                    <div>
+                      <div className="text-xs text-slate-400 mb-2">Pool bindings</div>
+                      <PoolBindings workspaceID={ws.id} />
                     </div>
                   </div>
                 )}

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1471,6 +1471,8 @@ export namespace types {
 	    max_input_tokens?: number;
 	    bash_timeout?: number;
 	    output_cap?: number;
+	    scope?: string;
+	    workspace_id?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new Pool(source);
@@ -1494,6 +1496,8 @@ export namespace types {
 	        this.max_input_tokens = source["max_input_tokens"];
 	        this.bash_timeout = source["bash_timeout"];
 	        this.output_cap = source["output_cap"];
+	        this.scope = source["scope"];
+	        this.workspace_id = source["workspace_id"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/store/pools.go
+++ b/internal/store/pools.go
@@ -23,7 +23,7 @@ func (s *Store) ListPools() ([]types.Pool, error) {
 		return nil, errors.New("store unavailable")
 	}
 	rows, err := s.DB.Query(`
-SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap
+SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id
 FROM pools
 ORDER BY priority ASC, created_at ASC, id ASC`)
 	if err != nil {
@@ -47,7 +47,7 @@ func (s *Store) ListPoolsByRole(role types.Role) ([]types.Pool, error) {
 		return nil, errors.New("store unavailable")
 	}
 	rows, err := s.DB.Query(`
-SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap
+SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id
 FROM pools
 WHERE role = ?
 ORDER BY priority ASC, created_at ASC, id ASC`, string(role))
@@ -72,7 +72,7 @@ func (s *Store) GetPool(id string) (types.Pool, error) {
 		return types.Pool{}, errors.New("store unavailable")
 	}
 	row := s.DB.QueryRow(`
-SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap
+SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id
 FROM pools WHERE id = ?`, id)
 	return scanPool(row)
 }
@@ -121,9 +121,13 @@ func (s *Store) SavePool(p types.Pool) error {
 		ms := p.BashTimeout.Milliseconds()
 		bashTimeoutMs = &ms
 	}
+	scope := string(p.Scope)
+	if scope == "" {
+		scope = string(types.PoolScopeShared)
+	}
 	_, err := s.DB.Exec(`
-INSERT INTO pools (id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO pools (id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     name = excluded.name,
     provider = excluded.provider,
@@ -138,10 +142,25 @@ ON CONFLICT(id) DO UPDATE SET
     max_turns = excluded.max_turns,
     max_input_tokens = excluded.max_input_tokens,
     bash_timeout_ms = excluded.bash_timeout_ms,
-    output_cap = excluded.output_cap`,
+    output_cap = excluded.output_cap,
+    scope = excluded.scope,
+    workspace_id = excluded.workspace_id`,
 		p.ID, p.Name, string(p.Provider), p.Endpoint, p.Model,
 		p.Capacity, enabled, p.APIKey, string(p.Role), p.CreatedAt.Unix(), p.Priority, p.Temperature,
-		p.MaxTurns, p.MaxInputTokens, bashTimeoutMs, p.OutputCap)
+		p.MaxTurns, p.MaxInputTokens, bashTimeoutMs, p.OutputCap, scope, p.WorkspaceID)
+	return err
+}
+
+// RebindWorkspacePools sets scope='shared' and workspace_id='' for every pool
+// bound to workspaceID. Called on workspace deletion so capacity isn't orphaned
+// (issue #109, q1: silently rebind on delete).
+func (s *Store) RebindWorkspacePools(workspaceID string) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	_, err := s.DB.Exec(
+		`UPDATE pools SET scope = 'shared', workspace_id = '' WHERE workspace_id = ?`,
+		workspaceID)
 	return err
 }
 
@@ -180,9 +199,10 @@ func scanPool(r rowScanner) (types.Pool, error) {
 	var createdAt int64
 	var temperature sql.NullFloat64
 	var maxTurns, maxInputTokens, bashTimeoutMs, outputCap sql.NullInt64
+	var scope, workspaceID string
 	if err := r.Scan(&p.ID, &p.Name, &provider, &p.Endpoint, &p.Model,
 		&p.Capacity, &enabled, &p.APIKey, &role, &createdAt, &p.Priority, &temperature,
-		&maxTurns, &maxInputTokens, &bashTimeoutMs, &outputCap); err != nil {
+		&maxTurns, &maxInputTokens, &bashTimeoutMs, &outputCap, &scope, &workspaceID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return types.Pool{}, fmt.Errorf("pool not found")
 		}
@@ -214,5 +234,10 @@ func scanPool(r rowScanner) (types.Pool, error) {
 		v := int(outputCap.Int64)
 		p.OutputCap = &v
 	}
+	if scope == "" {
+		scope = string(types.PoolScopeShared)
+	}
+	p.Scope = types.PoolScope(scope)
+	p.WorkspaceID = workspaceID
 	return p, nil
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -258,6 +258,18 @@ CREATE TABLE IF NOT EXISTS pools (
 		    AND json_extract(json, '$.state') <> state`); err != nil {
 		return fmt.Errorf("backfill session json.state: %w", err)
 	}
+	// Issue #109: pool scoping — shared vs workspace-specific.
+	// Default 'shared' keeps existing rows visible to all workspaces unchanged.
+	for _, col := range []string{
+		`ALTER TABLE pools ADD COLUMN scope TEXT NOT NULL DEFAULT 'shared'`,
+		`ALTER TABLE pools ADD COLUMN workspace_id TEXT NOT NULL DEFAULT ''`,
+	} {
+		if _, err := s.DB.Exec(col); err != nil {
+			if !strings.Contains(err.Error(), "duplicate column name") {
+				return err
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -126,6 +126,10 @@ type Pool struct {
 	MaxInputTokens *int           `json:"max_input_tokens,omitempty"`
 	BashTimeout    *time.Duration `json:"bash_timeout,omitempty"`
 	OutputCap      *int           `json:"output_cap,omitempty"`
+	// Scope controls whether this pool is shared across all workspaces or
+	// dedicated to a specific workspace (issue #109). Empty = shared.
+	Scope       PoolScope `json:"scope,omitempty"`
+	WorkspaceID string    `json:"workspace_id,omitempty"`
 }
 
 // PendingPoolRequest is a persisted "waiting for pool" request. Created when
@@ -138,6 +142,16 @@ type PendingPoolRequest struct {
 	Action      string    `json:"action"`
 	CreatedAt   time.Time `json:"created_at"`
 }
+
+// PoolScope controls whether a pool is reserved for one workspace or shared
+// across all workspaces (issue #109). Empty string is treated as PoolScopeShared
+// for backwards compatibility with rows written before this field existed.
+type PoolScope string
+
+const (
+	PoolScopeShared    PoolScope = "shared"
+	PoolScopeWorkspace PoolScope = "workspace"
+)
 
 // Role names which step in the orchestration loop a pool serves (issue #39).
 // Stored as TEXT in the pools table with a CHECK constraint.

--- a/internal/workerpool/pool.go
+++ b/internal/workerpool/pool.go
@@ -154,13 +154,18 @@ func (r *Registry) Sync(rows []types.Pool) {
 // AcquireForPlan reserves a plan slot. Selection order:
 //  1. ws.SkillProfile.PreferredPlanPoolID, if set + enabled + role=plan +
 //     spawn-capable provider + free.
-//  2. Round-robin among enabled role=plan pools whose providers can spawn,
-//     starting at the registry's rolling index.
-//  3. ("", false). NO fallback to role=work — the orchestrator's auto-pull
+//  2. Workspace-specific pools bound to ws.ID (issue #109), by priority.
+//  3. Round-robin among enabled shared role=plan pools.
+//  4. ("", false). NO fallback to role=work — the orchestrator's auto-pull
 //     surfaces this as a paused-state, not a silent retry on the wrong role.
 func (r *Registry) AcquireForPlan(ws types.Workspace) (string, bool) {
 	if id, ok := r.tryPreferred(ws.SkillProfile.PreferredPlanPoolID, types.RolePlan); ok {
 		return id, true
+	}
+	if ws.ID != "" {
+		if id, ok := r.acquireWorkspaceScoped(ws.ID, types.RolePlan); ok {
+			return id, true
+		}
 	}
 	return r.acquireRoundRobin(types.RolePlan)
 }
@@ -170,6 +175,11 @@ func (r *Registry) AcquireForPlan(ws types.Workspace) (string, bool) {
 func (r *Registry) AcquireForWork(ws types.Workspace) (string, bool) {
 	if id, ok := r.tryPreferred(ws.SkillProfile.PreferredWorkPoolID, types.RoleWork); ok {
 		return id, true
+	}
+	if ws.ID != "" {
+		if id, ok := r.acquireWorkspaceScoped(ws.ID, types.RoleWork); ok {
+			return id, true
+		}
 	}
 	return r.acquireRoundRobin(types.RoleWork)
 }
@@ -216,6 +226,47 @@ func (r *Registry) tryPreferred(poolID string, role types.Role) (string, bool) {
 	return "", false
 }
 
+// acquireWorkspaceScoped tries to reserve a slot from pools whose scope=workspace
+// and workspace_id matches the given workspaceID. Pools are tried in priority
+// order (lower value = preferred). No round-robin: workspace-dedicated pools are
+// typically few and the caller falls through to shared pools on failure.
+func (r *Registry) acquireWorkspaceScoped(workspaceID string, role types.Role) (string, bool) {
+	r.mu.Lock()
+	ids := make([]string, 0)
+	for _, id := range r.order {
+		meta, ok := r.meta[id]
+		if !ok {
+			continue
+		}
+		if meta.Role != role || !meta.Enabled || meta.Capacity <= 0 {
+			continue
+		}
+		if !r.canSpawn(meta.Provider) {
+			continue
+		}
+		if meta.Scope != types.PoolScopeWorkspace || meta.WorkspaceID != workspaceID {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	sort.SliceStable(ids, func(i, j int) bool {
+		return r.meta[ids[i]].Priority < r.meta[ids[j]].Priority
+	})
+	r.mu.Unlock()
+	for _, id := range ids {
+		r.mu.RLock()
+		p := r.pools[id]
+		r.mu.RUnlock()
+		if p == nil {
+			continue
+		}
+		if p.TryAcquire() {
+			return id, true
+		}
+	}
+	return "", false
+}
+
 func (r *Registry) acquireRoundRobin(role types.Role) (string, bool) {
 	r.mu.Lock()
 	ids := make([]string, 0, len(r.order))
@@ -228,6 +279,10 @@ func (r *Registry) acquireRoundRobin(role types.Role) (string, bool) {
 			continue
 		}
 		if !r.canSpawn(meta.Provider) {
+			continue
+		}
+		// Skip workspace-specific pools; those are handled by acquireWorkspaceScoped.
+		if meta.Scope == types.PoolScopeWorkspace {
 			continue
 		}
 		ids = append(ids, id)

--- a/internal/workerpool/registry_test.go
+++ b/internal/workerpool/registry_test.go
@@ -1,0 +1,141 @@
+package workerpool
+
+import (
+	"testing"
+
+	"prismconductor/internal/types"
+)
+
+// TestAcquireForPlan_PrefersWorkspaceSpecific verifies that a workspace-specific
+// pool bound to workspace A is selected before shared pools when workspace A
+// requests a slot (issue #109 acceptance criterion 2).
+func TestAcquireForPlan_PrefersWorkspaceSpecific(t *testing.T) {
+	r := NewRegistry(func(types.Provider) bool { return true })
+	r.Sync([]types.Pool{
+		{
+			ID: "shared", Provider: types.ProviderClaude, Capacity: 5,
+			Enabled: true, Role: types.RolePlan,
+			Scope: types.PoolScopeShared,
+		},
+		{
+			ID: "ws-specific", Provider: types.ProviderClaude, Capacity: 1,
+			Enabled: true, Role: types.RolePlan,
+			Scope: types.PoolScopeWorkspace, WorkspaceID: "ws-a",
+		},
+	})
+	ws := types.Workspace{ID: "ws-a"}
+	id, ok := r.AcquireForPlan(ws)
+	if !ok {
+		t.Fatal("AcquireForPlan returned ok=false")
+	}
+	if id != "ws-specific" {
+		t.Fatalf("AcquireForPlan picked %q, want ws-specific (workspace-specific pool)", id)
+	}
+}
+
+// TestAcquireForPlan_FallsBackToShared verifies that when the workspace-specific
+// pool is full, the acquire falls back to shared pools (issue #109 criterion 3).
+func TestAcquireForPlan_FallsBackToShared(t *testing.T) {
+	r := NewRegistry(func(types.Provider) bool { return true })
+	r.Sync([]types.Pool{
+		{
+			ID: "shared", Provider: types.ProviderClaude, Capacity: 5,
+			Enabled: true, Role: types.RolePlan,
+			Scope: types.PoolScopeShared,
+		},
+		{
+			ID: "ws-specific", Provider: types.ProviderClaude, Capacity: 1,
+			Enabled: true, Role: types.RolePlan,
+			Scope: types.PoolScopeWorkspace, WorkspaceID: "ws-a",
+		},
+	})
+	ws := types.Workspace{ID: "ws-a"}
+
+	// Fill the workspace-specific pool.
+	first, ok := r.AcquireForPlan(ws)
+	if !ok || first != "ws-specific" {
+		t.Fatalf("first acquire = (%q, %v), want (ws-specific, true)", first, ok)
+	}
+	// Next acquire should fall through to shared.
+	second, ok := r.AcquireForPlan(ws)
+	if !ok {
+		t.Fatal("second AcquireForPlan returned ok=false; expected fallback to shared pool")
+	}
+	if second != "shared" {
+		t.Fatalf("second acquire = %q, want shared", second)
+	}
+}
+
+// TestAcquireForPlan_OtherWorkspaceDoesNotSeeSpecific verifies that a pool bound
+// to workspace A is NOT selected when workspace B makes a request; workspace B
+// should only see shared pools (issue #109 criterion 2).
+func TestAcquireForPlan_OtherWorkspaceDoesNotSeeSpecific(t *testing.T) {
+	r := NewRegistry(func(types.Provider) bool { return true })
+	r.Sync([]types.Pool{
+		{
+			ID: "shared", Provider: types.ProviderClaude, Capacity: 5,
+			Enabled: true, Role: types.RolePlan,
+			Scope: types.PoolScopeShared,
+		},
+		{
+			ID: "ws-a-only", Provider: types.ProviderClaude, Capacity: 2,
+			Enabled: true, Role: types.RolePlan,
+			Scope: types.PoolScopeWorkspace, WorkspaceID: "ws-a",
+		},
+	})
+	wsB := types.Workspace{ID: "ws-b"}
+	id, ok := r.AcquireForPlan(wsB)
+	if !ok {
+		t.Fatal("AcquireForPlan returned ok=false for workspace B")
+	}
+	if id != "shared" {
+		t.Fatalf("workspace B acquired %q, want shared (not ws-a-only)", id)
+	}
+}
+
+// TestAcquireForWork_PrefersWorkspaceSpecific mirrors the plan test for work role.
+func TestAcquireForWork_PrefersWorkspaceSpecific(t *testing.T) {
+	r := NewRegistry(func(types.Provider) bool { return true })
+	r.Sync([]types.Pool{
+		{
+			ID: "shared", Provider: types.ProviderClaude, Capacity: 5,
+			Enabled: true, Role: types.RoleWork,
+			Scope: types.PoolScopeShared,
+		},
+		{
+			ID: "ws-specific", Provider: types.ProviderClaude, Capacity: 1,
+			Enabled: true, Role: types.RoleWork,
+			Scope: types.PoolScopeWorkspace, WorkspaceID: "ws-a",
+		},
+	})
+	ws := types.Workspace{ID: "ws-a"}
+	id, ok := r.AcquireForWork(ws)
+	if !ok {
+		t.Fatal("AcquireForWork returned ok=false")
+	}
+	if id != "ws-specific" {
+		t.Fatalf("AcquireForWork picked %q, want ws-specific", id)
+	}
+}
+
+// TestFreeWorkSlots_CountsAllScopes verifies that FreePlanSlots / FreeWorkSlots
+// aggregate across both shared and workspace-specific pools (the orchestrator
+// pre-check must see the full capacity picture).
+func TestFreeSlots_CountsAllScopes(t *testing.T) {
+	r := NewRegistry(func(types.Provider) bool { return true })
+	r.Sync([]types.Pool{
+		{
+			ID: "shared", Provider: types.ProviderClaude, Capacity: 3,
+			Enabled: true, Role: types.RolePlan,
+			Scope: types.PoolScopeShared,
+		},
+		{
+			ID: "ws-specific", Provider: types.ProviderClaude, Capacity: 2,
+			Enabled: true, Role: types.RolePlan,
+			Scope: types.PoolScopeWorkspace, WorkspaceID: "ws-a",
+		},
+	})
+	if got := r.FreePlanSlots(); got != 5 {
+		t.Fatalf("FreePlanSlots = %d, want 5 (3 shared + 2 workspace-specific)", got)
+	}
+}

--- a/migrations/20260504_add_pool_scope.sql
+++ b/migrations/20260504_add_pool_scope.sql
@@ -1,0 +1,6 @@
+-- Issue #109: pool scoping — shared vs workspace-specific.
+-- Applied by internal/store/sqlite.go migrate() using idempotent ALTER TABLE.
+-- This file is documentation only; the Go migration is the authoritative source.
+
+ALTER TABLE pools ADD COLUMN scope TEXT NOT NULL DEFAULT 'shared';
+ALTER TABLE pools ADD COLUMN workspace_id TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## Summary

- Introduces `Pool.Scope` (`shared` | `workspace`) and `Pool.WorkspaceID` so operators can reserve capacity for one workspace while keeping shared pools as global fallback.
- Existing pools migrate automatically to `scope=shared` via idempotent `ALTER TABLE` statements — single-workspace installs see no behavior change.
- On workspace deletion, bound pools are silently rebound to shared so capacity is never orphaned.

## Files modified

- `internal/types/types.go` — `PoolScope` type + constants, `Scope`/`WorkspaceID` fields on `Pool`
- `internal/store/sqlite.go` — idempotent `ALTER TABLE pools ADD COLUMN scope` / `workspace_id` migration
- `internal/store/pools.go` — updated `scanPool`, `SavePool`, new `RebindWorkspacePools`
- `internal/workerpool/pool.go` — `acquireWorkspaceScoped` phase before shared round-robin; `acquireRoundRobin` skips `scope=workspace` pools
- `internal/workerpool/registry_test.go` — 5 new tests: workspace preference, fallback, isolation, work-role, slot counting
- `app.go` — `RemoveWorkspace` rebinds pools + re-syncs registry before removing workspace
- `migrations/20260504_add_pool_scope.sql` — documentation-only mirror of the Go migration
- `frontend/src/components/PoolEditModal.tsx` — Scope radio (Shared / Workspace-specific) + workspace dropdown; Save disabled until workspace selected
- `frontend/src/components/PoolsPanel.tsx` — scope badge after pool name: `(shared)` or `workspace: <name>`
- `frontend/src/components/WorkspacesPanel.tsx` — Pool bindings section under expanded workspace settings
- `frontend/wailsjs/go/models.ts` — `scope` and `workspace_id` added to `Pool` class (regenerated by `wails build`)

## Verification

| Step | Command | Result |
|------|---------|--------|
| Lint | `go vet prismconductor/internal/...` | pass |
| Build | `wails build` (worktree) | pass — built in 10.99s |
| Smoke test | `tests/e2e/startup.spec.ts` | skipped — no dev server in worktree CI context (pre-existing limitation) |
| Tests | `go test prismconductor/internal/...` | pass — 19/19 workerpool tests (5 new), all 26 packages pass |

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-109

Closes #109