### PR TITLE
fix(pool): self-heal active counter from DB truth on every terminal event

### DIFF
--- a/app.go
+++ b/app.go
@@ -270,6 +270,21 @@ func (a *App) startup(ctx context.Context) {
 		// whenever any contributing source changes.
 		a.assembler = issueview.New(a.bus, a.store)
 
+		// Pool counter self-heal: on every terminal session-state event,
+		// re-derive every pool's `active` counter from the DB count of
+		// running sessions. This makes the registry counter a cache of
+		// authoritative DB state instead of a hand-maintained ledger that
+		// leaks slots on every acquire-without-release path. The hot
+		// AcquireForPlan / AcquireForWork path still uses the in-memory
+		// counter (synchronous, no DB round-trip), but we promise to keep
+		// it correct on the next event tick.
+		a.bus.Subscribe(func(e eventbus.Event) {
+			switch e.Type {
+			case eventbus.EvtSessionStateChanged, eventbus.EvtWorkerSlotFreed:
+				a.reconcilePoolActiveCounters(string(e.Type))
+			}
+		})
+
 		// Issue #116: auto-spawn self-heal and toast on CI check failures.
 		a.bus.Subscribe(a.handlePRChecksFailed)
 		a.bus.Subscribe(a.handlePRChecksRecovered)
@@ -324,6 +339,15 @@ func (a *App) startup(ctx context.Context) {
 		} else if n > 0 {
 			log.Printf("reconciled %d closed issues to DONE\n", n)
 		}
+
+		// Reconcile pool registry's in-memory `active` counter against DB
+		// truth. The hand-maintained TryAcquire/Release counter leaks on
+		// any acquire-without-matching-release (witnessed: planner 1/2
+		// with zero plan sessions running). DB count is authoritative;
+		// registry becomes a cache derived from it. Subsequent terminal
+		// session-state events keep it fresh via the bus subscriber wired
+		// in startup.go.
+		a.reconcilePoolActiveCounters("startup")
 
 		// Issue #107: auto-archive DONE cards per workspace config. Run once at
 		// startup and then on a 24-hour tick so long-running sessions stay clean.
@@ -2789,6 +2813,28 @@ func (a *App) acquirePool(reserve func() (string, bool)) (types.Pool, bool) {
 		return types.Pool{}, false
 	}
 	return pool, true
+}
+
+// reconcilePoolActiveCounters re-derives every pool's in-memory `active`
+// counter from the authoritative DB count of running sessions. Called at
+// startup AND on every terminal session-state-changed / worker-slot-freed
+// event so any acquire-without-matching-release leak self-corrects within
+// one event tick.
+//
+// Without this, the in-memory counter is a hand-maintained ledger that
+// drifts whenever ANY spawn-error path forgets to release. Witnessed live
+// as Planners 1/2 with zero plan sessions actually running. The "Reset
+// counters" UI button was the only fix; now drift heals automatically.
+func (a *App) reconcilePoolActiveCounters(reason string) {
+	if a.poolReg == nil || a.store == nil {
+		return
+	}
+	counts, err := a.store.CountRunningSessionsByPool()
+	if err != nil {
+		log.Printf("reconcile pool counters (reason=%s): %v", reason, err)
+		return
+	}
+	a.poolReg.ReconcileActive(counts)
 }
 
 // SpawnPlanForIssue spawns a plan-mode worker for the given issue in the given workspace.

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -369,6 +369,48 @@ func (s *Store) PoolSpendCents(poolID string, since time.Time) (float64, error) 
 	return total, err
 }
 
