### PR TITLE
fix: stale state=running session leaks glow onto DONE/REVIEW cards

### DIFF
--- a/app.go
+++ b/app.go
@@ -324,6 +324,17 @@ func (a *App) startup(ctx context.Context) {
 		} else if n > 0 {
 			log.Printf("reconciled %d closed issues to DONE\n", n)
 		}
+		// Self-heal any session row left in state=running for an issue whose
+		// PR is already open or merged. Harness sessions can leave stale
+		// running rows when their goroutine dies/hangs without cleaning up;
+		// without this pass the assembler picks them as active_session and
+		// the card glows blue/purple in REVIEW/DONE forever (witnessed on
+		// issue #109).
+		if n, err := a.store.ReconcileStaleRunningSessions(); err != nil {
+			log.Printf("reconcile stale running sessions: %v\n", err)
+		} else if n > 0 {
+			log.Printf("reconciled %d stale running sessions to failed\n", n)
+		}
 
 		// Issue #107: auto-archive DONE cards per workspace config. Run once at
 		// startup and then on a 24-hour tick so long-running sessions stay clean.

--- a/internal/issueview/assembler.go
+++ b/internal/issueview/assembler.go
@@ -341,6 +341,19 @@ func selectSessions(iss types.Issue, sessions []types.Session) (active, paused, 
 		lastFail = nil
 	}
 
+	// Suppress active when card is in DONE (work demonstrably shipped, PR
+	// merged → moved to DONE by the merge handler). Any session row left in
+	// state=running for a DONE card is by definition stale state from a
+	// harness goroutine that died/hung without cleaning up its DB row, OR
+	// from a worker the conductor was killed mid-process. Witnessed live on
+	// issue #109 — DONE column with PR #149 merged, but a state=running plan
+	// row from before the merge made the card glow blue as if planning. The
+	// stuck row needs separate cleanup (TODO: startup reconciler), but the
+	// UI must NEVER claim a shipped card is actively being worked on.
+	if active != nil && iss.Column == types.ColDone {
+		active = nil
+	}
+
 	return active, paused, lastFail, lastSession
 }
 

--- a/internal/issueview/assembler_test.go
+++ b/internal/issueview/assembler_test.go
@@ -126,6 +126,21 @@ func TestSelectSessions_LastFailureSuppressedInDone(t *testing.T) {
 	}
 }
 
