### PR TITLE
fix: preserve worktree on Blocked/Failed when it contains uncommitted work (data loss)

### DIFF
--- a/app.go
+++ b/app.go
@@ -1085,6 +1085,13 @@ func (a *App) ClearIssueFailure(workspaceID string, issueNumber int) error {
 				SessionID:   sess.ID,
 			})
 		}
+	} else if a.assembler != nil {
+		// No row matched the acknowledge query — could be the issue's
+		// frontend view is stale and still shows lastFailure even though
+		// nothing in DB is unacknowledged. Force a reassemble so the
+		// frontend's IssueView gets rebuilt from scratch and the button
+		// at least makes the UI converge with backend truth.
+		a.assembler.Reassemble(workspaceID, issueNumber)
 	}
 	return nil
 }

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -57,6 +57,55 @@ func List(repoPath string) ([]Entry, error) {
 	return parseWorktreeList(out), nil
 }
 
+// WorktreeIsEmpty reports whether the worktree has NO user-paid-for work
+// in it: no uncommitted changes, no untracked files, and no commits
+// ahead of HEAD's upstream-tracked base.
+//
+// Used by the terminal-state cleanup path to decide whether it's safe to
+// remove the worktree on Blocked/Failed exits. The historical policy of
+// always removing on Blocked/Failed was a data-loss bug — a worker that
+// finished its edits but failed at `git commit -S` (GPG passphrase
+// timeout, signing key missing) had its diff nuked even though the
+// LLM had been paid for the work.
+//
+// "Empty" semantics:
+//   - `git status --porcelain` returns no lines (no staged, no modified,
+//     no untracked).
+//   - `git rev-list HEAD ^@{u}` returns no commits ahead of upstream.
+//     If there's no upstream tracked (fresh branch never pushed), we
+//     fall back to comparing HEAD against the merge-base with `main`.
+//
+// On any error reading git state, we return FALSE (preserve the
+// worktree). Better to leak a directory than wipe data we can't inspect.
+func WorktreeIsEmpty(worktreeDir string) bool {
+	if worktreeDir == "" {
+		return true
+	}
+	// Uncommitted/untracked check.
+	status, err := run(worktreeDir, "git", "status", "--porcelain")
+	if err != nil {
+		return false
+	}
+	if strings.TrimSpace(status) != "" {
+		return false
+	}
+	// Commits-ahead check. Try upstream first; fall back to main.
+	for _, base := range []string{"@{u}", "main", "master"} {
+		out, err := run(worktreeDir, "git", "rev-list", "--count", "HEAD", "^"+base)
+		if err != nil {
+			continue
+		}
+		count := strings.TrimSpace(out)
+		if count == "0" {
+			return true
+		}
+		// Found a base, got a non-zero count → has commits → not empty.
+		return false
+	}
+	// Couldn't resolve any base — be conservative and preserve.
+	return false
+}
+
 // HasSubmodules reports whether the worktree has a .gitmodules file at its
 // root. Called after Add (q4=D) so InitSubmodules only fires on repos that
 // actually use submodules.

--- a/internal/issueview/assembler.go
+++ b/internal/issueview/assembler.go
@@ -135,6 +135,14 @@ func (a *Assembler) handleEvent(e eventbus.Event) {
 	a.reassembleAndEmit(wsID, issueNum)
 }
 
+// Reassemble forces a fresh assembly + emit for the given issue.
+// Public counterpart of reassembleAndEmit, exported so callers like
+// the Clear Failure handler can force the frontend's IssueView to
+// converge with backend truth even when nothing in the DB changed.
+func (a *Assembler) Reassemble(wsID string, issueNum int) {
+	a.reassembleAndEmit(wsID, issueNum)
+}
+
 func (a *Assembler) reassembleAndEmit(wsID string, issueNum int) {
 	view, err := a.Assemble(wsID, issueNum)
 	if err != nil {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -847,21 +847,43 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 		})
 	}
 
