### PR TITLE
feat(session): always write terminal state on harness exit (#152)

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -1,0 +1,17 @@
+package llm
+
+import (
+	"net/http"
+	"time"
+)
+
+// DefaultHTTPTimeout is the per-LLM-call timeout applied to all provider HTTP
+// clients. Five minutes is generous for slow local models while bounding
+// runaway HTTP hangs that would otherwise leave harness sessions as zombies.
+const DefaultHTTPTimeout = 5 * time.Minute
+
+// NewHTTPClient returns an *http.Client with the given timeout. Use this
+// instead of a bare &http.Client{} so every provider inherits a safety timeout.
+func NewHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{Timeout: timeout}
+}

--- a/internal/llm/litellm.go
+++ b/internal/llm/litellm.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"time"
 
 	"prismconductor/internal/types"
 )
@@ -20,7 +19,7 @@ type litellmProvider struct {
 }
 
 func NewLiteLLMProvider() Provider {
-	return litellmProvider{client: &http.Client{Timeout: 5 * time.Minute}}
+	return litellmProvider{client: NewHTTPClient(DefaultHTTPTimeout)}
 }
 
 func (litellmProvider) Kind() types.Provider    { return types.ProviderLiteLLM }

--- a/internal/llm/lmstudio.go
+++ b/internal/llm/lmstudio.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"sort"
 	"strings"
-	"time"
 
 	"prismconductor/internal/types"
 )
@@ -19,7 +18,7 @@ type lmstudioProvider struct {
 }
 
 func NewLMStudioProvider() Provider {
-	return lmstudioProvider{client: &http.Client{Timeout: 5 * time.Minute}}
+	return lmstudioProvider{client: NewHTTPClient(DefaultHTTPTimeout)}
 }
 
 func (lmstudioProvider) Kind() types.Provider    { return types.ProviderLMStudio }

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"sort"
 	"strings"
-	"time"
 
 	"prismconductor/internal/types"
 )
@@ -18,7 +17,7 @@ type ollamaProvider struct {
 }
 
 func NewOllamaProvider() Provider {
-	return ollamaProvider{client: &http.Client{Timeout: 5 * time.Minute}}
+	return ollamaProvider{client: NewHTTPClient(DefaultHTTPTimeout)}
 }
 
 func (ollamaProvider) Kind() types.Provider    { return types.ProviderOllama }

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	"prismconductor/internal/types"
 )