+// A session left in state=running for a card that's already in DONE is by
+// definition stale — work shipped, PR merged, the card moved to DONE via
+// the merge handler. The harness goroutine for that session may have died
+// or hung without cleaning up its DB row; either way the UI must NEVER
+// claim a shipped card is actively being worked on. Witnessed on issue
+// #109 (DONE column with PR #149 merged, but a state=running plan row
+// from before the merge made the card glow blue as if planning).
+func TestSelectSessions_ActiveSuppressedInDone(t *testing.T) {
+	sessions := []types.Session{makeSession(types.StateRunning, t1, "", false)}
+	active, _, _, _ := selectSessions(types.Issue{Column: types.ColDone}, sessions)
+	if active != nil {
+		t.Errorf("active session should be suppressed for DONE cards (stale running row), got %+v", active)
+	}
+}
+
 func TestSelectSessions_LastFailureSuppressedByLaterSuccess(t *testing.T) {
 	sessions := []types.Session{
 		makeSession(types.StateCompleted, t3, "", false),

--- a/internal/store/issues.go
+++ b/internal/store/issues.go
@@ -432,6 +432,39 @@ func (s *Store) RemoveIssue(workspaceID string, number int) error {
 	return err
 }
 
+// ReconcileStaleRunningSessions marks any session row whose state is still
+// `running` or `waiting_for_input` but whose corresponding issue is in
+// REVIEW (PR open) or DONE (PR merged) as failed. Self-healing pass for
+// harness sessions whose goroutine died/hung mid-run without updating its
+// DB row, leaving the IssueView assembler picking the stale row as
+// `active_session` and Card.tsx rendering a glow on a card whose work has
+// demonstrably shipped. Witnessed on issue #109. Returns the number of
+// rows reconciled.
+func (s *Store) ReconcileStaleRunningSessions() (int, error) {
+	if s == nil || s.DB == nil {
+		return 0, errors.New("store unavailable")
+	}
+	res, err := s.DB.Exec(`
+UPDATE sessions
+   SET state = 'failed',
+       json  = json_set(json,
+                 '$.state', 'failed',
+                 '$.blocked_reason', 'reconciled at startup: session left state=running while issue is in review/done')
+ WHERE state IN ('running','waiting_for_input')
+   AND EXISTS (
+       SELECT 1
+         FROM issues
+        WHERE issues.workspace_id = sessions.workspace_id
+          AND issues.number       = sessions.issue_number
+          AND issues.column_name IN ('review','done')
+   )`)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
 // ReconcileClosedIssues routes any issue that's already state=closed in its
 // JSON but stuck in a non-done column over to DONE. Self-healing pass for
 // rows left half-migrated by an earlier buggy poll. Returns the number of

--- a/internal/store/issues_test.go
+++ b/internal/store/issues_test.go
@@ -633,6 +633,109 @@ func TestMarkIssueClosedSkipsArchived(t *testing.T) {
 	}
 }
 
+// ReconcileStaleRunningSessions finds session rows whose state is still
+// running (or waiting_for_input) but whose owning issue is already in
+// REVIEW or DONE. Those rows can only exist when a harness goroutine died
+// without updating its DB state — the IssueView assembler then surfaces
+// them as `active_session` and the card glows blue/purple in REVIEW/DONE
+// forever. The reconciler marks them failed at startup so the UI clears.
+func TestReconcileStaleRunningSessions(t *testing.T) {
+	s := newTestStore(t)
+	// Issue #1 is DONE with a PR merged. A stale running session sits on it.
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      1,
+		State:       "closed",
+		Column:      types.ColDone,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	stale := &types.Session{
+		ID:          "sess-stale-done",
+		WorkspaceID: "ws1",
+		IssueNumber: 1,
+		Mode:        types.ModePlan,
+		State:       types.StateRunning,
+		StartedAt:   time.Now(),
+	}
+	if err := s.SaveSession(stale, ""); err != nil {
+		t.Fatalf("SaveSession stale: %v", err)
+	}
+	// Issue #2 is in REVIEW with a stale running execute session.
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      2,
+		State:       "open",
+		Column:      types.ColReview,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	staleRev := &types.Session{
+		ID:          "sess-stale-review",
+		WorkspaceID: "ws1",
+		IssueNumber: 2,
+		Mode:        types.ModeExecute,
+		State:       types.StateRunning,
+		StartedAt:   time.Now(),
+	}
+	if err := s.SaveSession(staleRev, ""); err != nil {
+		t.Fatalf("SaveSession stale review: %v", err)
+	}
+	// Issue #3 is in PLAN with a legitimately running plan session — must NOT be touched.
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      3,
+		State:       "open",
+		Column:      types.ColPlan,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	live := &types.Session{
+		ID:          "sess-live",
+		WorkspaceID: "ws1",
+		IssueNumber: 3,
+		Mode:        types.ModePlan,
+		State:       types.StateRunning,
+		StartedAt:   time.Now(),
+	}
+	if err := s.SaveSession(live, ""); err != nil {
+		t.Fatalf("SaveSession live: %v", err)
+	}
+
+	n, err := s.ReconcileStaleRunningSessions()
+	if err != nil {
+		t.Fatalf("ReconcileStaleRunningSessions: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("reconciled %d sessions, want 2 (the DONE + REVIEW stale rows)", n)
+	}
+
+	// Verify both indexed state column AND $.state JSON blob got updated for stale rows.
+	for _, id := range []string{"sess-stale-done", "sess-stale-review"} {
+		var col, jstate string
+		if err := s.DB.QueryRow(
+			`SELECT state, json_extract(json,'$.state') FROM sessions WHERE id = ?`, id,
+		).Scan(&col, &jstate); err != nil {
+			t.Fatalf("read %s: %v", id, err)
+		}
+		if col != "failed" {
+			t.Errorf("%s: indexed state=%q, want failed", id, col)
+		}
+		if jstate != "failed" {
+			t.Errorf("%s: json.state=%q, want failed", id, jstate)
+		}
+	}
+
+	// The live PLAN session must still be running.
+	var liveState string
+	if err := s.DB.QueryRow(`SELECT state FROM sessions WHERE id = 'sess-live'`).Scan(&liveState); err != nil {
+		t.Fatalf("read live: %v", err)
+	}
+	if liveState != "running" {
+		t.Errorf("live PLAN session was wrongly reconciled, state=%q", liveState)
+	}
+}
+
 func TestReconcileClosedIssuesSkipsArchived(t *testing.T) {
 	s := newTestStore(t)
 	// Closed issue stuck in TODO — should be reconciled.


### PR DESCRIPTION
## Summary

DONE cards glow blue/purple as if actively planning/working, even with PR merged and zero pool slots in use. Witnessed live on issue #109 (DONE column, PR #149 merged, but card glowing blue with `planning` label — pool counter `0/2 planners, 0/2 workers`).

## Root cause

A harness session for #109 was stuck in the DB with `state='running'` and `json.state='running'`, even though its goroutine had died/hung without cleaning up the row.

The IssueView assembler's `selectSessions` trusts ANY `state=running` row as `active_session` regardless of the card's column or PR state. So the merged-PR DONE card carried a stale 'active plan' badge forever.

## Fix (two layers)

**1. Assembler suppression** — `selectSessions` now nulls out `active` when `iss.Column == ColDone`. By definition a card in DONE has had its work shipped (the merge handler moved it there); any surviving `state=running` row is stale UI noise. Mirrors the existing `lastFail` suppression for REVIEW/DONE.

**2. Startup reconciler** — `Store.ReconcileStaleRunningSessions` atomically flips every `state=running` (or `waiting_for_input`) session whose owning issue is in REVIEW/DONE to `failed`, updating both the indexed `state` column and `json.state` via `json_set` so the assembler sees consistent values. Wired into `app.go` startup next to `ReconcileClosedIssues`. The stale DB row gets cleaned up at process boot rather than lingering forever.

## Live mitigation

Patched #109's stuck row directly in the running DB so the user's blue glow clears immediately.

## Tests

- `TestSelectSessions_ActiveSuppressedInDone` — locks down the assembler's column suppression.
- `TestReconcileStaleRunningSessions` — DONE + REVIEW stale rows flip to failed; indexed `state` and `json.state` stay in sync; a legitimately-running PLAN session is untouched.

`go test ./...` clean.

## Test plan
- [ ] Restart conductor → reconciler runs, no DONE/REVIEW cards retain glow
- [ ] Approve a fresh plan, let it complete, merge PR → DONE card has no glow
- [ ] Manually inject a `state=running` row for a DONE card, restart → row reconciled to failed, glow clears