-	// Issue #22: per-execute worktree teardown.
-	//   q2=A: Blocked/Failed → immediate `git worktree remove --force`. The
-	//         user loses post-mortem `cd` access to the worktree but gains
-	//         deterministic state with no goroutine fanout. A leftover from a
-	//         transient failure is reclaimed by the next startup Prune.
-	//   q3=A: Completed → leave on disk; the 24h GC walk reclaims it later.
-	// Issue #17: PausedForQuestion must also keep the worktree on disk so the
-	// resume worker can `git switch` back into it. The 24h GC reclaims if the
-	// user never answers.
+	// Worktree teardown policy.
+	//
+	// HISTORICAL (issue #22 q2=A): Blocked/Failed → immediate
+	// `git worktree remove --force`. That was a DATA-LOSS BUG: when a
+	// worker finished its edits but failed at `git commit -S` (GPG
+	// passphrase timeout, signing key missing, etc.), the diff lived
+	// only in the worktree's working directory and the cleanup nuked
+	// it. The user paid for the LLM work and got nothing.
+	//
+	// NEW POLICY: NEVER auto-remove a worktree that contains
+	// user-paid-for work. Specifically:
+	//   - Completed → keep on disk (24h GC walk reclaims later;
+	//     unchanged from before).
+	//   - PausedForQuestion → keep on disk so the resume worker can
+	//     `git switch` back into it (issue #17; unchanged).
+	//   - Blocked / Failed → keep on disk if there's ANY uncommitted
+	//     work, untracked files, or commits ahead of the base branch.
+	//     Only safe-remove when the worktree is verifiably empty.
+	//
+	// "Verifiably empty" means `git status --porcelain` returns no
+	// lines AND no commits exist ahead of the base. If git isn't even
+	// reachable (worktree corrupted), default to KEEP — better to leak
+	// a dir than wipe data we can't inspect.
+	//
+	// The 24h GC walk handles long-term cleanup of legitimately empty
+	// worktrees that were never resumed.
 	if rs.worktreeDir != "" {
 		switch rs.sess.State {
 		case types.StateBlocked, types.StateFailed:
-			if err := pcgit.Remove(rs.repoPath, rs.worktreeDir); err != nil {
-				log.Printf("worktree cleanup (terminal=%s) %s: %v",
-					rs.sess.State, rs.worktreeDir, err)
+			if pcgit.WorktreeIsEmpty(rs.worktreeDir) {
+				if err := pcgit.Remove(rs.repoPath, rs.worktreeDir); err != nil {
+					log.Printf("worktree cleanup (terminal=%s, empty) %s: %v",
+						rs.sess.State, rs.worktreeDir, err)
+				}
+			} else {
+				log.Printf("worktree preserved (terminal=%s) %s: contains uncommitted work; user can recover via `cd %s`",
+					rs.sess.State, rs.worktreeDir, rs.worktreeDir)
 			}
 		}
 	}

--- a/internal/session/reattach.go
+++ b/internal/session/reattach.go
@@ -245,15 +245,22 @@ func (m *Manager) classifyDeadWorker(rs *runtimeSession) {
 		m.onStateChange(*rs.sess, prev)
 	}
 
-	// Worktree teardown for the dead-worker terminal cases. Mirror manager.go's
-	// live-spawn cleanup: blocked / failed → immediate remove; completed and
-	// paused_for_question keep the dir on disk for post-mortem / resume.
+	// Worktree teardown for the dead-worker terminal cases. Mirror
+	// manager.go's live-spawn cleanup: NEVER auto-remove a worktree that
+	// contains user-paid-for work. Only safe-remove when the worktree is
+	// verifiably empty (no uncommitted changes, no commits ahead of base).
+	// See manager.go's tailAndParse cleanup for the full rationale.
 	if rs.worktreeDir != "" {
 		switch rs.sess.State {
 		case types.StateBlocked, types.StateFailed:
-			if err := pcgit.Remove(rs.repoPath, rs.worktreeDir); err != nil {
-				log.Printf("reattach: worktree cleanup (terminal=%s) %s: %v",
-					rs.sess.State, rs.worktreeDir, err)
+			if pcgit.WorktreeIsEmpty(rs.worktreeDir) {
+				if err := pcgit.Remove(rs.repoPath, rs.worktreeDir); err != nil {
+					log.Printf("reattach: worktree cleanup (terminal=%s, empty) %s: %v",
+						rs.sess.State, rs.worktreeDir, err)
+				}
+			} else {
+				log.Printf("reattach: worktree preserved (terminal=%s) %s: contains uncommitted work; user can recover via `cd %s`",
+					rs.sess.State, rs.worktreeDir, rs.worktreeDir)
 			}
 		}
 	}

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -507,10 +507,17 @@ func (s *Store) AcknowledgeLatestFailure(workspaceID string, issueNumber int) (*
 	}
 	now := time.Now().Unix()
 	var id, raw string
+	// Check BOTH the indexed `state` column AND the json blob's `$.state`
+	// because the two could be out of sync if a row was written by an
+	// older binary before the json_set unification (or if a future bug
+	// drifts them again). The Clear Failure button must clear the
+	// failure regardless of which source surfaced it; any other behavior
+	// makes the button look broken to the user.
 	err := s.DB.QueryRow(`
 		SELECT id, json FROM sessions
 		WHERE workspace_id = ? AND issue_number = ?
-		  AND state IN ('blocked','failed')
+		  AND (state IN ('blocked','failed')
+		       OR json_extract(json, '$.state') IN ('blocked','failed'))
 		  AND (acknowledged_at IS NULL OR acknowledged_at = 0)
 		ORDER BY json_extract(json, '$.started_at') DESC
 		LIMIT 1`, workspaceID, issueNumber).Scan(&id, &raw)


### PR DESCRIPTION
## Summary

CRITICAL data-loss bug fix. Workers that finished their edits but failed at `git commit -S` (GPG passphrase timeout, signing key missing on host) had their diff nuked by the post-terminal cleanup. **The user paid the LLM for the work and got nothing back.**

Witnessed live by a user whose GPG signing timed out on a remote machine. The card showed BLOCKED with a 'gpg signing timed out' reason. The user went looking for the work to push it manually, found the branch empty, the worktree directory gone, no orphan commits in `git fsck --lost-found`, no reflog entries — work was unrecoverable.

## Root cause

The historical "Blocked/Failed → immediate `git worktree remove --force`" policy (issue #22 q2=A) treated ALL terminal Blocked/Failed states identically. Made sense for clean failures (worker errored before doing useful work) but catastrophic when the worker had completed substantial work and only the final commit/push step failed. The diff lived only in the worktree's working directory; the force-remove wiped it before the user had any chance to recover.

## Fix

**Never auto-remove a worktree that contains user-paid-for work.**

- New `pcgit.WorktreeIsEmpty(dir)` — returns true only when `git status --porcelain` is empty AND no commits exist ahead of the upstream-tracked base (or `main`/`master` fallback). On any error reading git state, returns false (preserve the dir).
- `tailAndParse` and `reattach.classifyDeadWorker` both gate the `Remove` call on `WorktreeIsEmpty`. Non-empty worktrees stay on disk after Blocked/Failed; the user can `cd` into them and recover.
- `log.Printf` surfaces "worktree preserved" with the path so the user knows where their work lives.

The 24h GC walk handles long-term cleanup of legitimately empty worktrees.

## Bonus: Clear Failure button "did nothing" in some cases

- `AcknowledgeLatestFailure` checked only the indexed `state` column. Rows whose indexed state and `json.state` were out of sync (stale-binary artifact) were invisible to the query — button silently no-op'd. Broadened WHERE to `state IN (...) OR json_extract(json,'$.state') IN (...)`.
- `ClearIssueFailure` now calls `Assembler.Reassemble` even when no row matched, so the frontend view converges with backend truth on every click (defensive against stale frontend state).
- New public `Assembler.Reassemble` method (thin wrapper over the existing private path).

## Test plan

- [ ] Run a worker on a repo where `commit.gpgsign=true` is set and no GPG agent is loaded
- [ ] Worker fails at commit time, card transitions to BLOCKED
- [ ] Verify worktree at `.prismconductor/worktrees/<ws>-<n>` is **still on disk**
- [ ] `cd` into it, run `git status` → see the worker's edits
- [ ] User can manually `git commit -S && git push` to recover the work
- [ ] Click Clear Failure → red overlay clears within ~1s

## Related

- #157 — full NEEDS_PR design (this PR is the urgent data-loss subset; #157 ships the proper graceful fallback + dark-green glow + auto-detect-PR-from-poll)
- #22 — original worktree teardown policy this PR amends