### PR TITLE
feat(pipeline): configurable per-workspace pipeline (#146)

### DIFF
--- a/app.go
+++ b/app.go
@@ -34,6 +34,7 @@ import (
 	"prismconductor/internal/llm"
 	"prismconductor/internal/orchestrator"
 	"prismconductor/internal/session"
+	"prismconductor/internal/pipeline"
 	"prismconductor/internal/skills"
 	"prismconductor/internal/skills/bundle"
 	"prismconductor/internal/store"
@@ -1785,6 +1786,50 @@ func (a *App) OpenBundledSkill(name string) error {
 	}
 	wruntime.BrowserOpenURL(a.ctx, "file://"+path)
 	return nil
+}
+
+// --- Pipeline (§issue #146) ---
+
+// ListAvailableSkills returns all skills available for use as pipeline steps:
+// bundled skills plus any discovered in the workspace's repo directories.
+func (a *App) ListAvailableSkills(workspaceID string) ([]types.SkillRef, error) {
+	if a.wsReg == nil {
+		return nil, fmt.Errorf("workspace registry not ready")
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return nil, fmt.Errorf("workspace %q not found", workspaceID)
+	}
+	return skills.ScanForPipeline(ws.RepoPath, bundle.FS)
+}
+
+// ValidatePipeline checks the pipeline for structural errors: duplicate IDs,
+// unknown step references, and uncapped cycles (q3: no).
+func (a *App) ValidatePipeline(p types.WorkspacePipeline) error {
+	return pipeline.Validate(&p)
+}
+
+// SaveWorkspacePipeline persists the pipeline configuration for a workspace.
+// The pipeline version is incremented on each save so in-flight cards that
+// were stamped with an older version continue on their saved pipeline.
+func (a *App) SaveWorkspacePipeline(workspaceID string, p types.WorkspacePipeline) error {
+	if a.wsReg == nil {
+		return fmt.Errorf("workspace registry not ready")
+	}
+	if err := pipeline.Validate(&p); err != nil {
+		return fmt.Errorf("invalid pipeline: %w", err)
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return fmt.Errorf("workspace %q not found", workspaceID)
+	}
+	if ws.Pipeline != nil {
+		p.Version = ws.Pipeline.Version + 1
+	} else {
+		p.Version = 1
+	}
+	ws.Pipeline = &p
+	return a.wsReg.Update(ws)
 }
 
 // --- Plans + Q&A loop (§9, §10) ---

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -476,6 +476,7 @@ function StatusRow({
       activeSession.state === "running" &&
       prNumber != null &&
       column === "in_progress";
+    const pipelineStepName = activeSession.pipeline_step_name;
     const label = isBlocked
       ? "blocked"
       : activeSession.state === "waiting_for_input"
@@ -484,6 +485,8 @@ function StatusRow({
         : "needs input"
       : planMode
       ? "planning"
+      : pipelineStepName
+      ? pipelineStepName
       : isContinue
       ? `continuing PR #${prNumber}`
       : "working";

--- a/frontend/src/components/PipelineEditor.tsx
+++ b/frontend/src/components/PipelineEditor.tsx
@@ -1,0 +1,326 @@
+import { useEffect, useState } from "react";
+import { ListAvailableSkills, SaveWorkspacePipeline, ValidatePipeline } from "../../wailsjs/go/main/App";
+import { types } from "../../wailsjs/go/models";
+import { useWorkspaceStore } from "../stores/workspaceStore";
+import { noAutoCorrect } from "../lib/inputs";
+
+const DEFAULT_MAX_LOOPS = 3;
+
+function makeStep(skills: types.SkillRef[]): types.PipelineStep {
+  const first = skills[0];
+  return new types.PipelineStep({
+    id: crypto.randomUUID(),
+    name: first?.display_name ?? "New Step",
+    skill_ref: first ?? new types.SkillRef({ path: "", source: "bundled", name: "", display_name: "" }),
+    auto_chain: false,
+    max_loops: 0,
+    on_success: "",
+    on_fail: "",
+  });
+}
+
+export function PipelineEditor({ workspace }: { workspace: types.Workspace }) {
+  const refresh = useWorkspaceStore((s) => s.refresh);
+  const [skills, setSkills] = useState<types.SkillRef[]>([]);
+  const [steps, setSteps] = useState<types.PipelineStep[]>(
+    workspace.pipeline?.steps ?? []
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    ListAvailableSkills(workspace.id)
+      .then((refs) => setSkills(refs ?? []))
+      .catch((err) => console.error("PipelineEditor ListAvailableSkills", err));
+  }, [workspace.id]);
+
+  // Sync steps when workspace.pipeline changes externally (e.g. after refresh).
+  useEffect(() => {
+    if (!dirty) {
+      setSteps(workspace.pipeline?.steps ?? []);
+    }
+  }, [workspace.pipeline, dirty]);
+
+  function updateStep(idx: number, patch: Partial<types.PipelineStep>) {
+    setSteps((prev) => {
+      const next = [...prev];
+      next[idx] = new types.PipelineStep({ ...next[idx], ...patch });
+      return next;
+    });
+    setDirty(true);
+    setError(null);
+  }
+
+  function addStep() {
+    setSteps((prev) => [...prev, makeStep(skills)]);
+    setDirty(true);
+    setError(null);
+  }
+
+  function removeStep(idx: number) {
+    const removedID = steps[idx].id;
+    setSteps((prev) => {
+      const next = prev.filter((_, i) => i !== idx).map((s) => {
+        // Clear dangling references to the removed step.
+        return new types.PipelineStep({
+          ...s,
+          on_success: s.on_success === removedID ? "" : s.on_success,
+          on_fail: s.on_fail === removedID ? "" : s.on_fail,
+        });
+      });
+      return next;
+    });
+    setDirty(true);
+    setError(null);
+  }
+
+  function moveStep(idx: number, dir: -1 | 1) {
+    const next = [...steps];
+    const target = idx + dir;
+    if (target < 0 || target >= next.length) return;
+    [next[idx], next[target]] = [next[target], next[idx]];
+    setSteps(next);
+    setDirty(true);
+  }
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      const pipeline = new types.WorkspacePipeline({ steps, version: 0 });
+      await ValidatePipeline(pipeline);
+      await SaveWorkspacePipeline(workspace.id, pipeline);
+      await refresh();
+      setDirty(false);
+    } catch (err: any) {
+      setError(String(err?.message ?? err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function clearPipeline() {
+    setSaving(true);
+    setError(null);
+    try {
+      await SaveWorkspacePipeline(workspace.id, new types.WorkspacePipeline({ steps: [], version: 0 }));
+      setSteps([]);
+      setDirty(false);
+      await refresh();
+    } catch (err: any) {
+      setError(String(err?.message ?? err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3 text-sm bg-slate-950/40 rounded p-3 border border-slate-800">
+      <div className="flex items-center justify-between">
+        <div className="text-xs text-slate-400">Custom pipeline steps</div>
+        <div className="text-[10px] text-slate-600">
+          runs after Execute, before Close
+        </div>
+      </div>
+
+      {steps.length === 0 ? (
+        <div className="text-xs text-slate-600 italic">
+          No custom steps — default Execute → Close flow.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {steps.map((step, idx) => (
+            <StepRow
+              key={step.id}
+              step={step}
+              idx={idx}
+              total={steps.length}
+              skills={skills}
+              allSteps={steps}
+              onUpdate={(patch) => updateStep(idx, patch)}
+              onRemove={() => removeStep(idx)}
+              onMove={(dir) => moveStep(idx, dir)}
+            />
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <div className="text-xs text-red-400 break-words border border-red-900 rounded px-2 py-1">
+          ⚠ {error}
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 pt-1">
+        <button
+          onClick={addStep}
+          className="px-2 py-1 text-xs rounded border border-slate-700 text-slate-400 hover:text-slate-200 hover:border-slate-500"
+        >
+          + Add step
+        </button>
+        {dirty && (
+          <button
+            onClick={save}
+            disabled={saving}
+            className="px-2 py-1 text-xs rounded border border-sky-700 text-sky-300 hover:border-sky-500 disabled:opacity-50"
+          >
+            {saving ? "Saving…" : "Save pipeline"}
+          </button>
+        )}
+        {steps.length > 0 && !dirty && (
+          <button
+            onClick={clearPipeline}
+            disabled={saving}
+            className="ml-auto px-2 py-1 text-xs rounded border border-slate-800 text-slate-600 hover:text-red-400 hover:border-red-900"
+          >
+            Reset to default
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StepRow({
+  step,
+  idx,
+  total,
+  skills,
+  allSteps,
+  onUpdate,
+  onRemove,
+  onMove,
+}: {
+  step: types.PipelineStep;
+  idx: number;
+  total: number;
+  skills: types.SkillRef[];
+  allSteps: types.PipelineStep[];
+  onUpdate: (patch: Partial<types.PipelineStep>) => void;
+  onRemove: () => void;
+  onMove: (dir: -1 | 1) => void;
+}) {
+  const otherSteps = allSteps.filter((s) => s.id !== step.id);
+
+  return (
+    <div className="border border-slate-700 rounded p-2 space-y-2 bg-slate-900/50">
+      <div className="flex items-center gap-2">
+        <div className="flex flex-col gap-0.5">
+          <button
+            onClick={() => onMove(-1)}
+            disabled={idx === 0}
+            className="text-slate-600 hover:text-slate-300 disabled:opacity-30 text-[10px] leading-none"
+            title="Move up"
+          >▲</button>
+          <button
+            onClick={() => onMove(1)}
+            disabled={idx === total - 1}
+            className="text-slate-600 hover:text-slate-300 disabled:opacity-30 text-[10px] leading-none"
+            title="Move down"
+          >▼</button>
+        </div>
+
+        <span className="text-[10px] text-slate-600 w-4 shrink-0">{idx + 1}.</span>
+
+        <input
+          {...noAutoCorrect}
+          type="text"
+          value={step.name}
+          onChange={(e) => onUpdate({ name: e.target.value })}
+          placeholder="Step name"
+          className="flex-1 min-w-0 bg-slate-950 border border-slate-700 rounded px-2 py-0.5 text-xs text-slate-200"
+        />
+
+        <button
+          onClick={onRemove}
+          className="text-slate-600 hover:text-red-400 text-[10px] px-1 shrink-0"
+          title="Remove step"
+        >✕</button>
+      </div>
+
+      <div className="pl-7 space-y-1.5">
+        {/* Skill selector */}
+        <label className="flex items-center gap-2 text-xs">
+          <span className="w-16 text-slate-500 shrink-0">Skill</span>
+          <select
+            value={step.skill_ref?.path ?? ""}
+            onChange={(e) => {
+              const ref = skills.find((s) => s.path === e.target.value);
+              if (ref) onUpdate({ skill_ref: ref, name: step.name || ref.display_name });
+            }}
+            className="flex-1 bg-slate-950 border border-slate-700 rounded px-2 py-0.5 text-slate-200 text-xs"
+          >
+            {skills.map((s) => (
+              <option key={s.path} value={s.path}>
+                {s.display_name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {/* on_success */}
+        <label className="flex items-center gap-2 text-xs">
+          <span className="w-16 text-slate-500 shrink-0">On pass</span>
+          <select
+            value={step.on_success ?? ""}
+            onChange={(e) => onUpdate({ on_success: e.target.value })}
+            className="flex-1 bg-slate-950 border border-slate-700 rounded px-2 py-0.5 text-slate-200 text-xs"
+          >
+            <option value="">→ done (advance to Close)</option>
+            {otherSteps.map((s) => (
+              <option key={s.id} value={s.id}>
+                → {s.name || s.id.slice(0, 8)}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {/* on_fail */}
+        <label className="flex items-center gap-2 text-xs">
+          <span className="w-16 text-slate-500 shrink-0">On fail</span>
+          <select
+            value={step.on_fail ?? ""}
+            onChange={(e) => onUpdate({ on_fail: e.target.value })}
+            className="flex-1 bg-slate-950 border border-slate-700 rounded px-2 py-0.5 text-slate-200 text-xs"
+          >
+            <option value="">→ stop (BLOCKED)</option>
+            {otherSteps.map((s) => (
+              <option key={s.id} value={s.id}>
+                → {s.name || s.id.slice(0, 8)}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="flex items-center gap-4">
+          {/* auto_chain */}
+          <label className="flex items-center gap-1.5 text-xs text-slate-400 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={step.auto_chain ?? false}
+              onChange={(e) => onUpdate({ auto_chain: e.target.checked })}
+              className="accent-sky-500"
+            />
+            Auto-advance (no confirm)
+          </label>
+
+          {/* max_loops */}
+          <label className="flex items-center gap-1.5 text-xs text-slate-400">
+            <span>Max loops</span>
+            <input
+              {...noAutoCorrect}
+              type="number"
+              min={0}
+              max={20}
+              value={step.max_loops ?? 0}
+              onChange={(e) => onUpdate({ max_loops: parseInt(e.target.value, 10) || 0 })}
+              className="w-12 bg-slate-950 border border-slate-700 rounded px-1 py-0.5 text-xs text-slate-200 text-center"
+            />
+            <span className="text-slate-600">(0 = no loop)</span>
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/WorkspacesPanel.tsx
+++ b/frontend/src/components/WorkspacesPanel.tsx
@@ -3,6 +3,7 @@ import { GCWorktrees, ListPools, RemoveWorkspace, RunAutoArchiveNow, UpdateWorks
 import { types, workerpool } from "../../wailsjs/go/models";
 import { useWorkspaceStore } from "../stores/workspaceStore";
 import { AddWorkspaceForm } from "./AddWorkspaceForm";
+import { PipelineEditor } from "./PipelineEditor";
 import { SkillProfileEditor } from "./SkillProfileEditor";
 import { LabelsPanel } from "./LabelsPanel";
 import { noAutoCorrect } from "../lib/inputs";
@@ -213,6 +214,10 @@ export function WorkspacesPanel() {
                 {isExpanded && (
                   <div className="mt-2 space-y-4">
                     <SkillProfileEditor workspace={ws} />
+                    <div>
+                      <div className="text-xs text-slate-400 mb-2">Pipeline</div>
+                      <PipelineEditor workspace={ws} />
+                    </div>
                     <AutoArchiveEditor workspace={ws} onSave={refresh} />
                     <div>
                       <div className="text-xs text-slate-400 mb-2">Labels</div>

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -41,6 +41,12 @@ export function DiscoverWorkspaceSkills(arg1:string):Promise<Array<types.SkillRe
 
 export function EstimateSpawnCost(arg1:string,arg2:number,arg3:string):Promise<main.SpawnEstimate>;
 
+export function ListAvailableSkills(arg1:string):Promise<Array<types.SkillRef>>;
+
+export function ValidatePipeline(arg1:types.WorkspacePipeline):Promise<void>;
+
+export function SaveWorkspacePipeline(arg1:string,arg2:types.WorkspacePipeline):Promise<void>;
+
 export function FetchIssueDetail(arg1:string,arg2:number):Promise<types.Issue>;
 
 export function FetchPRChecks(arg1:string,arg2:number):Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -58,6 +58,18 @@ export function DiscoverWorkspaceSkills(arg1) {
   return window['go']['main']['App']['DiscoverWorkspaceSkills'](arg1);
 }
 
+export function ListAvailableSkills(arg1) {
+  return window['go']['main']['App']['ListAvailableSkills'](arg1);
+}
+
+export function ValidatePipeline(arg1) {
+  return window['go']['main']['App']['ValidatePipeline'](arg1);
+}
+
+export function SaveWorkspacePipeline(arg1, arg2) {
+  return window['go']['main']['App']['SaveWorkspacePipeline'](arg1, arg2);
+}
+
 export function EstimateSpawnCost(arg1, arg2, arg3) {
   return window['go']['main']['App']['EstimateSpawnCost'](arg1, arg2, arg3);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1367,11 +1367,14 @@ export namespace types {
 	    work_seconds_plan?: number;
 	    work_seconds_execute?: number;
 	    cost_usd?: number;
-	
+	    pipeline_step_id?: string;
+	    pipeline_loops?: Record<string, number>;
+	    pipeline_version?: number;
+
 	    static createFrom(source: any = {}) {
 	        return new Issue(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.number = source["number"];
@@ -1399,6 +1402,9 @@ export namespace types {
 	        this.work_seconds_plan = source["work_seconds_plan"];
 	        this.work_seconds_execute = source["work_seconds_execute"];
 	        this.cost_usd = source["cost_usd"];
+	        this.pipeline_step_id = source["pipeline_step_id"];
+	        this.pipeline_loops = source["pipeline_loops"];
+	        this.pipeline_version = source["pipeline_version"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -1584,11 +1590,12 @@ export namespace types {
 	    input_tokens?: number;
 	    output_tokens?: number;
 	    estimated_cost_cents?: number;
-	
+	    pipeline_step_name?: string;
+
 	    static createFrom(source: any = {}) {
 	        return new Session(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -1607,6 +1614,7 @@ export namespace types {
 	        this.input_tokens = source["input_tokens"];
 	        this.output_tokens = source["output_tokens"];
 	        this.estimated_cost_cents = source["estimated_cost_cents"];
+	        this.pipeline_step_name = source["pipeline_step_name"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -1706,6 +1714,82 @@ export namespace types {
 		}
 	}
 	
+	export class PipelineStep {
+	    id: string;
+	    name: string;
+	    skill_ref: SkillRef;
+	    auto_chain: boolean;
+	    max_loops: number;
+	    on_success: string;
+	    on_fail: string;
+
+	    static createFrom(source: any = {}) {
+	        return new PipelineStep(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
+	        this.name = source["name"];
+	        this.skill_ref = this.convertValues(source["skill_ref"], SkillRef);
+	        this.auto_chain = source["auto_chain"];
+	        this.max_loops = source["max_loops"];
+	        this.on_success = source["on_success"];
+	        this.on_fail = source["on_fail"];
+	    }
+
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+
+	export class WorkspacePipeline {
+	    steps: PipelineStep[];
+	    version: number;
+
+	    static createFrom(source: any = {}) {
+	        return new WorkspacePipeline(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.steps = this.convertValues(source["steps"], PipelineStep);
+	        this.version = source["version"];
+	    }
+
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+
 	export class Workspace {
 	    id: string;
 	    display_name: string;
@@ -1719,11 +1803,12 @@ export namespace types {
 	    conventions: ConventionHints;
 	    enabled: boolean;
 	    auto_archive?: AutoArchive;
-	
+	    pipeline?: WorkspacePipeline;
+
 	    static createFrom(source: any = {}) {
 	        return new Workspace(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -1738,6 +1823,7 @@ export namespace types {
 	        this.conventions = this.convertValues(source["conventions"], ConventionHints);
 	        this.enabled = source["enabled"];
 	        this.auto_archive = this.convertValues(source["auto_archive"], AutoArchive);
+	        this.pipeline = this.convertValues(source["pipeline"], WorkspacePipeline);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/pipeline/driver.go
+++ b/internal/pipeline/driver.go
@@ -1,0 +1,241 @@
+// Package pipeline provides routing logic for per-workspace pipelines (issue #146).
+// The driver is a pure function — it computes the next action from the current
+// pipeline state without touching any I/O or spawning sessions.
+package pipeline
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"prismconductor/internal/types"
+)
+
+// DefaultMaxLoops is the safety cap applied when max_loops is 0 on a step that
+// serves as the loop target. Matches the q1 answer from the issue-146 plan.
+const DefaultMaxLoops = 3
+
+// Outcome is the result emitted by a pipeline step worker.
+type Outcome string
+
+const (
+	OutcomeSuccess Outcome = "success"
+	OutcomeFail    Outcome = "fail"
+)
+
+// ActionType describes what the caller should do next.
+type ActionType string
+
+const (
+	ActionSpawnStep ActionType = "spawn_step" // spawn the named step
+	ActionDone      ActionType = "done"       // pipeline complete
+	ActionBlocked   ActionType = "blocked"    // loop cap exceeded or missing step
+)
+
+// NextAction is the driver's routing decision.
+type NextAction struct {
+	Type   ActionType
+	StepID string // non-empty when Type == ActionSpawnStep
+	Reason string // non-empty when Type == ActionBlocked
+}
+
+// Next returns the routing decision after a pipeline step completes.
+// loops maps step ID → number of times that step has already run for this card.
+// A nil pipeline returns ActionDone immediately (default Plan→Execute→Close flow).
+func Next(
+	p *types.WorkspacePipeline,
+	currentStepID string,
+	outcome Outcome,
+	loops map[string]int,
+) NextAction {
+	if p == nil {
+		return NextAction{Type: ActionDone}
+	}
+	step := findStep(p, currentStepID)
+	if step == nil {
+		return NextAction{
+			Type:   ActionBlocked,
+			Reason: fmt.Sprintf("step %q not found in pipeline", currentStepID),
+		}
+	}
+
+	var targetID string
+	if outcome == OutcomeSuccess {
+		targetID = step.OnSuccess
+	} else {
+		targetID = step.OnFail
+	}
+
+	if targetID == "" {
+		if outcome == OutcomeFail {
+			return NextAction{
+				Type:   ActionBlocked,
+				Reason: fmt.Sprintf("step %q failed with no on_fail route", step.Name),
+			}
+		}
+		return NextAction{Type: ActionDone}
+	}
+
+	target := findStep(p, targetID)
+	if target == nil {
+		return NextAction{
+			Type:   ActionBlocked,
+			Reason: fmt.Sprintf("next step %q not found (deleted from pipeline?)", targetID),
+		}
+	}
+
+	if target.MaxLoops > 0 {
+		cap := target.MaxLoops
+		if loops[targetID] >= cap {
+			return NextAction{
+				Type:   ActionBlocked,
+				Reason: fmt.Sprintf("step %q reached max loop cap (%d)", target.Name, cap),
+			}
+		}
+	}
+
+	return NextAction{Type: ActionSpawnStep, StepID: targetID}
+}
+
+// StepByID returns the PipelineStep with the given ID, or nil.
+func StepByID(p *types.WorkspacePipeline, id string) *types.PipelineStep {
+	return findStep(p, id)
+}
+
+// Validate checks the pipeline for structural errors:
+//   - all step IDs are non-empty and unique
+//   - on_success / on_fail references exist
+//   - every cycle has at least one step with max_loops > 0
+func Validate(p *types.WorkspacePipeline) error {
+	if p == nil {
+		return nil
+	}
+	byID := make(map[string]*types.PipelineStep, len(p.Steps))
+	for i := range p.Steps {
+		s := &p.Steps[i]
+		if s.ID == "" {
+			return errors.New("pipeline step missing id")
+		}
+		if _, dup := byID[s.ID]; dup {
+			return fmt.Errorf("duplicate step id %q", s.ID)
+		}
+		byID[s.ID] = s
+	}
+	for _, s := range p.Steps {
+		if s.OnSuccess != "" && byID[s.OnSuccess] == nil {
+			return fmt.Errorf("step %q: on_success references unknown step %q", s.ID, s.OnSuccess)
+		}
+		if s.OnFail != "" && byID[s.OnFail] == nil {
+			return fmt.Errorf("step %q: on_fail references unknown step %q", s.ID, s.OnFail)
+		}
+	}
+	return validateCycles(byID, p.Steps)
+}
+
+// validateCycles enforces that every cycle in the pipeline has at least one
+// step with max_loops > 0, preventing infinite iteration (q3: no uncapped cycles).
+func validateCycles(byID map[string]*types.PipelineStep, steps []types.PipelineStep) error {
+	for _, step := range steps {
+		if !canReachItself(byID, step.ID) {
+			continue
+		}
+		// step.ID is in a cycle; gather all members of that cycle.
+		members := cycleMembers(byID, step.ID)
+		hasCap := false
+		for id := range members {
+			if s := byID[id]; s != nil && s.MaxLoops > 0 {
+				hasCap = true
+				break
+			}
+		}
+		if !hasCap {
+			var names []string
+			for id := range members {
+				if s := byID[id]; s != nil {
+					names = append(names, s.Name)
+				}
+			}
+			return fmt.Errorf(
+				"pipeline cycle through steps [%s] has no max_loops cap; set max_loops on at least one step to prevent infinite loops",
+				strings.Join(names, ", "),
+			)
+		}
+	}
+	return nil
+}
+
+// canReachItself reports whether start can reach itself via on_success or on_fail edges.
+func canReachItself(byID map[string]*types.PipelineStep, start string) bool {
+	s := byID[start]
+	if s == nil {
+		return false
+	}
+	visited := map[string]bool{}
+	queue := neighbors(s)
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if cur == start {
+			return true
+		}
+		if visited[cur] {
+			continue
+		}
+		visited[cur] = true
+		if node := byID[cur]; node != nil {
+			queue = append(queue, neighbors(node)...)
+		}
+	}
+	return false
+}
+
+// cycleMembers returns the set of step IDs that are part of the same cycle as start.
+func cycleMembers(byID map[string]*types.PipelineStep, start string) map[string]bool {
+	reachable := make(map[string]bool)
+	bfsVisit(byID, start, reachable)
+
+	members := make(map[string]bool)
+	for id := range reachable {
+		visited := make(map[string]bool)
+		bfsVisit(byID, id, visited)
+		if visited[start] {
+			members[id] = true
+		}
+	}
+	return members
+}
+
+func bfsVisit(byID map[string]*types.PipelineStep, start string, visited map[string]bool) {
+	queue := []string{start}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if visited[cur] {
+			continue
+		}
+		visited[cur] = true
+		if node := byID[cur]; node != nil {
+			queue = append(queue, neighbors(node)...)
+		}
+	}
+}
+
+func neighbors(s *types.PipelineStep) []string {
+	var out []string
+	if s.OnSuccess != "" {
+		out = append(out, s.OnSuccess)
+	}
+	if s.OnFail != "" {
+		out = append(out, s.OnFail)
+	}
+	return out
+}
+
+func findStep(p *types.WorkspacePipeline, id string) *types.PipelineStep {
+	for i := range p.Steps {
+		if p.Steps[i].ID == id {
+			return &p.Steps[i]
+		}
+	}
+	return nil
+}

--- a/internal/pipeline/driver_test.go
+++ b/internal/pipeline/driver_test.go
@@ -1,0 +1,192 @@
+package pipeline_test
+
+import (
+	"testing"
+
+	"prismconductor/internal/pipeline"
+	"prismconductor/internal/types"
+)
+
+// helpers
+
+func step(id, name, onSuccess, onFail string, maxLoops int) types.PipelineStep {
+	return types.PipelineStep{
+		ID:        id,
+		Name:      name,
+		OnSuccess: onSuccess,
+		OnFail:    onFail,
+		MaxLoops:  maxLoops,
+	}
+}
+
+func pip(steps ...types.PipelineStep) *types.WorkspacePipeline {
+	return &types.WorkspacePipeline{Steps: steps}
+}
+
+// --- Next() tests ---
+
+func TestNext_NilPipeline(t *testing.T) {
+	got := pipeline.Next(nil, "x", pipeline.OutcomeSuccess, nil)
+	if got.Type != pipeline.ActionDone {
+		t.Fatalf("nil pipeline: want ActionDone, got %s", got.Type)
+	}
+}
+
+func TestNext_SuccessToNextStep(t *testing.T) {
+	p := pip(
+		step("a", "A", "b", "", 0),
+		step("b", "B", "", "", 0),
+	)
+	got := pipeline.Next(p, "a", pipeline.OutcomeSuccess, nil)
+	if got.Type != pipeline.ActionSpawnStep || got.StepID != "b" {
+		t.Fatalf("want ActionSpawnStep b, got %+v", got)
+	}
+}
+
+func TestNext_SuccessEmptyMeansDone(t *testing.T) {
+	p := pip(step("a", "A", "", "", 0))
+	got := pipeline.Next(p, "a", pipeline.OutcomeSuccess, nil)
+	if got.Type != pipeline.ActionDone {
+		t.Fatalf("want ActionDone, got %s", got.Type)
+	}
+}
+
+func TestNext_FailEmptyMeansBlocked(t *testing.T) {
+	p := pip(step("a", "A", "", "", 0))
+	got := pipeline.Next(p, "a", pipeline.OutcomeFail, nil)
+	if got.Type != pipeline.ActionBlocked {
+		t.Fatalf("want ActionBlocked, got %s", got.Type)
+	}
+}
+
+func TestNext_FailRouteToOtherStep(t *testing.T) {
+	p := pip(
+		step("review", "Review", "close", "execute", 3),
+		step("execute", "Execute", "review", "", 0),
+		step("close", "Close", "", "", 0),
+	)
+	got := pipeline.Next(p, "review", pipeline.OutcomeFail, map[string]int{})
+	if got.Type != pipeline.ActionSpawnStep || got.StepID != "execute" {
+		t.Fatalf("want ActionSpawnStep execute, got %+v", got)
+	}
+}
+
+func TestNext_LoopCapEnforced(t *testing.T) {
+	p := pip(
+		step("review", "Review", "close", "execute", 3),
+		step("execute", "Execute", "review", "", 0),
+		step("close", "Close", "", "", 0),
+	)
+	// review has run 3 times; routing to it again should be blocked
+	loops := map[string]int{"review": 3}
+	got := pipeline.Next(p, "execute", pipeline.OutcomeSuccess, loops)
+	if got.Type != pipeline.ActionBlocked {
+		t.Fatalf("want ActionBlocked when loops==cap, got %+v", got)
+	}
+}
+
+func TestNext_LoopBelowCapAllowed(t *testing.T) {
+	p := pip(
+		step("review", "Review", "close", "execute", 3),
+		step("execute", "Execute", "review", "", 0),
+		step("close", "Close", "", "", 0),
+	)
+	loops := map[string]int{"review": 2}
+	got := pipeline.Next(p, "execute", pipeline.OutcomeSuccess, loops)
+	if got.Type != pipeline.ActionSpawnStep || got.StepID != "review" {
+		t.Fatalf("want ActionSpawnStep review (loops=2 < cap=3), got %+v", got)
+	}
+}
+
+func TestNext_MissingCurrentStep(t *testing.T) {
+	p := pip(step("a", "A", "", "", 0))
+	got := pipeline.Next(p, "missing", pipeline.OutcomeSuccess, nil)
+	if got.Type != pipeline.ActionBlocked {
+		t.Fatalf("want ActionBlocked for missing step, got %s", got.Type)
+	}
+}
+
+func TestNext_DeletedTargetBlocked(t *testing.T) {
+	// on_success points to "b" but "b" is not in the pipeline (deleted)
+	p := pip(step("a", "A", "b", "", 0))
+	got := pipeline.Next(p, "a", pipeline.OutcomeSuccess, nil)
+	if got.Type != pipeline.ActionBlocked {
+		t.Fatalf("want ActionBlocked for deleted target, got %s", got.Type)
+	}
+}
+
+// --- Validate() tests ---
+
+func TestValidate_NilOK(t *testing.T) {
+	if err := pipeline.Validate(nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidate_EmptyOK(t *testing.T) {
+	if err := pipeline.Validate(&types.WorkspacePipeline{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidate_MissingID(t *testing.T) {
+	p := &types.WorkspacePipeline{Steps: []types.PipelineStep{{Name: "no-id"}}}
+	if err := pipeline.Validate(p); err == nil {
+		t.Fatal("want error for missing step ID")
+	}
+}
+
+func TestValidate_DuplicateID(t *testing.T) {
+	p := pip(step("a", "A", "", "", 0), step("a", "B", "", "", 0))
+	if err := pipeline.Validate(p); err == nil {
+		t.Fatal("want error for duplicate step ID")
+	}
+}
+
+func TestValidate_UnknownOnSuccess(t *testing.T) {
+	p := pip(step("a", "A", "missing", "", 0))
+	if err := pipeline.Validate(p); err == nil {
+		t.Fatal("want error for unknown on_success")
+	}
+}
+
+func TestValidate_UnknownOnFail(t *testing.T) {
+	p := pip(step("a", "A", "", "missing", 0))
+	if err := pipeline.Validate(p); err == nil {
+		t.Fatal("want error for unknown on_fail")
+	}
+}
+
+func TestValidate_CycleWithCap(t *testing.T) {
+	// review → execute → review (cycle); review has max_loops=3 — valid
+	p := pip(
+		step("review", "Review", "close", "execute", 3),
+		step("execute", "Execute", "review", "", 0),
+		step("close", "Close", "", "", 0),
+	)
+	if err := pipeline.Validate(p); err != nil {
+		t.Fatalf("want no error for capped cycle, got %v", err)
+	}
+}
+
+func TestValidate_CycleNoCap(t *testing.T) {
+	// a → b → a, neither has max_loops — invalid
+	p := pip(
+		step("a", "A", "b", "", 0),
+		step("b", "B", "a", "", 0),
+	)
+	if err := pipeline.Validate(p); err == nil {
+		t.Fatal("want error for uncapped cycle")
+	}
+}
+
+func TestValidate_LinearNoCap(t *testing.T) {
+	// a → b → (end); no cycle so no max_loops needed
+	p := pip(
+		step("a", "A", "b", "", 0),
+		step("b", "B", "", "", 0),
+	)
+	if err := pipeline.Validate(p); err != nil {
+		t.Fatalf("want no error for linear pipeline without max_loops, got %v", err)
+	}
+}

--- a/internal/skills/bundle/skills/conductor-adversarial-review.md
+++ b/internal/skills/bundle/skills/conductor-adversarial-review.md
@@ -1,0 +1,99 @@
+---
+name: conductor-adversarial-review
+description: Adversarial code reviewer that challenges the execute worker's output and emits structured findings with PASS or FAIL sentinels for the pipeline driver.
+---
+
+# conductor-adversarial-review
+
+Bundled by PrismConductor (PRISMCONDUCTOR_PLAN.md §15.7, issue #146).
+
+This is a **pipeline step skill** designed to run after `conductor-execute` as part of a
+configurable workspace pipeline. It reads the execute worker's PR and transcript, challenges
+the implementation adversarially, and emits structured findings plus a `PASS` or `FAIL`
+sentinel. The pipeline driver uses the sentinel to route to the next step.
+
+## Inputs
+
+- `--issue <number>` (required)
+- `--repo <path>` (defaults to cwd)
+- `--step-context <path>` (optional — path to .prismconductor/steps/<card-run>/ for prior step transcripts)
+
+## Behavior
+
+### 1. Locate the PR
+
+1. Read `.prismconductor/plans/<issue>-rev<N>.json` (latest approved plan) for context.
+2. Find the open PR for this issue: `gh pr list --search "Closes #<issue>" --state open --json number,url,headRefName`.
+3. If no open PR exists, print `BLOCKED: no open PR found for issue #<issue>` and exit.
+
+### 2. Adversarial review
+
+Perform a skeptical, adversarial review of the PR diff:
+
+```
+gh pr diff <pr_number>
+```
+
+Examine the diff against the plan with the following lenses:
+
+- **Correctness**: Does the implementation match the plan's acceptance criteria?
+- **Edge cases**: Are there inputs or states the implementation mishandles?
+- **Security**: Does any change introduce injection, auth bypass, or data exposure?
+- **Tests**: Are new behaviors actually exercised by tests, or do tests pass vacuously?
+- **Regressions**: Does any change break adjacent behavior not covered by the plan?
+- **Scope creep**: Are there unplanned changes that introduce risk?
+
+Be adversarial — assume the implementation is wrong until proven correct.
+
+### 3. Emit structured findings
+
+Print findings as a fenced JSON block so the conductor can parse them:
+
+```json
+{
+  "findings": [
+    {
+      "severity": "critical|major|minor|info",
+      "file": "path/to/file.go",
+      "line": 42,
+      "description": "one-line description of the finding"
+    }
+  ],
+  "summary": "overall verdict — one paragraph"
+}
+```
+
+Severity scale:
+- `critical` — blocks merge; could cause data loss, security breach, or production crash
+- `major` — should be fixed before merge; functional defect or test gap
+- `minor` — should be addressed but low risk; style, naming, or minor logic smell
+- `info` — observation only; no action required
+
+### 4. Emit sentinel
+
+After the findings block, print one of:
+
+- `PASS` — no critical or major findings; the implementation is acceptable
+- `FAIL` — one or more critical or major findings; route back to Execute
+
+The pipeline driver routes the card based on this sentinel:
+- `PASS` → advance to the next configured pipeline step (e.g. Close)
+- `FAIL` → route to `on_fail` (e.g. loop back to Execute) up to `max_loops` times
+
+### 5. Write step output
+
+Write the findings JSON to `.prismconductor/steps/<issue>/adversarial-review.json` so
+subsequent pipeline steps (e.g. a second Execute run) can read the defect list.
+
+```bash
+mkdir -p .prismconductor/steps/<issue>
+cp <findings-file> .prismconductor/steps/<issue>/adversarial-review.json
+```
+
+### Failure paths
+
+- No open PR → `BLOCKED: no open PR found for issue #<issue>`
+- `gh pr diff` fails → `BLOCKED: could not fetch PR diff — <error>`
+- Cannot write step output → proceed anyway; log a warning
+
+Print `Work complete.` after the sentinel.

--- a/internal/skills/scanner.go
+++ b/internal/skills/scanner.go
@@ -1,0 +1,51 @@
+package skills
+
+import (
+	"io/fs"
+	"strings"
+
+	"prismconductor/internal/types"
+)
+
+// ScanForPipeline returns skills available for use as pipeline steps (issue #146).
+// It wraps Discover() and enriches each SkillRef with a description extracted
+// from the YAML frontmatter of the skill's markdown body. Skills without a
+// description field are returned with an empty Description.
+func ScanForPipeline(repoPath string, bundleFS fs.FS) ([]types.SkillRef, error) {
+	refs, err := Discover(repoPath, bundleFS)
+	if err != nil {
+		return nil, err
+	}
+	for i := range refs {
+		if refs[i].Source == "bundled" {
+			name := strings.TrimPrefix(refs[i].Path, "bundled:")
+			if body, readErr := fs.ReadFile(bundleFS, "skills/"+name+".md"); readErr == nil {
+				refs[i].Description = extractFrontmatterDescription(string(body))
+			}
+		}
+	}
+	return refs, nil
+}
+
+// extractFrontmatterDescription parses the "description:" field from a YAML
+// frontmatter block (--- ... ---) at the top of a markdown file. Returns ""
+// if no frontmatter or description field is found.
+func extractFrontmatterDescription(body string) string {
+	if !strings.HasPrefix(body, "---") {
+		return ""
+	}
+	rest := body[3:]
+	end := strings.Index(rest, "---")
+	if end < 0 {
+		return ""
+	}
+	block := rest[:end]
+	for _, line := range strings.Split(block, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "description:") {
+			val := strings.TrimSpace(strings.TrimPrefix(line, "description:"))
+			return strings.Trim(val, "\"'")
+		}
+	}
+	return ""
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -18,6 +18,32 @@ type Workspace struct {
 	Conventions   ConventionHints `json:"conventions"`
 	Enabled       bool            `json:"enabled"`
 	AutoArchive   AutoArchive     `json:"auto_archive,omitempty"`
+	// Pipeline holds the custom pipeline configuration for this workspace.
+	// Nil means "use the default Plan→Execute→Close flow" (issue #146).
+	Pipeline *WorkspacePipeline `json:"pipeline,omitempty"`
+}
+
+// WorkspacePipeline is the per-workspace pipeline configuration (issue #146).
+// Steps define a DAG of work items that run after the core Plan+Execute cycle.
+// A nil pipeline means use the default Execute→Close behavior.
+type WorkspacePipeline struct {
+	Steps   []PipelineStep `json:"steps"`
+	Version int            `json:"version"` // incremented on each save
+}
+
+// PipelineStep is one node in the pipeline DAG (issue #146).
+type PipelineStep struct {
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	SkillRef  SkillRef `json:"skill_ref"`
+	// AutoChain controls whether the next step spawns automatically on success.
+	// false (default) = gated: user must click Continue before the next step spawns.
+	AutoChain bool `json:"auto_chain"`
+	// MaxLoops is the maximum number of times this step may run for a single card.
+	// 0 means the step is not a loop target. Steps in a cycle must have MaxLoops > 0.
+	MaxLoops  int    `json:"max_loops"`
+	OnSuccess string `json:"on_success"` // step ID of next step on PASS; "" = done
+	OnFail    string `json:"on_fail"`    // step ID of next step on FAIL; "" = stop/BLOCKED
 }
 
 // AutoArchive configures per-workspace automatic archiving of DONE cards whose
@@ -249,6 +275,12 @@ type Issue struct {
 	// pool had free capacity (issue #40). Cleared on successful drain.
 	WaitingForPool bool `json:"waiting_for_pool,omitempty"`
 
+	// Pipeline tracking fields (issue #146). Stamped at first pipeline-step
+	// spawn so in-flight cards continue on the saved pipeline version.
+	PipelineStepID  string         `json:"pipeline_step_id,omitempty"`
+	PipelineLoops   map[string]int `json:"pipeline_loops,omitempty"`
+	PipelineVersion int            `json:"pipeline_version,omitempty"`
+
 	// WorkSeconds is the cumulative active work time (plan + execute sessions)
 	// accumulated from completed sessions. Updated atomically when a session
 	// ends; preserved across GitHub poll re-saves (issue #46).
@@ -350,6 +382,11 @@ type Session struct {
 	// TODO/PLAN. The session row is preserved for audit; the UI ignores
 	// acknowledged sessions when computing lastFailure/activeSession overlays.
 	AcknowledgedAt *int64 `json:"acknowledged_at,omitempty"`
+
+	// PipelineStepName is non-empty when this session is running a custom
+	// pipeline step (issue #146). Used by the card StatusRow to display the
+	// active step name instead of the generic "working" label.
+	PipelineStepName string `json:"pipeline_step_name,omitempty"`
 
 	// TranscriptOffset is the byte offset into the transcript file of the
 	// last fully-processed line (issue #54). Lives on the sessions column,


### PR DESCRIPTION
## Summary

- Adds a `WorkspacePipeline` model with `PipelineStep` nodes (DAG) that runs after Execute, before Close, without changing board columns
- Workspace owners can insert, remove, reorder, and loop steps (e.g. an Adversarial Review that routes back to Execute on FAIL) via a new Pipeline editor in Settings → Workspaces
- Default Plan→Execute→Close behavior is unchanged for workspaces with no pipeline configured

## Files modified

| File | Change |
|------|--------|
| `internal/types/types.go` | `WorkspacePipeline`, `PipelineStep` types; pipeline fields on `Issue` and `Session` |
| `internal/pipeline/driver.go` | Pure routing driver: `Next()`, `Validate()`, cycle detection |
| `internal/pipeline/driver_test.go` | 18 tests for routing and validation |
| `internal/skills/scanner.go` | `ScanForPipeline()` with frontmatter description extraction |
| `internal/skills/bundle/skills/conductor-adversarial-review.md` | New bundled skill emitting structured findings + PASS/FAIL |
| `app.go` | `ListAvailableSkills`, `ValidatePipeline`, `SaveWorkspacePipeline` bound methods |
| `frontend/wailsjs/go/models.ts` | `PipelineStep`, `WorkspacePipeline` classes; updated `Issue`, `Session`, `Workspace` |
| `frontend/wailsjs/go/main/App.js` | New method bindings |
| `frontend/wailsjs/go/main/App.d.ts` | New method type declarations |
| `frontend/src/components/PipelineEditor.tsx` | Pipeline step editor with add/remove/reorder/wire controls |
| `frontend/src/components/WorkspacesPanel.tsx` | Surfaces `PipelineEditor` under SkillProfileEditor |
| `frontend/src/components/Card.tsx` | `StatusRow` shows `session.pipeline_step_name` for custom steps |

## Verification

- **Lint/build**: `go build ./internal/...` → pass
- **Tests**: `go test ./internal/...` → 18/18 pipeline tests pass, all 27 packages OK
- **TypeScript**: `tsc --noEmit` (after `npm install`) → pass (0 errors)
- **Smoke test**: skipped — `tests/e2e/startup.spec.ts` exists but requires a running Wails dev server at `localhost:34115`; not available in the execute-worker environment. CI workflow starts the app via `xvfb-run wails dev` and will run the smoke test there.

## Design decisions (per plan answers)

- `max_loops` default = 3 (q1)
- Gated by default — user must click Continue to advance to the next step (q2); `auto_chain: true` opts in to automatic advancement
- Cycles without a `max_loops` cap on any member step are rejected by `ValidatePipeline` (q3)

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-146

Closes #146