+// CountRunningSessionsByPool returns a map[poolID]count of every session
+// currently in `running` or `waiting_for_input` state, keyed by the
+// session's pool_id.
+//
+// Used by the Registry to reconcile its in-memory `active` counter against
+// DB ground truth. Without this reconciliation, any acquire-without-matching-
+// release leaks the slot in the registry forever (witnessed: planner
+// counter stuck at 1/2 with zero plan sessions actually running). The DB is
+// the source of truth; the registry counter is now a cache derived from
+// this query at startup and on every terminal session transition.
+//
+// Reads json_extract on $.pool_id rather than a dedicated column because
+// PoolID is stored only inside the session JSON blob, not in an indexed
+// column. SQLite's json1 extension handles this efficiently for the small
+// active-session row count we ever have (sub-100 rows).
+func (s *Store) CountRunningSessionsByPool() (map[string]int, error) {
+	if s == nil || s.DB == nil {
+		return nil, nil
+	}
+	rows, err := s.DB.Query(
+		`SELECT json_extract(json, '$.pool_id') AS pool_id, COUNT(*)
+		   FROM sessions
+		  WHERE state IN ('running','waiting_for_input')
+		    AND json_extract(json, '$.pool_id') IS NOT NULL
+		    AND json_extract(json, '$.pool_id') <> ''
+		  GROUP BY json_extract(json, '$.pool_id')`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]int{}
+	for rows.Next() {
+		var poolID string
+		var count int
+		if err := rows.Scan(&poolID, &count); err != nil {
+			return nil, err
+		}
+		out[poolID] = count
+	}
+	return out, rows.Err()
+}
+
 // GoalSpendCents returns the (totalCents, runCount) for all terminal sessions
 // belonging to issues assigned to the given goal since the supplied time
 // (issue #101).

--- a/internal/workerpool/pool.go
+++ b/internal/workerpool/pool.go
@@ -124,6 +124,46 @@ func NewRegistry(canSpawn func(types.Provider) bool) *Registry {
 	}
 }
 
+// SetActive overwrites the in-memory active counter to n (clamped >= 0).
+// Called by ReconcileActive to align the registry's view with DB truth.
+func (p *Pool) SetActive(n int) {
+	if n < 0 {
+		n = 0
+	}
+	p.mu.Lock()
+	p.active = n
+	p.mu.Unlock()
+}
+
+// ReconcileActive aligns every pool's in-memory `active` counter with the
+// authoritative DB count of currently-running sessions.
+//
+// Why this exists: the Registry's `active` counter is hand-maintained via
+// paired TryAcquire/Release calls. Any code path that acquires a slot but
+// errors before the matching Release runs leaks the slot in the counter
+// forever — the user sees ghost slots (e.g. Planners 1/2 with zero plan
+// sessions actually running). Manual "Reset counters" was the only fix.
+//
+// Now: callers (app.go startup, the bus subscriber on session-state and
+// worker-slot-freed events) feed the registry the DB-derived counts via
+// Store.CountRunningSessionsByPool, and the registry trusts that as truth.
+// Drift becomes self-correcting: the counter is at most one terminal-event
+// tick stale before reconcile pulls it back in line.
+//
+// Pools whose ID is not in the counts map are reset to 0 (no live
+// sessions on them). Pools that no longer exist in the registry are
+// silently ignored.
+func (r *Registry) ReconcileActive(counts map[string]int) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for id, p := range r.pools {
+		if p == nil {
+			continue
+		}
+		p.SetActive(counts[id])
+	}
+}
+
 // Sync reconciles the registry with a fresh DB read. New pools get a
 // fresh *Pool. Surviving entries keep their active counts but pick up updated
 // metadata (name, model, capacity, enabled, role). Pools that disappeared are

--- a/internal/workerpool/pool_test.go
+++ b/internal/workerpool/pool_test.go
@@ -222,3 +222,74 @@ func TestPriorityFallbackWhenPreferredFull(t *testing.T) {
 		t.Fatalf("second acquire = (%q, %v), want (fallback, true)", second, ok)
 	}
 }
