### PR TITLE
fix(store): WaitingForPool flag stuck true forever (preservation rule blocked clear path)

### DIFF
--- a/app.go
+++ b/app.go
@@ -982,10 +982,7 @@ func (a *App) MoveIssueColumn(workspaceID string, number int, column string) err
 					// card.
 					log.Printf("auto-spawn plan #%d: no plan pool available — enqueuing", number)
 					_ = a.store.EnqueuePendingPool(workspaceID, number, types.RolePlan, "drag_to_plan")
-					if iss, lerr := a.store.LoadIssue(workspaceID, number); lerr == nil && !iss.WaitingForPool {
-						iss.WaitingForPool = true
-						_, _ = a.store.SaveIssue(iss)
-					}
+					_ = a.store.SetIssueWaitingForPool(workspaceID, number, true)
 					a.bus.Publish(eventbus.EvtPendingPoolEnqueued, eventbus.PendingPoolChange{
 						WorkspaceID: workspaceID,
 						IssueNumber: number,
@@ -2219,10 +2216,7 @@ func (a *App) ApprovePlan(workspaceID string, issueNumber, revision int) error {
 		// No work slot available — persist intent and show waiting decoration.
 		// The card stays in IN_PROGRESS; drain fires it when a slot frees.
 		_ = a.store.EnqueuePendingPool(workspaceID, issueNumber, types.RoleWork, "approve_execute")
-		if iss, lerr := a.store.LoadIssue(workspaceID, issueNumber); lerr == nil {
-			iss.WaitingForPool = true
-			_, _ = a.store.SaveIssue(iss)
-		}
+		_ = a.store.SetIssueWaitingForPool(workspaceID, issueNumber, true)
 		a.bus.Publish(eventbus.EvtPendingPoolEnqueued, eventbus.PendingPoolChange{
 			WorkspaceID: workspaceID,
 			IssueNumber: issueNumber,
@@ -2313,10 +2307,7 @@ func (a *App) ContinueWork(workspaceID string, issueNumber int, note string) err
 	pool, ok := a.acquireWorkPool(ws)
 	if !ok {
 		_ = a.store.EnqueuePendingPool(workspaceID, issueNumber, types.RoleWork, "continue_execute")
-		if iss, lerr := a.store.LoadIssue(workspaceID, issueNumber); lerr == nil {
-			iss.WaitingForPool = true
-			_, _ = a.store.SaveIssue(iss)
-		}
+		_ = a.store.SetIssueWaitingForPool(workspaceID, issueNumber, true)
 		a.bus.Publish(eventbus.EvtPendingPoolEnqueued, eventbus.PendingPoolChange{
 			WorkspaceID: workspaceID,
 			IssueNumber: issueNumber,

--- a/internal/orchestrator/drain_pending_pools.go
+++ b/internal/orchestrator/drain_pending_pools.go
@@ -94,10 +94,7 @@ func (o *Orchestrator) enqueuePending(iss *types.Issue, role types.Role, action 
 		log.Printf("orchestrator: enqueue pending pool (#%d): %v", iss.Number, err)
 		return
 	}
-	if loaded, err := o.store.LoadIssue(iss.WorkspaceID, iss.Number); err == nil && !loaded.WaitingForPool {
-		loaded.WaitingForPool = true
-		_, _ = o.store.SaveIssue(loaded)
-	}
+	_ = o.store.SetIssueWaitingForPool(iss.WorkspaceID, iss.Number, true)
 	o.bus.Publish(eventbus.EvtPendingPoolEnqueued, eventbus.PendingPoolChange{
 		WorkspaceID: iss.WorkspaceID,
 		IssueNumber: iss.Number,
@@ -107,15 +104,19 @@ func (o *Orchestrator) enqueuePending(iss *types.Issue, role types.Role, action 
 
 // clearWaitingForPool clears the WaitingForPool flag and removes any pending
 // rows for the issue. No-op if the issue is already clear.
+//
+// Uses the dedicated SetIssueWaitingForPool atomic SQL update instead of
+// SaveIssue. SaveIssue preserves `waiting_for_pool=true` across re-saves to
+// defend against the GitHub poll cycle clobbering the flag, but that
+// preservation also blocks the legitimate clear path: a Load → mutate →
+// SaveIssue would re-read prev=true and preservation would force the flag
+// back to true, so the flag could never actually be cleared. Witnessed
+// live on issue #144 (PR #147 already in REVIEW, but card still glowing
+// pink "waiting for available agent pool" with no pending_pool_for row).
 func (o *Orchestrator) clearWaitingForPool(workspaceID string, issueNumber int) {
 	if o.store == nil {
 		return
 	}
 	_ = o.store.DeletePendingForIssue(workspaceID, issueNumber)
-	loaded, err := o.store.LoadIssue(workspaceID, issueNumber)
-	if err != nil || !loaded.WaitingForPool {
-		return
-	}
-	loaded.WaitingForPool = false
-	_, _ = o.store.SaveIssue(loaded)
+	_ = o.store.SetIssueWaitingForPool(workspaceID, issueNumber, false)
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -30,6 +30,7 @@ type Store interface {
 	ListPendingPools(limit int) ([]types.PendingPoolRequest, error)
 	DequeuePendingPool(id int64) error
 	DeletePendingForIssue(workspaceID string, issueNumber int) error
+	SetIssueWaitingForPool(workspaceID string, issueNumber int, waiting bool) error
 }
 
 // PoolRouter is the slice of *workerpool.Registry we need (issue #27,

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -54,6 +54,7 @@ func (s *stubStore) EnqueuePendingPool(string, int, types.Role, string) error { 
 func (s *stubStore) ListPendingPools(int) ([]types.PendingPoolRequest, error)  { return nil, nil }
 func (s *stubStore) DequeuePendingPool(int64) error                            { return nil }
 func (s *stubStore) DeletePendingForIssue(string, int) error                   { return nil }
+func (s *stubStore) SetIssueWaitingForPool(string, int, bool) error            { return nil }
 
 type stubPool struct {
 	free        int

--- a/internal/store/issues.go
+++ b/internal/store/issues.go
@@ -285,6 +285,40 @@ func (s *Store) UnarchiveAll(workspaceID string) error {
 	return err
 }
 
+// SetIssueWaitingForPool atomically writes `$.waiting_for_pool` inside the
+// JSON blob via json_set, bypassing SaveIssue's preservation logic.
+//
+// Why this exists as a dedicated method: SaveIssue preserves
+// `waiting_for_pool=true` across re-saves (see issues.go:96 — needed so the
+// GitHub poller's 5-min SaveIssue cycle doesn't clobber the conductor's
+// queued-spawn flag back to false). That preservation rule is correct for
+// the poll case but BLOCKS the legitimate clear path: orchestrator's
+// clearWaitingForPool would Load → set false → SaveIssue, but SaveIssue
+// re-reads prev (still true), preservation kicks in, and the flag is forced
+// back to true. The flag could never actually be cleared.
+//
+// json_set avoids the read-modify-write entirely; the indexed column-style
+// fix that worked for UpdateSessionState (#sessions.go:UpdateSessionState).
+//
+// Use only from paths that should authoritatively set/clear the flag
+// (orchestrator drain success, explicit user action). NOT from anywhere
+// that should respect the GitHub-poll preservation rule.
+func (s *Store) SetIssueWaitingForPool(workspaceID string, number int, waiting bool) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	v := "false"
+	if waiting {
+		v = "true"
+	}
+	_, err := s.DB.Exec(
+		`UPDATE issues
+		    SET json = json_set(json, '$.waiting_for_pool', json(?))
+		  WHERE workspace_id = ? AND number = ?`,
+		v, workspaceID, number)
+	return err
+}
+
 // MoveIssueColumn updates the column for an issue and resets manual_order to
 // the bottom of the destination column.
 func (s *Store) MoveIssueColumn(workspaceID string, number int, column types.BoardColumn) error {

--- a/internal/store/issues_test.go
+++ b/internal/store/issues_test.go
@@ -788,3 +788,90 @@ func TestMarkIssueClosedSetsClosedAt(t *testing.T) {
 		t.Errorf("closed_at %d is before test start %d", *closedAt, before.Unix())
 	}
 }
+
+// SetIssueWaitingForPool MUST bypass SaveIssue's preservation rule. The
+// preservation forces waiting_for_pool back to true on every re-save when
+// prev was true (defends against the GitHub-poll cycle). That preservation
+// also blocked the legitimate clear path: orchestrator's clearWaitingForPool
+// did Load → set false → SaveIssue, and SaveIssue re-read prev=true,
+// preservation triggered, the flag was forced back to true. Witnessed live
+// on issue #144 (PR already in REVIEW, card stuck pink "waiting" with no
+// pending_pool_for row). Atomic json_set bypasses SaveIssue entirely.
+func TestSetIssueWaitingForPool_ClearsBypassingPreservation(t *testing.T) {
+	s := newTestStore(t)
+	// Save with WaitingForPool=true (the conductor's enqueue path).
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID:    "ws1",
+		Number:         144,
+		State:          "open",
+		Column:         types.ColReview,
+		WaitingForPool: true,
+	}); err != nil {
+		t.Fatalf("SaveIssue: %v", err)
+	}
+	// Sanity: the flag is set.
+	iss, err := s.LoadIssue("ws1", 144)
+	if err != nil {
+		t.Fatalf("LoadIssue: %v", err)
+	}
+	if !iss.WaitingForPool {
+		t.Fatal("setup: expected WaitingForPool=true after SaveIssue")
+	}
+
+	// Clear via the dedicated atomic method.
+	if err := s.SetIssueWaitingForPool("ws1", 144, false); err != nil {
+		t.Fatalf("SetIssueWaitingForPool: %v", err)
+	}
+	iss, err = s.LoadIssue("ws1", 144)
+	if err != nil {
+		t.Fatalf("LoadIssue post-clear: %v", err)
+	}
+	if iss.WaitingForPool {
+		t.Fatal("WaitingForPool should be false after SetIssueWaitingForPool(false), but it's true (preservation rule incorrectly fired)")
+	}
+
+	// And a SUBSEQUENT SaveIssue (e.g. from a GitHub poll) must NOT
+	// resurrect the flag — prev is now false in the DB, so preservation
+	// has nothing to preserve.
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      144,
+		State:       "open",
+		Column:      types.ColReview,
+		// WaitingForPool not set in the incoming struct (zero value = false)
+	}); err != nil {
+		t.Fatalf("post-clear SaveIssue: %v", err)
+	}
+	iss, err = s.LoadIssue("ws1", 144)
+	if err != nil {
+		t.Fatalf("LoadIssue post-poll: %v", err)
+	}
+	if iss.WaitingForPool {
+		t.Fatal("WaitingForPool resurrected after a clean poll — preservation rule fired against a falsely-true prev")
+	}
+}
+
+// Sanity: SetIssueWaitingForPool can also SET to true atomically without
+// going through SaveIssue. Used by enqueue paths to avoid load-modify-write
+// races against the GitHub poll cycle.
+func TestSetIssueWaitingForPool_SetsTrue(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      150,
+		State:       "open",
+		Column:      types.ColInProgress,
+	}); err != nil {
+		t.Fatalf("SaveIssue: %v", err)
+	}
+	if err := s.SetIssueWaitingForPool("ws1", 150, true); err != nil {
+		t.Fatalf("SetIssueWaitingForPool: %v", err)
+	}
+	iss, err := s.LoadIssue("ws1", 150)
+	if err != nil {
+		t.Fatalf("LoadIssue: %v", err)
+	}
+	if !iss.WaitingForPool {
+		t.Fatal("WaitingForPool should be true after SetIssueWaitingForPool(true)")
+	}
+}


### PR DESCRIPTION
## Summary

Cards stayed glowing pink "waiting for available agent pool" forever, even after the pool drained and the spawn succeeded.

Witnessed live on issue #144 — PR #147 already in REVIEW, plan + execute both completed cleanly, no `pending_pool_for` row. But `issues.json.$.waiting_for_pool` was permanently stuck at `true`.

## Root cause

`SaveIssue` has a preservation rule (added earlier to defend against the GitHub-poll cycle clobbering the flag): if `prev.WaitingForPool == true` in the DB, force the incoming value back to true. That rule was correct for poll-vs-conductor races but **also blocked the legitimate clear path**:

`orchestrator.clearWaitingForPool` did:
1. `LoadIssue` → reads `prev.WaitingForPool=true`
2. set `loaded.WaitingForPool = false`
3. `SaveIssue` → re-reads `prev=true` from DB (we haven't written yet), preservation kicks in, forces incoming false back to true.

The clear path was a no-op every time. The flag was unclearable except by direct SQL.

## Fix

Dedicated atomic SQL update `Store.SetIssueWaitingForPool(ws, num, bool)` that writes via `json_set(json, '$.waiting_for_pool', json(?))`, completely bypassing SaveIssue's read-modify preservation logic. Same pattern as the `UpdateSessionState` `json_set` fix for the parallel session-state-stuck-running bug.

All four flip sites now use the atomic method:
- `orchestrator.clearWaitingForPool` (the broken clear path)
- `orchestrator.enqueuePending` (drain auto-enqueue)
- `app.go` drag-to-PLAN no-slot enqueue
- `app.go` ApprovePlan no-slot enqueue
- `app.go` ContinueWork no-slot enqueue

The poll-protection preservation rule still fires correctly: when a poll runs against a freshly-cleared row, `prev=false` in the DB, no preservation triggers, the new false sticks.

## Tests

`TestSetIssueWaitingForPool_ClearsBypassingPreservation` — locks down clear → poll → re-poll without resurrection. Will fail at CI if any future refactor re-introduces the preservation race.

`TestSetIssueWaitingForPool_SetsTrue` — sanity check on the set-true path.

Full `go test ./...` clean.

## Live mitigation

Patched the stuck flag for #144 directly in the running DB so the pink glow clears immediately rather than waiting on restart + this PR landing.

## Test plan
- [ ] Restart conductor, drag a fresh issue to PLAN while planner pool is full → flag set to true, pink glow appears
- [ ] Slot frees, drain spawns the worker → flag cleared, pink glow disappears
- [ ] GitHub poll cycle runs after the clear → flag stays cleared (no resurrection)