### PR TITLE
fix(assembler): force-emit IssueView on load-bearing events (no more stale frontend views)

### DIFF
--- a/internal/issueview/assembler.go
+++ b/internal/issueview/assembler.go
@@ -132,6 +132,27 @@ func (a *Assembler) handleEvent(e eventbus.Event) {
 			a.mu.Unlock()
 		}
 	}
+	// Session-state changes are LOAD-BEARING for the frontend's glow ladder
+	// (running execute → purple, blocked → red, etc). The cache-diff gate
+	// in reassembleAndEmit can suppress an emit if the marshaled JSON
+	// happens to equal the cache — possible after edge cases like
+	// rapid-fire state ping-pongs or recovery from a missed earlier event.
+	// Force-emit on these to guarantee the frontend converges.
+	//
+	// For non-state events (poll re-emits where nothing changed), the
+	// diff gate stays in effect to avoid spamming the bus.
+	switch e.Type {
+	case eventbus.EvtSessionStateChanged,
+		eventbus.EvtPRChecksFailed,
+		eventbus.EvtPRChecksRecovered,
+		eventbus.EvtPRConflictsDetected,
+		eventbus.EvtPRConflictsResolved,
+		eventbus.EvtPROpened,
+		eventbus.EvtPRMerged,
+		eventbus.EvtPRClosedUnmerged:
+		a.reassembleAndForceEmit(wsID, issueNum)
+		return
+	}
 	a.reassembleAndEmit(wsID, issueNum)
 }
 
@@ -140,7 +161,26 @@ func (a *Assembler) handleEvent(e eventbus.Event) {
 // the Clear Failure handler can force the frontend's IssueView to
 // converge with backend truth even when nothing in the DB changed.
 func (a *Assembler) Reassemble(wsID string, issueNum int) {
-	a.reassembleAndEmit(wsID, issueNum)
+	a.reassembleAndForceEmit(wsID, issueNum)
+}
+
+// reassembleAndForceEmit runs Assemble + Publish unconditionally.
+// Used when the caller knows a load-bearing state change occurred and
+// can't trust the cache-diff to detect it — e.g. session state
+// transitions, where a reused JSON shape could mask a real change to
+// what the frontend's glow ladder reads.
+func (a *Assembler) reassembleAndForceEmit(wsID string, issueNum int) {
+	view, err := a.Assemble(wsID, issueNum)
+	if err != nil {
+		log.Printf("issueview: assemble %s#%d: %v", wsID, issueNum, err)
+		return
+	}
+	b, _ := json.Marshal(view)
+	key := wsID + "#" + strconv.Itoa(issueNum)
+	a.mu.Lock()
+	a.cache[key] = string(b)
+	a.mu.Unlock()
+	a.bus.Publish(eventbus.EvtIssueViewUpdated, view)
 }
 
 func (a *Assembler) reassembleAndEmit(wsID string, issueNum int) {


### PR DESCRIPTION
## Summary

User reported: a card with a live execute session fixing merge conflicts glowed **red** instead of **purple**. DB confirmed the running execute session existed; the frontend just wasn't seeing the updated IssueView. User's verdict: "there should be no such thing as a 'stale frontend view', this should be dynamically updating."

## Root cause

`reassembleAndEmit`'s cache-diff gate suppresses the `EvtIssueViewUpdated` publish when the marshaled view JSON happens to equal the previously cached value. That's correct for poll-driven re-emits (avoid bus noise on no-op events), but wrong for load-bearing events like `EvtSessionStateChanged` — where the frontend's glow ladder reads the session state field directly and a missed emit means the card stays painted from a stale earlier view forever.

## Fix

Split into two paths:
- **`reassembleAndForceEmit`** — assembles, updates the cache, ALWAYS publishes. No diff gate.
- **`reassembleAndEmit`** — original diff-gated behavior. Kept for poll re-emits where nothing changed.

`handleEvent` routes load-bearing events through force-emit:
- `EvtSessionStateChanged`
- `EvtPRChecksFailed` / `EvtPRChecksRecovered`
- `EvtPRConflictsDetected` / `EvtPRConflictsResolved`
- `EvtPROpened` / `EvtPRMerged` / `EvtPRClosedUnmerged`

The exported `Reassemble()` method (used by the Clear Failure handler) also upgrades to force-emit.

## Net effect

Stale-frontend-view becomes structurally impossible for the events that matter to the card UI. The card glows purple the moment the conflict-resolver worker spawns, regardless of any cache quirks.

`go test ./...` clean.

## Test plan
- [ ] Card with detected merge conflicts (red glow) → click Resolve Conflicts → execute spawns → card flips to purple within ~1s, no reload required
- [ ] PR opened, checks fail, then green again → emerald glow updates without reload
- [ ] Approve plan → IN_PROGRESS card flips to purple immediately on spawn