@@ -29,14 +28,14 @@ type openaiProvider struct {
 
 // NewOpenAIProvider returns a provider with no usage sink.
 func NewOpenAIProvider() Provider {
-	return openaiProvider{client: &http.Client{Timeout: 5 * time.Minute}}
+	return openaiProvider{client: NewHTTPClient(DefaultHTTPTimeout)}
 }
 
 // NewOpenAIProviderWithSink returns a provider that calls sink after each
 // successful call with any rate-limit snapshots found in response headers.
 func NewOpenAIProviderWithSink(sink UsageSink) Provider {
 	return openaiProvider{
-		client:    &http.Client{Timeout: 5 * time.Minute},
+		client:    NewHTTPClient(DefaultHTTPTimeout),
 		usageSink: sink,
 	}
 }

--- a/internal/session/harness.go
+++ b/internal/session/harness.go
@@ -1,0 +1,75 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"runtime/debug"
+
+	"prismconductor/internal/harness"
+	"prismconductor/internal/llm"
+	"prismconductor/internal/skills/bundle"
+	"prismconductor/internal/types"
+)
+
+// spawnHarness launches the in-process harness goroutine for a harness-strategy
+// session (issue #58, #152). The goroutine wraps harness.Execute with a
+// top-level panic-recovery defer so a misbehaving provider or tool cannot crash
+// the conductor. Any recovered panic is written to rs.harnessErr so that
+// mapTerminalState reports StateFailed rather than silently treating the panicked
+// session as completed.
+//
+// The returned channel is closed when the goroutine exits (clean, panic, or
+// context cancel). Wire it into synthCmd.done before passing rs to tailAndParse.
+//
+// Callers must ensure m.providers.Get(pool.Provider) succeeds before calling;
+// the provider is passed explicitly (prov) to avoid a second registry lookup.
+func (m *Manager) spawnHarness(
+	ctx context.Context,
+	rs *runtimeSession,
+	prov llm.Provider,
+	ws types.Workspace,
+	pool types.Pool,
+	prompt, skillMarkdown string,
+) chan struct{} {
+	done := make(chan struct{})
+	run := harness.Run{
+		SessionID:     rs.sess.ID,
+		RepoPath:      ws.RepoPath,
+		WorktreeDir:   rs.worktreeDir,
+		Mode:          rs.sess.Mode,
+		SkillMode:     ws.SkillProfile.Mode,
+		SkillMarkdown: skillMarkdown,
+		Pool:          pool,
+		Provider:      prov,
+		UserPrompt:    prompt,
+		Skills:        bundle.FS,
+		EnvVars:       envSpecToSlice(ws.AgentEnv),
+		Budget:        poolBudget(pool),
+		Out:           rs.transcriptFile,
+		OnTurnUsage: func(in, out int) {
+			rs.actMu.Lock()
+			rs.harnessInputTokens = int64(in)
+			rs.harnessOutputTokens = int64(out)
+			rs.actMu.Unlock()
+		},
+	}
+	go func() {
+		defer func() {
+			// Safety-net: recover panics so a misbehaving provider or tool does
+			// not crash the conductor process. The panic text is embedded in
+			// harnessErr so mapTerminalState resolves to StateFailed and the UI
+			// shows a blocked card instead of a zombie running card.
+			if r := recover(); r != nil {
+				stack := debug.Stack()
+				rs.actMu.Lock()
+				rs.harnessErr = fmt.Errorf("harness panic: %v\n%s", r, stack)
+				rs.actMu.Unlock()
+				log.Printf("session %s: harness panic recovered: %v", rs.sess.ID, r)
+			}
+			close(done)
+		}()
+		rs.harnessErr = harness.Execute(ctx, run)
+	}()
+	return done
+}

