### PR TITLE
feat: recover orphaned paused_for_question sessions (#153)

### DIFF
--- a/app.go
+++ b/app.go
@@ -270,6 +270,16 @@ func (a *App) startup(ctx context.Context) {
 		// Issue #98: canonical IssueView assembler — emits bus.issue_view_updated
 		// whenever any contributing source changes.
 		a.assembler = issueview.New(a.bus, a.store)
+		// Issue #153: wire workspace path resolver so the assembler can probe
+		// for orphan question files during IssueView assembly.
+		if a.wsReg != nil {
+			a.assembler.SetWorkspacePathFn(func(id string) string {
+				if ws, ok := a.wsReg.Get(id); ok {
+					return ws.RepoPath
+				}
+				return ""
+			})
+		}
 
 		// Pool counter self-heal: on every terminal session-state event,
 		// re-derive every pool's `active` counter from the DB count of
@@ -315,6 +325,8 @@ func (a *App) startup(ctx context.Context) {
 			},
 			a.handleMidRunAnswerArrived,
 		)
+		// Issue #153: auto-recover orphaned paused sessions after 60s grace.
+		a.answerWatcher.SetOrphanCallback(60*time.Second, a.handleOrphanQuestion)
 		go a.answerWatcher.Run(a.ctx)
 	}
 
@@ -2185,6 +2197,133 @@ func (a *App) handleMidRunAnswerArrived(ps store.PausedSession) {
 	}
 	log.Printf("answer resume: spawned execute worker for #%d on branch %s (qid=%s)",
 		ps.IssueNumber, ctx.Branch, ps.QuestionID)
+}
+
+// handleOrphanQuestion is the AnswerWatcher callback for orphaned paused
+// sessions (#153). Auto-recover fires only when the workspace setting
+// `auto_recover_orphan_questions:<wsID>` is not explicitly set to "false".
+func (a *App) handleOrphanQuestion(ps store.PausedSession) {
+	if a.store == nil {
+		return
+	}
+	v, _ := a.store.GetSetting("auto_recover_orphan_questions:" + ps.WorkspaceID)
+	if v == "false" {
+		return
+	}
+	sess, err := a.store.TerminateOrphanPausedSession(ps.WorkspaceID, ps.IssueNumber,
+		"question file gone — auto-recovered after 60s")
+	if err != nil {
+		log.Printf("auto-recover orphan #%d: %v", ps.IssueNumber, err)
+		return
+	}
+	if sess == nil {
+		return
+	}
+	if sess.PoolID != "" {
+		a.bus.Publish(eventbus.EvtWorkerSlotFreed, eventbus.WorkerSlotFreed{
+			SessionID: sess.ID,
+			PoolID:    sess.PoolID,
+		})
+	}
+	if a.ctx != nil {
+		wruntime.EventsEmit(a.ctx, "session.state", *sess)
+	}
+	if a.bus != nil {
+		a.bus.Publish(eventbus.EvtSessionStateChanged, eventbus.SessionStateChanged{
+			WorkspaceID: sess.WorkspaceID,
+			IssueNumber: sess.IssueNumber,
+			SessionID:   sess.ID,
+		})
+	}
+	log.Printf("auto-recovered orphan paused session %s for #%d", sess.ID[:8], ps.IssueNumber)
+}
+
+// RecoverOrphanQuestion manually marks an orphaned paused_for_question session
+// as failed and releases its worker slot (#153). Called from the card's Recover
+// button when OrphanQuestion is set in the IssueView.
+func (a *App) RecoverOrphanQuestion(workspaceID string, issueNumber int) error {
+	if a.store == nil {
+		return fmt.Errorf("store unavailable")
+	}
+	if a.wsReg != nil {
+		if _, ok := a.wsReg.Get(workspaceID); !ok {
+			return fmt.Errorf("unknown workspace %q", workspaceID)
+		}
+	}
+	sess, err := a.store.TerminateOrphanPausedSession(workspaceID, issueNumber,
+		"question file missing — recovered manually")
+	if err != nil {
+		return err
+	}
+	if sess == nil {
+		// No orphan found — force a reassemble so the frontend's view converges.
+		if a.assembler != nil {
+			a.assembler.Reassemble(workspaceID, issueNumber)
+		}
+		return nil
+	}
+	if sess.PoolID != "" {
+		a.bus.Publish(eventbus.EvtWorkerSlotFreed, eventbus.WorkerSlotFreed{
+			SessionID: sess.ID,
+			PoolID:    sess.PoolID,
+		})
+	}
+	if a.ctx != nil {
+		wruntime.EventsEmit(a.ctx, "session.state", *sess)
+	}
+	if a.bus != nil {
+		a.bus.Publish(eventbus.EvtSessionStateChanged, eventbus.SessionStateChanged{
+			WorkspaceID: sess.WorkspaceID,
+			IssueNumber: sess.IssueNumber,
+			SessionID:   sess.ID,
+		})
+	}
+	log.Printf("RecoverOrphanQuestion: recovered session %s for %s#%d", sess.ID[:8], workspaceID, issueNumber)
+	return nil
+}
+
+// ReplanForce cancels any non-terminal plan-mode sessions for the given issue
+// (running, waiting_for_input, paused_for_question) then spawns a fresh plan
+// worker (#153, Q1=A: only plan-mode sessions; execute sessions are left alone).
+func (a *App) ReplanForce(workspaceID string, number int) error {
+	if a.wsReg == nil || a.mgr == nil {
+		return fmt.Errorf("registry/manager unavailable")
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return fmt.Errorf("unknown workspace %q", workspaceID)
+	}
+	// Cancel live plan sessions (running / waiting_for_input / blocked).
+	for _, s := range a.mgr.Snapshot() {
+		if s.WorkspaceID != workspaceID || s.IssueNumber != number || s.Mode != types.ModePlan {
+			continue
+		}
+		switch s.State {
+		case types.StateRunning, types.StateWaitingForInput, types.StateBlocked:
+			if err := a.mgr.KillGraceful(s.ID); err != nil {
+				log.Printf("ReplanForce: kill session %s: %v", s.ID[:8], err)
+			}
+		}
+	}
+	// Terminate any paused_for_question plan session.
+	if a.store != nil {
+		if _, err := a.store.TerminateOrphanPausedSession(workspaceID, number, "force-replan by user"); err != nil {
+			log.Printf("ReplanForce: terminate paused session for #%d: %v", number, err)
+		}
+	}
+	log.Printf("ReplanForce: spawning plan worker for %s#%d", workspaceID, number)
+	pool, ok := a.acquirePlanPool(ws)
+	if !ok {
+		return fmt.Errorf("no plan pool available")
+	}
+	sess, err := a.mgr.SpawnPlan(ws, types.Issue{Number: number, WorkspaceID: workspaceID}, pool)
+	if err != nil {
+		a.poolReg.ReleaseByPool(pool.ID)
+		log.Printf("ReplanForce #%d FAILED: %v", number, err)
+		return err
+	}
+	log.Printf("ReplanForce: spawn ok for #%d, session=%s pid=%d pool=%s", number, sess.ID[:8], sess.PID, pool.ID)
+	return nil
 }
 
 // SubmitMidRunAnswer writes the user's answer for a mid-run question (#17).

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { BrowserOpenURL } from "../../wailsjs/runtime/runtime";
-import { Replan, ClearIssueFailure, SelfHeal, CancelSession, SpawnPlanForIssue, ResolveConflicts } from "../../wailsjs/go/main/App";
+import { Replan, ReplanForce, ClearIssueFailure, SelfHeal, CancelSession, SpawnPlanForIssue, ResolveConflicts } from "../../wailsjs/go/main/App";
+import { RecoverButton } from "./RecoverButton";
 import { types } from "../../wailsjs/go/models";
 import { useSessionStore, SessionActivity } from "../stores/sessionStore";
 import { useLabelsStore, EMPTY_LABELS } from "../stores/labelsStore";