+
+// TestReconcileActiveSelfHealsLeakedSlot verifies the self-heal contract:
+// a pool whose in-memory `active` counter has drifted ahead of DB truth
+// (e.g. a previous spawn acquired but errored before releasing) gets
+// pulled back into line by ReconcileActive(counts). This is the
+// permanent fix for the "Planners 1/2 with zero sessions running" ghost
+// — the registry trusts the DB count, not its own ledger.
+func TestReconcileActiveSelfHealsLeakedSlot(t *testing.T) {
+	r := NewRegistry(func(types.Provider) bool { return true })
+	r.Sync([]types.Pool{
+		{ID: "p1", Provider: types.ProviderClaude, Capacity: 2, Enabled: true, Role: types.RolePlan},
+	})
+	// Simulate a leak: acquire twice without releasing. Registry now thinks
+	// active=2 (full) but DB has zero running sessions on this pool.
+	if _, ok := r.AcquireForPlan(types.Workspace{}); !ok {
+		t.Fatal("first acquire should succeed")
+	}
+	if _, ok := r.AcquireForPlan(types.Workspace{}); !ok {
+		t.Fatal("second acquire should succeed")
+	}
+	if _, ok := r.AcquireForPlan(types.Workspace{}); ok {
+		t.Fatal("third acquire should fail (pool full per leaked counter)")
+	}
+
+	// DB truth says zero sessions are running on p1. Reconcile.
+	r.ReconcileActive(map[string]int{})
+
+	// Now a fresh acquire should succeed because the leak self-healed.
+	if _, ok := r.AcquireForPlan(types.Workspace{}); !ok {
+		t.Fatal("post-reconcile acquire should succeed (leak should have self-healed)")
+	}
+	r.mu.RLock()
+	got := r.pools["p1"].Active()
+	r.mu.RUnlock()
+	if got != 1 {
+		t.Errorf("post-reconcile-then-acquire active = %d, want 1", got)
+	}
+}
+
+// TestReconcileActiveAlignsWithDBCount confirms ReconcileActive sets the
+// counter to whatever the DB-derived map says, even if it's nonzero.
+func TestReconcileActiveAlignsWithDBCount(t *testing.T) {
+	r := NewRegistry(func(types.Provider) bool { return true })
+	r.Sync([]types.Pool{
+		{ID: "p1", Provider: types.ProviderClaude, Capacity: 5, Enabled: true, Role: types.RolePlan},
+		{ID: "p2", Provider: types.ProviderClaude, Capacity: 5, Enabled: true, Role: types.RoleWork},
+	})
+	r.ReconcileActive(map[string]int{"p1": 3, "p2": 1})
+
+	r.mu.RLock()
+	a1 := r.pools["p1"].Active()
+	a2 := r.pools["p2"].Active()
+	r.mu.RUnlock()
+
+	if a1 != 3 {
+		t.Errorf("p1 active = %d, want 3", a1)
+	}
+	if a2 != 1 {
+		t.Errorf("p2 active = %d, want 1", a2)
+	}
+
+	// A pool not present in the counts map is reset to 0.
+	r.ReconcileActive(map[string]int{"p1": 0})
+	r.mu.RLock()
+	a1 = r.pools["p1"].Active()
+	a2 = r.pools["p2"].Active()
+	r.mu.RUnlock()
+	if a1 != 0 || a2 != 0 {
+		t.Errorf("after empty-ish reconcile: p1=%d p2=%d, want 0/0", a1, a2)
+	}
+}


### PR DESCRIPTION
## Summary

Permanent fix for the pool-slot drift bug ("Planners 1/2 with zero plan sessions running"). Replaces the manual "Reset counters" button as the recovery path — drift now self-heals on every terminal session event.

## Root cause

`Pool.active` is hand-maintained via paired `TryAcquire` (++) and `Release` (--). Every code path that acquires a slot and errors before its matching release leaks a slot in the counter forever. There are MANY such paths and proving "every error path releases" is a losing audit.

## Fix (3 pieces)

**1. `Store.CountRunningSessionsByPool`** — single SQL query returning `map[poolID]int` of sessions in `state IN (running, waiting_for_input)`. DB is now the source of truth.

**2. `Registry.ReconcileActive(counts)`** — overwrites every pool's in-memory counter with the DB-derived value. Missing pool ID → counter set to 0.

**3. Wired into app.go two ways:**
- **Startup**, after Sync — catches drift that survived a restart.
- **Every `EvtSessionStateChanged` / `EvtWorkerSlotFreed`** — catches drift within one event tick.

The hot acquire path still reads the in-memory counter (no DB round-trip per acquire); the counter is allowed to be stale for the brief window between an acquire and the next terminal event, but it self-heals. Drift becomes mathematically impossible to accumulate beyond one event tick.

## Tests

- `TestReconcileActiveSelfHealsLeakedSlot` — simulates a leaked acquire-without-release; ReconcileActive(empty) brings the registry back to truth; subsequent acquire succeeds.
- `TestReconcileActiveAlignsWithDBCount` — counts map applied verbatim; pools missing from map zero out.

`go test ./...` clean.

## Test plan
- [ ] Restart conductor with stuck Planners 1/2 — startup reconcile sets counter to 0/2 (DB truth).
- [ ] Spawn a plan worker, kill it externally before it terminates cleanly — registry counter stays correct (next session-state event reconciles).
- [ ] Settings → Pools → Reset counters button still works as a manual escape hatch (no behavior change there).

## Live mitigation

For the currently-stuck running app, click Settings → Pools → Reset counters once to fix the in-memory drift. After this PR lands and you restart, drift won't recur.