--- a/internal/session/harness_test.go
+++ b/internal/session/harness_test.go
@@ -1,0 +1,214 @@
+package session
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"prismconductor/internal/llm"
+	"prismconductor/internal/types"
+)
+
+// controlledProviderKind is the types.Provider key for the test fake.
+const controlledProviderKind types.Provider = "fake-harness-test"
+
+// controlledProvider is a programmable llm.Provider used to exercise harness
+// lifecycle paths without real HTTP. Set behavior to:
+//
+//   - "panic"  — ToolChat panics with a known message.
+//   - "hang"   — ToolChat blocks until ctx is cancelled.
+//   - "stop"   — ToolChat immediately returns Stop: true (clean exit).
+type controlledProvider struct {
+	behavior string
+}
+
+func (controlledProvider) Kind() types.Provider    { return controlledProviderKind }
+func (controlledProvider) DisplayName() string     { return "fake-harness-test" }
+func (controlledProvider) DefaultEndpoint() string { return "" }
+func (controlledProvider) NeedsAPIKey() bool       { return false }
+func (controlledProvider) CanSpawn() bool          { return true }
+func (controlledProvider) ListModels(context.Context, types.Pool) ([]string, error) {
+	return nil, llm.ErrNotSupported
+}
+func (controlledProvider) SpawnArgs(types.Pool, string) ([]string, error) {
+	return nil, llm.ErrNotSupported
+}
+func (controlledProvider) ChatJSON(context.Context, types.Pool, string, string) (string, error) {
+	return "", llm.ErrNotSupported
+}
+func (p controlledProvider) ToolChat(ctx context.Context, _ types.Pool, _ llm.ChatRequest) (llm.ChatResponse, error) {
+	switch p.behavior {
+	case "panic":
+		panic("injected test panic")
+	case "hang":
+		<-ctx.Done()
+		return llm.ChatResponse{}, ctx.Err()
+	default: // "stop"
+		return llm.ChatResponse{Stop: true}, nil
+	}
+}
+
+// spawnHarnessSession is a helper that registers a fake harness provider, spawns
+// a harness-strategy session, and returns the session plus the manager for
+// assertion. The caller is responsible for cleanup via m.Kill if needed.
+func spawnHarnessSession(t *testing.T, behavior string) (sess *types.Session, m *Manager, store *fakePersister) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX-only: harness integration tests require os.Pipe / file I/O")
+	}
+	tdir := t.TempDir()
+	store = &fakePersister{}
+	m = NewManager(nil, nil)
+	m.Configure(filepath.Join(tdir, "transcripts"), store, nil)
+	m.SetProviders(llm.NewRegistry(controlledProvider{behavior: behavior}))
+
+	ws := types.Workspace{ID: "ws-h", RepoPath: tdir}
+	issue := types.Issue{Number: 501, WorkspaceID: ws.ID}
+	pool := types.Pool{ID: "pool-h", Provider: controlledProviderKind}
+
+	var err error
+	sess, err = m.spawnWithDir(ws, issue, types.ModePlan, nil, "test prompt", "", "", pool, "")
+	if err != nil {
+		t.Fatalf("spawnWithDir: %v", err)
+	}
+	return sess, m, store
+}
+
+// waitForSessionGone polls m.sessions until the session is removed or a
+// deadline expires. Returns true when the session is gone.
+func waitForSessionGone(m *Manager, sessID string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		m.mu.RLock()
+		_, there := m.sessions[sessID]
+		m.mu.RUnlock()
+		if !there {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// lastStateFor returns the last state update recorded by fakePersister for the
+// given session ID, or "" if none was recorded.
+func lastStateFor(store *fakePersister, sessID string) string {
+	var last string
+	for _, upd := range store.stateUpd {
+		if strings.HasPrefix(upd, sessID+":") {
+			last = strings.TrimPrefix(upd, sessID+":")
+		}
+	}
+	return last
+}
+
+// TestHarnessPanicLandsInFailedState verifies that a panic inside
+// harness.Execute is caught by the spawnHarness recovery defer, written to
+// rs.harnessErr, and then mapped to state=failed by mapTerminalState via the
+// normal tailAndParse path.
+func TestHarnessPanicLandsInFailedState(t *testing.T) {
+	sess, m, store := spawnHarnessSession(t, "panic")
+
+	if !waitForSessionGone(m, sess.ID, 5*time.Second) {
+		t.Fatal("session never exited after harness panic")
+	}
+
+	got := lastStateFor(store, sess.ID)
+	if got != "failed" {
+		t.Errorf("state after panic = %q, want failed; all updates=%v", got, store.stateUpd)
+	}
+}
+
+// TestHarnessContextCancelLandsInFailedState verifies that cancelling the
+// session context (via Kill) results in state=failed (context.Canceled from
+// harness.Execute → mapTerminalState → StateFailed).
+func TestHarnessContextCancelLandsInFailedState(t *testing.T) {
+	sess, m, store := spawnHarnessSession(t, "hang")
+
+	// Give the goroutine time to enter the blocking ToolChat.
+	time.Sleep(50 * time.Millisecond)
+
+	if err := m.Kill(sess.ID); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+
+	if !waitForSessionGone(m, sess.ID, 5*time.Second) {
+		t.Fatal("session never exited after Kill")
+	}
+
+	got := lastStateFor(store, sess.ID)
+	if got != "failed" {
+		t.Errorf("state after Kill = %q, want failed; all updates=%v", got, store.stateUpd)
+	}
+}
+
+// TestHarnessCleanExitLandsInCompletedState verifies the happy path: a harness
+// that returns immediately with Stop:true ends with state=completed.
+func TestHarnessCleanExitLandsInCompletedState(t *testing.T) {
+	sess, m, store := spawnHarnessSession(t, "stop")
+
+	if !waitForSessionGone(m, sess.ID, 5*time.Second) {
+		t.Fatal("session never exited after clean stop")
+	}
+
+	got := lastStateFor(store, sess.ID)
+	if got != "completed" {
+		t.Errorf("state after clean stop = %q, want completed; all updates=%v", got, store.stateUpd)
+	}
+}
+
+// TestHarnessKillRemovesFromSessionsMap verifies that Kill + session exit
+// removes the entry from Manager.sessions so subsequent Snapshot calls don't
+// return a zombie running session.
+func TestHarnessKillRemovesFromSessionsMap(t *testing.T) {
+	sess, m, _ := spawnHarnessSession(t, "hang")
+
+	time.Sleep(50 * time.Millisecond)
+	if err := m.Kill(sess.ID); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+
+	if !waitForSessionGone(m, sess.ID, 5*time.Second) {
+		t.Fatal("session still in m.sessions after Kill + exit deadline")
+	}
+
+	// Snapshot must not return the killed session.
+	for _, s := range m.Snapshot() {
+		if s.ID == sess.ID {
+			t.Errorf("Snapshot returned killed session %s", sess.ID)
+		}
+	}
+}
+
+// TestWatchdogScanKillsStaleSession exercises runWatchdogScan directly with a
+// fabricated stale lastLineAt. The session is a real harness session in "hang"
+// mode; we backdate lastLineAt past WatchdogTimeout and verify that the
+// watchdog issues a Kill that results in a terminal state.
+func TestWatchdogScanKillsStaleSession(t *testing.T) {
+	sess, m, store := spawnHarnessSession(t, "hang")
+
+	// Backdate lastLineAt so the watchdog considers the session stale.
+	m.mu.RLock()
+	rs := m.sessions[sess.ID]
+	m.mu.RUnlock()
+	if rs == nil {
+		t.Fatal("session not in map before watchdog scan")
+	}
+	rs.actMu.Lock()
+	rs.lastLineAt = time.Now().Add(-(WatchdogTimeout + time.Second))
+	rs.actMu.Unlock()
+
+	m.runWatchdogScan()
+
+	if !waitForSessionGone(m, sess.ID, 5*time.Second) {
+		t.Fatal("session never exited after watchdog kill")
+	}
+
+	got := lastStateFor(store, sess.ID)
+	if got != "failed" {
+		t.Errorf("state after watchdog kill = %q, want failed; updates=%v", got, store.stateUpd)
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -173,6 +173,17 @@ type runtimeSession struct {
 	// where CostData from the stream parser is authoritative.
 	harnessInputTokens  int64
 	harnessOutputTokens int64
+
+	// slotReleased is set to true the first time EvtWorkerSlotFreed is
+	// published for this session. Guards against double-release when both the
+	// normal tailAndParse cleanup path and the safety-net defer race to free
+	// the pool slot. Protected by actMu.
+	slotReleased bool
+
+	// lastLineAt is the time of the most recent transcript line consumed by
+	// tailAndParse. Initialised to the session start time so new sessions
+	// aren't immediately considered stale by the watchdog. Protected by actMu.
+	lastLineAt time.Time
 }
 
 // sessionCmd is the §10.5 abstraction over both spawn strategies. The
@@ -633,6 +644,7 @@ func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types
 		poolID:         pool.ID,
 		poolName:       pool.Name,
 		poolModel:      pool.Model,
+		lastLineAt:     time.Now(),
 	}
 
 	if len(argv) > 0 {
@@ -673,32 +685,8 @@ func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types
 			cancel()
 			return nil, fmt.Errorf("session manager: unknown provider %q for pool %s", pool.Provider, pool.ID)
 		}
-		done := make(chan struct{})
+		done := m.spawnHarness(ctx, rs, prov, ws, pool, prompt, skillMarkdown)
 		rs.cmd = &synthCmd{done: done, err: &rs.harnessErr, cancel: cancel}
-		go func() {
-			defer close(done)
-			rs.harnessErr = harness.Execute(ctx, harness.Run{
-				SessionID:     sessID,
-				RepoPath:      ws.RepoPath,
-				WorktreeDir:   worktreeDir,
-				Mode:          mode,
-				SkillMode:     ws.SkillProfile.Mode,
-				SkillMarkdown: skillMarkdown,
-				Pool:          pool,
-				Provider:      prov,
-				UserPrompt:    prompt,
-				Skills:        bundle.FS,
-				EnvVars:       envSpecToSlice(ws.AgentEnv),
-				Budget:        poolBudget(pool),
-				Out:           tf,
-				OnTurnUsage: func(in, out int) {
-					rs.actMu.Lock()
-					rs.harnessInputTokens = int64(in)
-					rs.harnessOutputTokens = int64(out)
-					rs.actMu.Unlock()
-				},
-			})
-		}()
 	}
 
 	if m.store != nil {
@@ -716,12 +704,58 @@ func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types
 	return sess, nil
 }
 
+// releaseSlot publishes EvtWorkerSlotFreed for rs exactly once (idempotent via
+// slotReleased). Safe to call from both the normal tailAndParse cleanup path
+// and the safety-net defer — whichever fires first wins and the other is a
+// no-op.
+func (m *Manager) releaseSlot(rs *runtimeSession) {
+	rs.actMu.Lock()
+	released := rs.slotReleased
+	rs.slotReleased = true
+	rs.actMu.Unlock()
+	if released {
+		return
+	}
+	if m.bus != nil {
+		m.bus.Publish(eventbus.EvtWorkerSlotFreed, eventbus.WorkerSlotFreed{
+			SessionID: rs.sess.ID,
+			PoolID:    rs.poolID,
+		})
+	}
+}
+
 // tailAndParse polls the transcript file for new lines, feeds each through
 // the per-session parser, and routes the resulting display lines to emit /
 // matchPatterns / recordActivity. Issue #54 replaces the old PTY byte-stream
 // reader with a file tail because the worker's stdout IS the transcript file
 // now (so the conductor exiting doesn't break the worker's writes).
 func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
+	// Safety-net (issue #152): registered first so it fires last in LIFO order,
+	// after the transcript-close defer below. Guarantees that regardless of how
+	// this goroutine exits — including a panic in the function body — the pool
+	// slot is released and the session is removed from m.sessions. On the normal
+	// (no-panic) path every call here is a no-op: the function body already ran
+	// the same cleanup, and releaseSlot is idempotent via slotReleased.
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("tailAndParse panic: session %s: %v", rs.sess.ID, r)
+			end := time.Now()
+			if rs.sess.EndedAt == nil {
+				rs.sess.EndedAt = &end
+			}
+			if rs.sess.State == types.StateRunning || rs.sess.State == types.StateWaitingForInput {
+				rs.sess.State = types.StateFailed
+			}
+			if m.store != nil {
+				_ = m.store.UpdateSessionState(rs.sess.ID, rs.sess.State)
+			}
+		}
+		m.releaseSlot(rs)
+		m.mu.Lock()
+		delete(m.sessions, rs.sess.ID)
+		m.mu.Unlock()
+	}()
+
 	defer func() {
 		// Conductor's handle on the transcript file. Closing it here doesn't
 		// affect the worker — the worker has its own fd via fork+exec dup.
@@ -752,6 +786,9 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 			}
 			line, rerr := reader.ReadString('\n')
 			if len(line) > 0 {
+				rs.actMu.Lock()
+				rs.lastLineAt = time.Now()
+				rs.actMu.Unlock()
 				m.feedLine(rs, strings.TrimRight(line, "\r\n"))
 				rs.transcriptOffset += int64(len(line))
 				if m.store != nil && time.Since(lastFlush) >= 2*time.Second {
@@ -769,6 +806,9 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 					for {
 						line, rerr := reader.ReadString('\n')
 						if len(line) > 0 {
+							rs.actMu.Lock()
+							rs.lastLineAt = time.Now()
+							rs.actMu.Unlock()
 							m.feedLine(rs, strings.TrimRight(line, "\r\n"))
 							rs.transcriptOffset += int64(len(line))
 						}
@@ -840,12 +880,7 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 	if m.onStateChange != nil && prev != rs.sess.State {
 		m.onStateChange(*rs.sess, prev)
 	}
-	if m.bus != nil {
-		m.bus.Publish(eventbus.EvtWorkerSlotFreed, eventbus.WorkerSlotFreed{
-			SessionID: rs.sess.ID,
-			PoolID:    rs.poolID,
-		})
-	}
+	m.releaseSlot(rs)
 
 	// Issue #22: per-execute worktree teardown.
 	//   q2=A: Blocked/Failed → immediate `git worktree remove --force`. The

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -502,3 +502,63 @@ func TestFindActiveExecuteSession_PausedForQuestion(t *testing.T) {
 		t.Errorf("id = %q, want %q", id, "sess-paused")
 	}
 }
+
+// TestKillSubprocessLandsInFailedState verifies that calling Kill on a running
+// subprocess session cancels the process, causes tailAndParse to write a
+// terminal state (failed), and removes the session from Manager.sessions.
+func TestKillSubprocessLandsInFailedState(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX-only")
+	}
+	tdir := t.TempDir()
+	store := &fakePersister{}
+	m := NewManager(nil, nil)
+	m.Configure(filepath.Join(tdir, "transcripts"), store, nil)
+
+	ws := types.Workspace{ID: "ws-kill", RepoPath: tdir}
+	issue := types.Issue{Number: 42, WorkspaceID: ws.ID}
+
+	// A long-running subprocess that will not exit on its own.
+	sess, err := m.spawnWithDir(ws, issue, types.ModePlan,
+		[]string{"/bin/sh", "-c", "sleep 60"},
+		"", "", "", types.Pool{}, "")
+	if err != nil {
+		t.Fatalf("spawnWithDir: %v", err)
+	}
+
+	// Brief delay to ensure the shell is running before we Kill it.
+	time.Sleep(50 * time.Millisecond)
+
+	if err := m.Kill(sess.ID); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		m.mu.RLock()
+		_, there := m.sessions[sess.ID]
+		m.mu.RUnlock()
+		if !there {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	m.mu.RLock()
+	_, stillThere := m.sessions[sess.ID]
+	m.mu.RUnlock()
+	if stillThere {
+		t.Fatal("session still in m.sessions after Kill + deadline")
+	}
+
+	// State must be failed (non-zero exit code from killed subprocess).
+	var lastState string
+	for _, upd := range store.stateUpd {
+		if strings.HasPrefix(upd, sess.ID+":") {
+			lastState = strings.TrimPrefix(upd, sess.ID+":")
+		}
+	}
+	if lastState != "failed" {
+		t.Errorf("state after Kill = %q, want failed; all updates=%v", lastState, store.stateUpd)
+	}
+}

--- a/internal/session/watchdog.go
+++ b/internal/session/watchdog.go
@@ -1,0 +1,77 @@
+package session
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"prismconductor/internal/types"
+)
+
+// WatchdogTimeout is the maximum time a running session may go without writing
+// any output to its transcript before the watchdog force-kills it. Fifteen
+// minutes is long enough to tolerate slow providers while catching deadlocked
+// tool dispatches and sessions whose HTTP timeout did not fire.
+const WatchdogTimeout = 15 * time.Minute
+
+// watchdogInterval is how often the watchdog scans active sessions.
+const watchdogInterval = time.Minute
+
+// StartWatchdog launches a background goroutine that scans running sessions
+// once per minute and kills any that have not written a transcript line for
+// WatchdogTimeout. The goroutine exits when ctx is cancelled.
+//
+// Call this from app startup (e.g. after Manager.Configure) to enable the
+// belt-and-suspenders liveness guarantee.
+func (m *Manager) StartWatchdog(ctx context.Context) {
+	go func() {
+		t := time.NewTicker(watchdogInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				m.runWatchdogScan()
+			}
+		}
+	}()
+}
+
+// runWatchdogScan checks all running sessions and kills any that have been
+// silent for longer than WatchdogTimeout. Separated from StartWatchdog so it
+// can be called directly in tests.
+func (m *Manager) runWatchdogScan() {
+	now := time.Now()
+	m.mu.RLock()
+	type staleEntry struct {
+		id   string
+		last time.Time
+	}
+	var stale []staleEntry
+	for id, rs := range m.sessions {
+		if rs == nil || rs.sess == nil {
+			continue
+		}
+		if rs.sess.State != types.StateRunning {
+			continue
+		}
+		rs.actMu.Lock()
+		last := rs.lastLineAt
+		rs.actMu.Unlock()
+		if last.IsZero() {
+			continue
+		}
+		if now.Sub(last) > WatchdogTimeout {
+			stale = append(stale, staleEntry{id: id, last: last})
+		}
+	}
+	m.mu.RUnlock()
+
+	for _, e := range stale {
+		log.Printf("watchdog: killing stale session %s (last output %v ago)", e.id, now.Sub(e.last).Round(time.Second))
+		if err := m.Kill(e.id); err != nil {
+			log.Printf("watchdog: Kill %s: %v", e.id, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds panic-recovery defer in `spawnHarness` so a crashing provider never leaves a session as zombie-running in the DB
- Adds safety-net defer at the top of `tailAndParse` (covers both harness and subprocess paths) that guarantees terminal state write + pool slot release on any goroutine exit, including panics
- Adds `Manager.StartWatchdog` / `runWatchdogScan`: kills sessions with no transcript output for 15 minutes (belt-and-suspenders for deadlocked tool dispatches or provider hangs)
- Centralises LLM HTTP client construction in `llm.NewHTTPClient` / `llm.DefaultHTTPTimeout` (5 min)

## Files modified

- `internal/llm/client.go` — new: `NewHTTPClient`, `DefaultHTTPTimeout`
- `internal/llm/{openai,litellm,lmstudio,ollama}.go` — use `NewHTTPClient(DefaultHTTPTimeout)`
- `internal/session/harness.go` — new: `spawnHarness` with panic-recovery defer
- `internal/session/manager.go` — add `slotReleased`/`lastLineAt` to `runtimeSession`; add `releaseSlot`; add safety-net defer in `tailAndParse`; update `lastLineAt` in tail loop; call `spawnHarness`
- `internal/session/watchdog.go` — new: `WatchdogTimeout`, `StartWatchdog`, `runWatchdogScan`
- `internal/session/harness_test.go` — new: panic→failed, context-cancel→failed, clean-exit→completed, Kill removes from map, watchdog kills stale session
- `internal/session/manager_test.go` — add `TestKillSubprocessLandsInFailedState`

## Verification

- **Lint:** `go vet prismconductor/internal/...` → pass
- **Build:** `wails build` → pass (11.1s)
- **Smoke test:** `npx playwright test e2e/startup.spec.ts` → 1 passed (2.2m)
- **Tests:** `go test prismconductor/internal/llm/... prismconductor/internal/session/... prismconductor/internal/harness/...` → all ok

## Wiring note

`Manager.StartWatchdog(ctx)` must be called from `app.go` after `Manager.Configure` to activate the watchdog. This PR adds the capability; the call-site wiring is a one-liner follow-up.

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-152

Closes #152