@@ -45,6 +46,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
   const lastFailure: types.Session | null = view?.last_failure ?? null;
   const testsFailingInfo = view?.tests_failing_info ?? null;
   const conflictsInfo = view?.conflicts_info ?? null;
+  const orphanQuestion = view?.orphan_question ?? null;
   // Activity is live-streaming data not captured in the view — still from sessionStore.
   const activity: SessionActivity | null = useSessionStore((s) =>
     activeSession ? (s.sessions[activeSession.id]?.activity ?? null) : null
@@ -203,6 +205,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
         activity={activity}
         lastFailure={lastFailure}
         pausedSession={pausedSession}
+        orphanQuestion={orphanQuestion}
         planReady={planReady}
         blocked={blocked}
         isPrimitive={isPrimitive}
@@ -393,11 +396,17 @@ type ConflictsInfo = {
   conflicting_files: string[];
 };
 
+type OrphanQuestionInfo = {
+  pending_question_id: string;
+  since: number;
+};
+
 function StatusRow({
   activeSession,
   activity,
   lastFailure,
   pausedSession,
+  orphanQuestion,
   planReady,
   blocked,
   isPrimitive,
@@ -419,6 +428,7 @@ function StatusRow({
   activity: SessionActivity | null;
   lastFailure: types.Session | null;
   pausedSession: types.Session | null;
+  orphanQuestion: OrphanQuestionInfo | null;
   planReady: { revision: number } | null;
   blocked: boolean;
   isPrimitive: boolean;
@@ -449,6 +459,21 @@ function StatusRow({
   ) : null;
 
   if (pausedSession) {
+    if (orphanQuestion) {
+      return (
+        <>
+          <div className="text-[11px] mt-1.5 space-y-0.5">
+            <div className="flex items-center gap-1.5 flex-wrap">
+              <Pulse className="bg-red-400" />
+              <span className="text-red-300 font-medium">BLOCKED — orphan question</span>
+              <RecoverButton workspaceID={workspaceID} issueNumber={issueNumber} />
+            </div>
+            <div className="text-slate-500 pl-3.5">question file missing — session cannot resume</div>
+          </div>
+          {menuEl}
+        </>
+      );
+    }
     return (
       <>
         <div className="text-[11px] mt-1.5 flex items-center gap-1.5 flex-wrap">
@@ -692,7 +717,16 @@ function StatusRow({
           <button
             onClick={(e) => {
               e.stopPropagation();
-              Replan(workspaceID, issueNumber).catch((err: any) => alert(String(err?.message ?? err)));
+              Replan(workspaceID, issueNumber).catch((err: any) => {
+                const msg = String(err?.message ?? err);
+                if (msg.includes("already in flight")) {
+                  if (confirm(`A session for #${issueNumber} is currently in progress. Cancel it and start a fresh plan?`)) {
+                    ReplanForce(workspaceID, issueNumber).catch((e2: any) => alert(String(e2?.message ?? e2)));
+                  }
+                } else {
+                  alert(msg);
+                }
+              });
             }}
             onMouseDown={(e) => e.stopPropagation()}
             onPointerDown={(e) => e.stopPropagation()}

--- a/frontend/src/components/MidRunQuestionModal.tsx
+++ b/frontend/src/components/MidRunQuestionModal.tsx
@@ -2,12 +2,16 @@ import { useEffect, useState } from "react";
 import { GetMidRunQuestion, SubmitMidRunAnswer } from "../../wailsjs/go/main/App";
 import { types } from "../../wailsjs/go/models";
 import { AnswerState, QuestionForm, emptyAnswers, initialAnswers, isComplete } from "./QuestionForm";
+import { RecoverButton } from "./RecoverButton";
 
 // MidRunQuestionModal renders a single mid-run question (#17) that the worker
 // raised via /conductor-question. The question lives at
 // .prismconductor/questions/<id>.json on disk; the answer file (written by
 // SubmitMidRunAnswer below) trips the answer-file watcher, which spawns a
 // fresh execute worker on the same branch to continue the work.
+//
+// If the question file is missing (orphan session), the modal shows a recovery
+// UI instead and always allows closing (#153).
 export function MidRunQuestionModal({
   open,
   onClose,
@@ -73,41 +77,62 @@ export function MidRunQuestionModal({
     }
   }
 
+  // Question file load failed — render orphan recovery UI instead.
+  const isOrphan = !loading && error != null && question == null;
+
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
-      <div className="w-[600px] max-h-[80vh] bg-slate-900 border border-amber-700 rounded-lg flex flex-col overflow-hidden">
-        <div className="flex items-center justify-between px-4 py-2 border-b border-slate-800 bg-amber-950/30">
+      <div className={`w-[600px] max-h-[80vh] bg-slate-900 border rounded-lg flex flex-col overflow-hidden ${isOrphan ? "border-red-700" : "border-amber-700"}`}>
+        <div className={`flex items-center justify-between px-4 py-2 border-b border-slate-800 ${isOrphan ? "bg-red-950/30" : "bg-amber-950/30"}`}>
           <div className="text-slate-200">
-            ❓ Mid-run question — <span className="text-slate-400">#{issueNumber}</span>
+            {isOrphan ? "⚠ Orphaned session" : "❓ Mid-run question"}{" "}
+            — <span className="text-slate-400">#{issueNumber}</span>
           </div>
+          {/* X button always closes unconditionally (#153) */}
           <button onClick={onClose} className="text-slate-400 hover:text-slate-200">✕</button>
         </div>
         <div className="flex-1 overflow-y-auto px-4 py-3 text-sm space-y-3">
           {loading && <div className="text-slate-500">loading…</div>}
-          {error && <div className="text-red-400">{error}</div>}
+          {isOrphan && (
+            <div className="space-y-2">
+              <div className="text-red-400">The question file for this session could not be loaded.</div>
+              <div className="text-slate-400 text-xs">
+                The worker that raised this question may have exited without writing its question file,
+                or the file was deleted. The session is stuck and cannot resume. Use Recover to mark it
+                as failed and release its worker slot.
+              </div>
+            </div>
+          )}
+          {!isOrphan && error && <div className="text-red-400">{error}</div>}
           {question && (
             <QuestionForm questions={[question]} state={state} onChange={setState} />
           )}
         </div>
         <div className="px-4 py-2 border-t border-slate-800 flex items-center justify-between gap-2">
           <div className="text-xs text-slate-500">
-            Answering re-spawns the execute worker on the same branch.
+            {isOrphan
+              ? "Recover marks the session as failed and releases the worker slot."
+              : "Answering re-spawns the execute worker on the same branch."}
           </div>
           <div className="flex items-center gap-2">
+            {/* Dismiss always enabled — never block closing (#153) */}
             <button
               onClick={onClose}
-              disabled={busy}
-              className="px-3 py-1.5 rounded border border-slate-700 text-slate-300 hover:border-slate-500 disabled:opacity-50"
+              className="px-3 py-1.5 rounded border border-slate-700 text-slate-300 hover:border-slate-500"
             >
-              Dismiss
+              {isOrphan ? "Close" : "Dismiss"}
             </button>
-            <button
-              onClick={submit}
-              disabled={busy || !ready}
-              className="px-3 py-1.5 rounded bg-amber-600 text-slate-50 hover:bg-amber-500 disabled:opacity-50"
-            >
-              {busy ? "Submitting…" : "Submit answer"}
-            </button>
+            {isOrphan ? (
+              <RecoverButton workspaceID={workspaceID} issueNumber={issueNumber} />
+            ) : (
+              <button
+                onClick={submit}
+                disabled={busy || !ready}
+                className="px-3 py-1.5 rounded bg-amber-600 text-slate-50 hover:bg-amber-500 disabled:opacity-50"
+              >
+                {busy ? "Submitting…" : "Submit answer"}
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/components/RecoverButton.tsx
+++ b/frontend/src/components/RecoverButton.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { RecoverOrphanQuestion } from "../../wailsjs/go/main/App";
+
+export function RecoverButton({
+  workspaceID,
+  issueNumber,
+}: {
+  workspaceID: string;
+  issueNumber: number;
+}) {
+  const [busy, setBusy] = useState(false);
+
+  async function recover(e: React.MouseEvent) {
+    e.stopPropagation();
+    setBusy(true);
+    try {
+      await RecoverOrphanQuestion(workspaceID, issueNumber);
+    } catch (err: any) {
+      alert(String(err?.message ?? err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={recover}
+      onMouseDown={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+      disabled={busy}
+      className="ml-auto px-1.5 py-0.5 rounded text-[10px] border border-red-700 text-red-300 hover:border-red-500 hover:text-red-200 disabled:opacity-50"
+      title="Mark orphaned paused session as failed and release its worker slot"
+    >
+      {busy ? "Recovering…" : "↺ Recover"}
+    </button>
+  );
+}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -41,12 +41,6 @@ export function DiscoverWorkspaceSkills(arg1:string):Promise<Array<types.SkillRe
 
 export function EstimateSpawnCost(arg1:string,arg2:number,arg3:string):Promise<main.SpawnEstimate>;
 
-export function ListAvailableSkills(arg1:string):Promise<Array<types.SkillRef>>;
-
-export function ValidatePipeline(arg1:types.WorkspacePipeline):Promise<void>;
-
-export function SaveWorkspacePipeline(arg1:string,arg2:types.WorkspacePipeline):Promise<void>;
-
 export function FetchIssueDetail(arg1:string,arg2:number):Promise<types.Issue>;
 
 export function FetchPRChecks(arg1:string,arg2:number):Promise<string>;
@@ -91,6 +85,8 @@ export function LatestPlan(arg1:string,arg2:number):Promise<types.Plan>;
 
 export function ListArchivedIssues(arg1:string):Promise<Array<types.Issue>>;
 
+export function ListAvailableSkills(arg1:string):Promise<Array<types.SkillRef>>;
+
 export function ListBundledSkills():Promise<Array<main.BundledSkill>>;
 
 export function ListGoals():Promise<Array<types.Goal>>;
@@ -133,6 +129,8 @@ export function ReadTranscript(arg1:string):Promise<string>;
 
 export function RecentLogs():Promise<Array<logbuffer.Entry>>;
 
+export function RecoverOrphanQuestion(arg1:string,arg2:number):Promise<void>;
+
 export function RefreshIssuesNow():Promise<void>;
 
 export function RejectPlan(arg1:string,arg2:number):Promise<void>;
@@ -145,6 +143,8 @@ export function ReorderIssues(arg1:string,arg2:string,arg3:Array<number>):Promis
 
 export function Replan(arg1:string,arg2:number):Promise<void>;
 
+export function ReplanForce(arg1:string,arg2:number):Promise<void>;
+
 export function ResetPoolCounters():Promise<number>;
 
 export function ResolveConflicts(arg1:string,arg2:number):Promise<void>;
@@ -156,6 +156,8 @@ export function RunOrchestrator():Promise<void>;
 export function SaveGoal(arg1:types.Goal):Promise<void>;
 
 export function SavePool(arg1:types.Pool):Promise<void>;
+
+export function SaveWorkspacePipeline(arg1:string,arg2:types.WorkspacePipeline):Promise<void>;
 
 export function SelfHeal(arg1:string,arg2:number):Promise<void>;
 
@@ -188,6 +190,8 @@ export function UnarchiveIssue(arg1:string,arg2:number):Promise<void>;
 export function UpdateLabel(arg1:string,arg2:string,arg3:types.Label):Promise<types.Label>;
 
 export function UpdateWorkspace(arg1:types.Workspace):Promise<void>;
+
+export function ValidatePipeline(arg1:types.WorkspacePipeline):Promise<void>;
 
 export function WorkspaceSpendToday(arg1:string):Promise<number>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -58,18 +58,6 @@ export function DiscoverWorkspaceSkills(arg1) {
   return window['go']['main']['App']['DiscoverWorkspaceSkills'](arg1);
 }
 
-export function ListAvailableSkills(arg1) {
-  return window['go']['main']['App']['ListAvailableSkills'](arg1);
-}
-
-export function ValidatePipeline(arg1) {
-  return window['go']['main']['App']['ValidatePipeline'](arg1);
-}
-
-export function SaveWorkspacePipeline(arg1, arg2) {
-  return window['go']['main']['App']['SaveWorkspacePipeline'](arg1, arg2);
-}
-
 export function EstimateSpawnCost(arg1, arg2, arg3) {
   return window['go']['main']['App']['EstimateSpawnCost'](arg1, arg2, arg3);
 }
@@ -162,6 +150,10 @@ export function ListArchivedIssues(arg1) {
   return window['go']['main']['App']['ListArchivedIssues'](arg1);
 }
 
+export function ListAvailableSkills(arg1) {
+  return window['go']['main']['App']['ListAvailableSkills'](arg1);
+}
+
 export function ListBundledSkills() {
   return window['go']['main']['App']['ListBundledSkills']();
 }
@@ -246,6 +238,10 @@ export function RecentLogs() {
   return window['go']['main']['App']['RecentLogs']();
 }
 
+export function RecoverOrphanQuestion(arg1, arg2) {
+  return window['go']['main']['App']['RecoverOrphanQuestion'](arg1, arg2);
+}
+
 export function RefreshIssuesNow() {
   return window['go']['main']['App']['RefreshIssuesNow']();
 }
@@ -270,6 +266,10 @@ export function Replan(arg1, arg2) {
   return window['go']['main']['App']['Replan'](arg1, arg2);
 }
 
+export function ReplanForce(arg1, arg2) {
+  return window['go']['main']['App']['ReplanForce'](arg1, arg2);
+}
+
 export function ResetPoolCounters() {
   return window['go']['main']['App']['ResetPoolCounters']();
 }
@@ -292,6 +292,10 @@ export function SaveGoal(arg1) {
 
 export function SavePool(arg1) {
   return window['go']['main']['App']['SavePool'](arg1);
+}
+
+export function SaveWorkspacePipeline(arg1, arg2) {
+  return window['go']['main']['App']['SaveWorkspacePipeline'](arg1, arg2);
 }
 
 export function SelfHeal(arg1, arg2) {
@@ -356,6 +360,10 @@ export function UpdateLabel(arg1, arg2, arg3) {
 
 export function UpdateWorkspace(arg1) {
   return window['go']['main']['App']['UpdateWorkspace'](arg1);
+}
+
+export function ValidatePipeline(arg1) {
+  return window['go']['main']['App']['ValidatePipeline'](arg1);
 }
 
 export function WorkspaceSpendToday(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -826,6 +826,20 @@ export namespace issueview {
 	        this.conflicting_files = source["conflicting_files"];
 	    }
 	}
+	export class OrphanQuestionInfo {
+	    pending_question_id: string;
+	    since: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new OrphanQuestionInfo(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.pending_question_id = source["pending_question_id"];
+	        this.since = source["since"];
+	    }
+	}
 	export class TestsFailingInfo {
 	    failing_jobs: string[];
 	    failing_check_run_urls: string[];
@@ -875,6 +889,7 @@ export namespace issueview {
 	    derived_column: string;
 	    tests_failing_info?: TestsFailingInfo;
 	    conflicts_info?: ConflictsInfo;
+	    orphan_question?: OrphanQuestionInfo;
 	
 	    static createFrom(source: any = {}) {
 	        return new IssueView(source);
@@ -892,6 +907,7 @@ export namespace issueview {
 	        this.derived_column = source["derived_column"];
 	        this.tests_failing_info = this.convertValues(source["tests_failing_info"], TestsFailingInfo);
 	        this.conflicts_info = this.convertValues(source["conflicts_info"], ConflictsInfo);
+	        this.orphan_question = this.convertValues(source["orphan_question"], OrphanQuestionInfo);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -912,6 +928,7 @@ export namespace issueview {
 		    return a;
 		}
 	}
+	
 	
 
 }
@@ -1363,18 +1380,18 @@ export namespace types {
 	    // Go type: time
 	    closed_at?: any;
 	    waiting_for_pool?: boolean;
+	    pipeline_step_id?: string;
+	    pipeline_loops?: Record<string, number>;
+	    pipeline_version?: number;
 	    work_seconds?: number;
 	    work_seconds_plan?: number;
 	    work_seconds_execute?: number;
 	    cost_usd?: number;
-	    pipeline_step_id?: string;
-	    pipeline_loops?: Record<string, number>;
-	    pipeline_version?: number;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new Issue(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.number = source["number"];
@@ -1398,13 +1415,13 @@ export namespace types {
 	        this.archived_at = this.convertValues(source["archived_at"], null);
 	        this.closed_at = this.convertValues(source["closed_at"], null);
 	        this.waiting_for_pool = source["waiting_for_pool"];
+	        this.pipeline_step_id = source["pipeline_step_id"];
+	        this.pipeline_loops = source["pipeline_loops"];
+	        this.pipeline_version = source["pipeline_version"];
 	        this.work_seconds = source["work_seconds"];
 	        this.work_seconds_plan = source["work_seconds_plan"];
 	        this.work_seconds_execute = source["work_seconds_execute"];
 	        this.cost_usd = source["cost_usd"];
-	        this.pipeline_step_id = source["pipeline_step_id"];
-	        this.pipeline_loops = source["pipeline_loops"];
-	        this.pipeline_version = source["pipeline_version"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -1457,6 +1474,68 @@ export namespace types {
 	        this.answer = source["answer"];
 	        this.multi = source["multi"];
 	    }
+	}
+	export class SkillRef {
+	    path: string;
+	    source: string;
+	    name: string;
+	    display_name: string;
+	    description?: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new SkillRef(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.path = source["path"];
+	        this.source = source["source"];
+	        this.name = source["name"];
+	        this.display_name = source["display_name"];
+	        this.description = source["description"];
+	    }
+	}
+	export class PipelineStep {
+	    id: string;
+	    name: string;
+	    skill_ref: SkillRef;
+	    auto_chain: boolean;
+	    max_loops: number;
+	    on_success: string;
+	    on_fail: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new PipelineStep(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
+	        this.name = source["name"];
+	        this.skill_ref = this.convertValues(source["skill_ref"], SkillRef);
+	        this.auto_chain = source["auto_chain"];
+	        this.max_loops = source["max_loops"];
+	        this.on_success = source["on_success"];
+	        this.on_fail = source["on_fail"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
 	}
 	
 	export class Pool {
@@ -1587,15 +1666,15 @@ export namespace types {
 	    pending_question_id?: string;
 	    pool_id?: string;
 	    acknowledged_at?: number;
+	    pipeline_step_name?: string;
 	    input_tokens?: number;
 	    output_tokens?: number;
 	    estimated_cost_cents?: number;
-	    pipeline_step_name?: string;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new Session(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -1611,10 +1690,10 @@ export namespace types {
 	        this.pending_question_id = source["pending_question_id"];
 	        this.pool_id = source["pool_id"];
 	        this.acknowledged_at = source["acknowledged_at"];
+	        this.pipeline_step_name = source["pipeline_step_name"];
 	        this.input_tokens = source["input_tokens"];
 	        this.output_tokens = source["output_tokens"];
 	        this.estimated_cost_cents = source["estimated_cost_cents"];
-	        this.pipeline_step_name = source["pipeline_step_name"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -1634,26 +1713,6 @@ export namespace types {
 		    }
 		    return a;
 		}
-	}
-	export class SkillRef {
-	    path: string;
-	    source: string;
-	    name: string;
-	    display_name: string;
-	    description?: string;
-	
-	    static createFrom(source: any = {}) {
-	        return new SkillRef(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.path = source["path"];
-	        this.source = source["source"];
-	        this.name = source["name"];
-	        this.display_name = source["display_name"];
-	        this.description = source["description"];
-	    }
 	}
 	export class SkillProfile {
 	    mode: string;
@@ -1714,63 +1773,20 @@ export namespace types {
 		}
 	}
 	
-	export class PipelineStep {
-	    id: string;
-	    name: string;
-	    skill_ref: SkillRef;
-	    auto_chain: boolean;
-	    max_loops: number;
-	    on_success: string;
-	    on_fail: string;
-
-	    static createFrom(source: any = {}) {
-	        return new PipelineStep(source);
-	    }
-
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.id = source["id"];
-	        this.name = source["name"];
-	        this.skill_ref = this.convertValues(source["skill_ref"], SkillRef);
-	        this.auto_chain = source["auto_chain"];
-	        this.max_loops = source["max_loops"];
-	        this.on_success = source["on_success"];
-	        this.on_fail = source["on_fail"];
-	    }
-
-		convertValues(a: any, classs: any, asMap: boolean = false): any {
-		    if (!a) {
-		        return a;
-		    }
-		    if (a.slice && a.map) {
-		        return (a as any[]).map(elem => this.convertValues(elem, classs));
-		    } else if ("object" === typeof a) {
-		        if (asMap) {
-		            for (const key of Object.keys(a)) {
-		                a[key] = new classs(a[key]);
-		            }
-		            return a;
-		        }
-		        return new classs(a);
-		    }
-		    return a;
-		}
-	}
-
 	export class WorkspacePipeline {
 	    steps: PipelineStep[];
 	    version: number;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new WorkspacePipeline(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.steps = this.convertValues(source["steps"], PipelineStep);
 	        this.version = source["version"];
 	    }
-
+	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
 		    if (!a) {
 		        return a;
@@ -1789,7 +1805,6 @@ export namespace types {
 		    return a;
 		}
 	}
-
 	export class Workspace {
 	    id: string;
 	    display_name: string;
@@ -1804,11 +1819,11 @@ export namespace types {
 	    enabled: boolean;
 	    auto_archive?: AutoArchive;
 	    pipeline?: WorkspacePipeline;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new Workspace(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];

--- a/internal/issueview/assembler.go
+++ b/internal/issueview/assembler.go
@@ -3,6 +3,8 @@ package issueview
 import (
 	"encoding/json"
 	"log"
+	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 
@@ -48,6 +50,11 @@ type Assembler struct {
 	cache         map[string]string           // "wsID#num" → last-emitted JSON
 	checkFails    map[string]*checkFailEntry  // "wsID#num" → latest check failure
 	conflictFails map[string]*conflictEntry   // "wsID#num" → latest conflict state
+
+	// repoPathFn resolves a workspace ID to its local repo path. When set,
+	// Assemble probes the questions directory to detect orphan question files
+	// (#153). Nil disables the probe (conservative: no orphan flag set).
+	repoPathFn func(workspaceID string) string
 }
 
 // New wires the Assembler to the bus. Call once at startup after the store is ready.
@@ -133,6 +140,14 @@ func (a *Assembler) handleEvent(e eventbus.Event) {
 		}
 	}
 	a.reassembleAndEmit(wsID, issueNum)
+}
+
+// SetWorkspacePathFn wires the workspace-path resolver used to probe for
+// orphan question files (#153). Call once after New, before any events arrive.
+func (a *Assembler) SetWorkspacePathFn(fn func(workspaceID string) string) {
+	a.mu.Lock()
+	a.repoPathFn = fn
+	a.mu.Unlock()
 }
 
 // Reassemble forces a fresh assembly + emit for the given issue.
@@ -222,6 +237,28 @@ func (a *Assembler) Assemble(workspaceID string, issueNumber int) (IssueView, er
 		}
 	}
 
+	// Detect orphan question: paused session with a question_id that has no
+	// corresponding file on disk (#153). The probe is best-effort — if
+	// repoPathFn is nil or the path is unknown, skip silently.
+	var orphanQuestion *OrphanQuestionInfo
+	if paused != nil && paused.PendingQuestionID != "" {
+		a.mu.Lock()
+		fn := a.repoPathFn
+		a.mu.Unlock()
+		if fn != nil {
+			repoPath := fn(workspaceID)
+			if repoPath != "" {
+				qPath := filepath.Join(repoPath, ".prismconductor", "questions", paused.PendingQuestionID+".json")
+				if _, err := os.Stat(qPath); os.IsNotExist(err) {
+					orphanQuestion = &OrphanQuestionInfo{
+						PendingQuestionID: paused.PendingQuestionID,
+						Since:             paused.StartedAt.Unix(),
+					}
+				}
+			}
+		}
+	}
+
 	return IssueView{
 		Issue:            iss,
 		LatestPlan:       plan,
@@ -233,6 +270,7 @@ func (a *Assembler) Assemble(workspaceID string, issueNumber int) (IssueView, er
 		DerivedColumn:    derivedColumn(iss, plan, active),
 		TestsFailingInfo: testsFailingInfo,
 		ConflictsInfo:    conflictsInfo,
+		OrphanQuestion:   orphanQuestion,
 	}, nil
 }
 

--- a/internal/issueview/issueview.go
+++ b/internal/issueview/issueview.go
@@ -36,6 +36,16 @@ type ConflictsInfo struct {
 	ConflictingFiles []string `json:"conflicting_files"`
 }
 
+// OrphanQuestionInfo is populated when a paused_for_question session's question
+// file is absent from disk (#153). The frontend uses this to render a recovery
+// badge and enable the Recover action without re-checking the filesystem.
+type OrphanQuestionInfo struct {
+	PendingQuestionID string `json:"pending_question_id"`
+	// Since is the Unix epoch of the session's started_at, used to compute
+	// how long the card has been stuck.
+	Since int64 `json:"since"`
+}
+
 // IssueView is the single canonical read model for a board card. Assembled on
 // the backend and emitted as bus.issue_view_updated on every change so the
 // frontend can render without reconciling multiple stores.
@@ -48,9 +58,13 @@ type IssueView struct {
 	// LastSession is the most recent terminal session regardless of outcome.
 	// Used by the CostChip hover tooltip to show per-session token breakdown
 	// (issue #101). Nil when no terminal session exists.
-	LastSession      *types.Session    `json:"last_session,omitempty"`
-	PoolBadge        *PoolBadge        `json:"pool_badge,omitempty"`
-	DerivedColumn    types.BoardColumn `json:"derived_column"`
-	TestsFailingInfo *TestsFailingInfo `json:"tests_failing_info,omitempty"`
-	ConflictsInfo    *ConflictsInfo    `json:"conflicts_info,omitempty"`
+	LastSession      *types.Session      `json:"last_session,omitempty"`
+	PoolBadge        *PoolBadge          `json:"pool_badge,omitempty"`
+	DerivedColumn    types.BoardColumn   `json:"derived_column"`
+	TestsFailingInfo *TestsFailingInfo   `json:"tests_failing_info,omitempty"`
+	ConflictsInfo    *ConflictsInfo      `json:"conflicts_info,omitempty"`
+	// OrphanQuestion is set when PausedSession has a pending_question_id but
+	// the corresponding question file is missing from disk (#153). The
+	// frontend renders a BLOCKED badge and a Recover action.
+	OrphanQuestion *OrphanQuestionInfo `json:"orphan_question,omitempty"`
 }

--- a/internal/store/answers_watch.go
+++ b/internal/store/answers_watch.go
@@ -32,6 +32,11 @@ type PausedSession struct {
 // watcher's lifetime; the resume path is expected to clear pending_question_id
 // on the old session row so subsequent paused-session lookups won't surface
 // the stale match.
+//
+// Orphan detection (#153): if SetOrphanCallback is called with a non-nil fn,
+// the watcher also tracks sessions whose question file is absent from disk.
+// When a session's question file has been missing for longer than gracePeriod,
+// the onOrphanQuestion callback is invoked (at most once per session).
 type AnswerWatcher struct {
 	interval     time.Duration
 	workspacesFn func() []types.Workspace
@@ -40,6 +45,12 @@ type AnswerWatcher struct {
 
 	mu    sync.Mutex
 	fired map[string]bool
+
+	// Orphan detection fields (#153). All guarded by mu.
+	onOrphanQuestion func(PausedSession)
+	gracePeriod      time.Duration
+	firstMissing     map[string]time.Time // sessionID → time question file first absent
+	orphanFired      map[string]bool       // sessionID → already fired onOrphanQuestion
 }
 
 func NewAnswerWatcher(
@@ -57,7 +68,22 @@ func NewAnswerWatcher(
 		pausedFn:     pausedFn,
 		onAnswer:     onAnswer,
 		fired:        map[string]bool{},
+		firstMissing: map[string]time.Time{},
+		orphanFired:  map[string]bool{},
 	}
+}
+
+// SetOrphanCallback enables orphan detection (#153). After gracePeriod of
+// continuous question-file absence for a paused session, fn is called once.
+// Must be called before Run/Tick. A nil fn disables orphan detection.
+func (w *AnswerWatcher) SetOrphanCallback(gracePeriod time.Duration, fn func(PausedSession)) {
+	if w == nil {
+		return
+	}
+	w.mu.Lock()
+	w.gracePeriod = gracePeriod
+	w.onOrphanQuestion = fn
+	w.mu.Unlock()
 }
 
 // Run blocks until ctx is done, ticking every interval. Spawn in a goroutine.
@@ -93,6 +119,12 @@ func (w *AnswerWatcher) Tick() {
 	for _, p := range paused {
 		idx[p.WorkspaceID+"|"+p.QuestionID] = p
 	}
+	// Build a workspace-path index for O(1) access during orphan probing.
+	wsPath := make(map[string]string)
+	for _, ws := range w.workspacesFn() {
+		wsPath[ws.ID] = ws.RepoPath
+	}
+
 	for _, ws := range w.workspacesFn() {
 		if !ws.Enabled || ws.RepoPath == "" {
 			continue
@@ -133,5 +165,53 @@ func (w *AnswerWatcher) Tick() {
 			w.mu.Unlock()
 			w.onAnswer(ps)
 		}
+	}
+
+	// Orphan detection: for each paused session, probe the question file.
+	// If absent for > gracePeriod, fire onOrphanQuestion once (#153).
+	w.mu.Lock()
+	orphanFn := w.onOrphanQuestion
+	grace := w.gracePeriod
+	w.mu.Unlock()
+	if orphanFn == nil || grace <= 0 {
+		return
+	}
+	now := time.Now()
+	for _, ps := range paused {
+		if ps.QuestionID == "" {
+			continue
+		}
+		repoPath := wsPath[ps.WorkspaceID]
+		if repoPath == "" {
+			continue
+		}
+		qPath := filepath.Join(repoPath, ".prismconductor", "questions", ps.QuestionID+".json")
+		_, statErr := os.Stat(qPath)
+		questionExists := statErr == nil
+
+		w.mu.Lock()
+		if questionExists {
+			// Question file back on disk (e.g. worker re-wrote it) — reset timer.
+			delete(w.firstMissing, ps.SessionID)
+			w.mu.Unlock()
+			continue
+		}
+		if w.orphanFired[ps.SessionID] {
+			w.mu.Unlock()
+			continue
+		}
+		first, seen := w.firstMissing[ps.SessionID]
+		if !seen {
+			w.firstMissing[ps.SessionID] = now
+			w.mu.Unlock()
+			continue
+		}
+		if now.Sub(first) < grace {
+			w.mu.Unlock()
+			continue
+		}
+		w.orphanFired[ps.SessionID] = true
+		w.mu.Unlock()
+		orphanFn(ps)
 	}
 }

--- a/internal/store/answers_watch_test.go
+++ b/internal/store/answers_watch_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"prismconductor/internal/types"
 )
@@ -146,5 +147,129 @@ func TestAnswerWatcherSkipsDisabledWorkspace(t *testing.T) {
 	w.Tick()
 	if len(fired) != 0 {
 		t.Errorf("expected no callbacks for disabled workspace, got %d", len(fired))
+	}
+}
+
+// --- Orphan detection tests (#153) ---
+
+func writeQuestionFile(t *testing.T, repoPath, questionID, body string) {
+	t.Helper()
+	dir := filepath.Join(repoPath, ".prismconductor", "questions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir questions: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, questionID+".json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write question: %v", err)
+	}
+}
+
+func TestOrphanWatcherFiresAfterGracePeriod(t *testing.T) {
+	ws := newWS(t, "ws1")
+	ws.Enabled = true
+	const qid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	// Question file is absent — no writeQuestionFile call.
+
+	paused := []PausedSession{{
+		SessionID:   "sess-orphan",
+		WorkspaceID: ws.ID,
+		IssueNumber: 99,
+		QuestionID:  qid,
+	}}
+	var orphanFired []PausedSession
+	w := NewAnswerWatcher(0,
+		func() []types.Workspace { return []types.Workspace{ws} },
+		func() []PausedSession { return paused },
+		func(ps PausedSession) {}, // answer callback, not triggered here
+	)
+	// Set a very short grace period for testing.
+	w.SetOrphanCallback(10*time.Millisecond, func(ps PausedSession) {
+		orphanFired = append(orphanFired, ps)
+	})
+
+	// First tick: records firstMissing, does not fire yet.
+	w.Tick()
+	if len(orphanFired) != 0 {
+		t.Fatalf("expected no orphan callback on first tick, got %d", len(orphanFired))
+	}
+
+	// Wait past grace period, then tick again.
+	time.Sleep(20 * time.Millisecond)
+	w.Tick()
+	if len(orphanFired) != 1 {
+		t.Fatalf("expected 1 orphan callback after grace, got %d", len(orphanFired))
+	}
+	if orphanFired[0].SessionID != "sess-orphan" {
+		t.Errorf("wrong session ID: %s", orphanFired[0].SessionID)
+	}
+
+	// Third tick: idempotent, must not re-fire.
+	w.Tick()
+	if len(orphanFired) != 1 {
+		t.Errorf("orphan callback should fire exactly once, got %d total", len(orphanFired))
+	}
+}
+
+func TestOrphanWatcherDoesNotFireWhenQuestionExists(t *testing.T) {
+	ws := newWS(t, "ws1")
+	ws.Enabled = true
+	const qid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	writeQuestionFile(t, ws.RepoPath, qid, `{"id":"`+qid+`"}`)
+
+	paused := []PausedSession{{
+		SessionID:   "sess-good",
+		WorkspaceID: ws.ID,
+		IssueNumber: 77,
+		QuestionID:  qid,
+	}}
+	var orphanFired []PausedSession
+	w := NewAnswerWatcher(0,
+		func() []types.Workspace { return []types.Workspace{ws} },
+		func() []PausedSession { return paused },
+		func(ps PausedSession) {},
+	)
+	w.SetOrphanCallback(0, func(ps PausedSession) {
+		orphanFired = append(orphanFired, ps)
+	})
+
+	w.Tick()
+	w.Tick()
+	if len(orphanFired) != 0 {
+		t.Errorf("expected no orphan callback when question file exists, got %d", len(orphanFired))
+	}
+}
+
+func TestOrphanWatcherResetsTimerWhenFileReturns(t *testing.T) {
+	ws := newWS(t, "ws1")
+	ws.Enabled = true
+	const qid = "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff"
+
+	paused := []PausedSession{{
+		SessionID:   "sess-reset",
+		WorkspaceID: ws.ID,
+		IssueNumber: 55,
+		QuestionID:  qid,
+	}}
+	var orphanFired []PausedSession
+	w := NewAnswerWatcher(0,
+		func() []types.Workspace { return []types.Workspace{ws} },
+		func() []PausedSession { return paused },
+		func(ps PausedSession) {},
+	)
+	w.SetOrphanCallback(10*time.Millisecond, func(ps PausedSession) {
+		orphanFired = append(orphanFired, ps)
+	})
+
+	// First tick: file missing, starts timer.
+	w.Tick()
+
+	// File reappears before grace period elapses.
+	writeQuestionFile(t, ws.RepoPath, qid, `{}`)
+	w.Tick() // resets timer
+
+	// Wait past original grace, then another tick.
+	time.Sleep(20 * time.Millisecond)
+	w.Tick()
+	if len(orphanFired) != 0 {
+		t.Errorf("expected no orphan callback after file returned, got %d", len(orphanFired))
 	}
 }

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -497,6 +497,56 @@ func (s *Store) ListSessionsForIssue(workspaceID string, issueNumber int) ([]typ
 	return out, rows.Err()
 }
 
+// TerminateOrphanPausedSession finds the most-recent unacknowledged
+// paused_for_question session for (workspaceID, issueNumber), marks it as
+// failed with the given reason, stamps acknowledged_at, and returns the
+// updated session. Returns nil (no error) if no matching row exists.
+// Used by RecoverOrphanQuestion and the auto-recovery watcher (#153).
+func (s *Store) TerminateOrphanPausedSession(workspaceID string, issueNumber int, reason string) (*types.Session, error) {
+	if s == nil || s.DB == nil {
+		return nil, errors.New("store unavailable")
+	}
+	now := time.Now()
+	nowUnix := now.Unix()
+	var id, raw string
+	err := s.DB.QueryRow(`
+		SELECT id, json FROM sessions
+		WHERE workspace_id = ? AND issue_number = ?
+		  AND state = 'paused_for_question'
+		  AND (acknowledged_at IS NULL OR acknowledged_at = 0)
+		ORDER BY json_extract(json, '$.started_at') DESC
+		LIMIT 1`, workspaceID, issueNumber).Scan(&id, &raw)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var sess types.Session
+	if err := json.Unmarshal([]byte(raw), &sess); err != nil {
+		return nil, err
+	}
+	sess.State = types.StateFailed
+	sess.BlockedReason = reason
+	sess.EndedAt = &now
+	sess.AcknowledgedAt = &nowUnix
+	updated, err := json.Marshal(&sess)
+	if err != nil {
+		return nil, err
+	}
+	_, err = s.DB.Exec(`
+		UPDATE sessions
+		   SET state = 'failed',
+		       json = ?,
+		       acknowledged_at = ?
+		 WHERE id = ?`,
+		string(updated), nowUnix, id)
+	if err != nil {
+		return nil, err
+	}
+	return &sess, nil
+}
+
 // AcknowledgeLatestFailure marks the most recent unacknowledged blocked/failed
 // session for the given issue as acknowledged (issue #88). The session row is
 // preserved for audit; only acknowledged_at is set so the UI stops showing the

--- a/internal/store/sessions_test.go
+++ b/internal/store/sessions_test.go
@@ -167,3 +167,66 @@ func TestLoadRunningSessions_SkipsAcknowledged(t *testing.T) {
 		}
 	}
 }
+
+// TestTerminateOrphanPausedSession verifies the state transition from
+// paused_for_question → failed with acknowledgement (#153).
+func TestTerminateOrphanPausedSession(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now()
+	sess := &types.Session{
+		ID:                "sess-paused",
+		WorkspaceID:       "ws1",
+		IssueNumber:       42,
+		Mode:              types.ModeExecute,
+		State:             types.StatePausedForQuestion,
+		StartedAt:         now.Add(-5 * time.Minute),
+		PendingQuestionID: "q-uuid-123",
+		PoolID:            "pool-1",
+	}
+	if err := s.SaveSession(sess, ""); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+
+	got, err := s.TerminateOrphanPausedSession("ws1", 42, "question file missing — test")
+	if err != nil {
+		t.Fatalf("TerminateOrphanPausedSession: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected a session, got nil")
+	}
+	if got.State != types.StateFailed {
+		t.Errorf("expected state=failed, got %s", got.State)
+	}
+	if got.BlockedReason != "question file missing — test" {
+		t.Errorf("unexpected blocked_reason: %q", got.BlockedReason)
+	}
+	if got.AcknowledgedAt == nil || *got.AcknowledgedAt == 0 {
+		t.Error("expected acknowledged_at to be set")
+	}
+	if got.EndedAt == nil {
+		t.Error("expected ended_at to be set")
+	}
+
+	// Should not appear in LoadRunningSessions after termination.
+	sessions, _, err := s.LoadRunningSessions()
+	if err != nil {
+		t.Fatalf("LoadRunningSessions: %v", err)
+	}
+	for _, s2 := range sessions {
+		if s2.ID == "sess-paused" {
+			t.Fatal("terminated orphan should not appear in LoadRunningSessions")
+		}
+	}
+}
+
+// TestTerminateOrphanPausedSession_NoMatch returns nil when no paused session exists.
+func TestTerminateOrphanPausedSession_NoMatch(t *testing.T) {
+	s := newTestStore(t)
+	got, err := s.TerminateOrphanPausedSession("ws1", 99, "reason")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Cards permanently wedged in `paused_for_question` (question file missing/unwritten) now self-recover via three complementary mechanisms: automatic timeout recovery, a manual Recover RPC, and a ReplanForce that clears stale plan sessions before re-spawning.

## Changes

### Backend
- **`internal/store/sessions.go`** — `TerminateOrphanPausedSession`: finds the most-recent unacknowledged `paused_for_question` session for (workspace, issue), transitions it to `failed+acknowledged`, releases the worker slot.
- **`internal/issueview/issueview.go`** — `OrphanQuestionInfo` struct + `orphan_question` field on `IssueView`.
- **`internal/issueview/assembler.go`** — FS probe for missing question file; populates `orphan_question` on `IssueView` when paused session's question file is absent.
- **`internal/store/answers_watch.go`** — Extended `AnswerWatcher` with per-session `firstMissing` tracking; auto-fires orphan callback after configurable grace period (default 60s); timer resets if file reappears.
- **`app.go`** — `RecoverOrphanQuestion` (manual RPC), `ReplanForce` (force-replan clearing stale plan sessions), `handleOrphanQuestion` (auto-recovery callback wired to AnswerWatcher).

### Frontend
- **`frontend/src/components/RecoverButton.tsx`** — New component; calls `RecoverOrphanQuestion` RPC, shows spinner, surfaces errors via alert.
- **`frontend/src/components/Card.tsx`** — Orphan badge (red `BLOCKED — orphan question`) with `RecoverButton` shown when `orphan_question` is set. Re-plan button shows confirm dialog then `ReplanForce` on already-in-flight error.
- **`frontend/src/components/MidRunQuestionModal.tsx`** — X and Dismiss buttons are now unconditional (never disabled). Orphan UI (red border, explanatory text, `RecoverButton`) shown when question file load fails.

## Verification

- **Lint:** `go vet prismconductor/internal/...` — pass
- **Typecheck:** `node_modules/.bin/tsc --noEmit` (frontend) — pass
- **Build:** `wails build` — pass (9.2s)
- **Smoke test:** `npx --prefix tests playwright test tests/e2e/startup.spec.ts` — pass (1 test, 6.2s)
- **Tests:** `go test prismconductor/internal/store/...` — pass (8 tests including 5 new: `TestTerminateOrphanPausedSession`, `TestTerminateOrphanPausedSession_NoMatch`, `TestOrphanWatcherFiresAfterGracePeriod`, `TestOrphanWatcherDoesNotFireWhenQuestionExists`, `TestOrphanWatcherResetsTimerWhenFileReturns`)

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-153

Closes #153
