### PR TITLE
feat: auto-kill execute worker on PR_OPENED (#118)

### DIFF
--- a/app.go
+++ b/app.go
@@ -1993,17 +1993,42 @@ func (a *App) handlePROpened(sess types.Session, prURL string) {
 		"pr_number":    n,
 		"pr_url":       prURL,
 	})
-	if a.notificationsSuppressed() {
-		return
+	if !a.notificationsSuppressed() {
+		a.emitToast("success", toastWorkspaceName(a.wsReg, sess.WorkspaceID),
+			fmt.Sprintf("#%d opened PR #%d", sess.IssueNumber, n),
+			map[string]any{
+				"workspace_id": sess.WorkspaceID,
+				"issue_number": sess.IssueNumber,
+				"pr_url":       prURL,
+				"action":       "open_pr",
+			})
 	}
-	a.emitToast("success", toastWorkspaceName(a.wsReg, sess.WorkspaceID),
-		fmt.Sprintf("#%d opened PR #%d", sess.IssueNumber, n),
-		map[string]any{
-			"workspace_id": sess.WorkspaceID,
-			"issue_number": sess.IssueNumber,
-			"pr_url":       prURL,
-			"action":       "open_pr",
-		})
+	// Auto-kill the execute worker now that the PR is open (#118). The
+	// worktree is preserved (session lands in Completed) so Continue Work can
+	// resume. Emit a toast only when the kill succeeded so we surface real impact.
+	killID, killStart, costCents, killed := a.mgr.KillAfterPROpened(sess.WorkspaceID, sess.IssueNumber)
+	if killed {
+		dur := time.Since(killStart).Round(time.Second)
+		mins := int(dur.Minutes())
+		secs := int(dur.Seconds()) % 60
+		var durStr string
+		if mins > 0 {
+			durStr = fmt.Sprintf("%dm %ds", mins, secs)
+		} else {
+			durStr = fmt.Sprintf("%ds", secs)
+		}
+		log.Printf("auto-cancel: PR #%d opened; killing execute session %s for issue #%d (was running %s)",
+			n, killID, sess.IssueNumber, durStr)
+		if !a.notificationsSuppressed() {
+			a.emitToast("info", toastWorkspaceName(a.wsReg, sess.WorkspaceID),
+				fmt.Sprintf("#%d: PR opened — stopping execute worker (was running %s, ~$%.2f)",
+					sess.IssueNumber, durStr, costCents/100),
+				map[string]any{
+					"workspace_id": sess.WorkspaceID,
+					"issue_number": sess.IssueNumber,
+				})
+		}
+	}
 }
 
 // notifyOnPRStateChange fires an in-app toast when the poller publishes

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -184,6 +184,12 @@ type runtimeSession struct {
 	// tailAndParse. Initialised to the session start time so new sessions
 	// aren't immediately considered stale by the watchdog. Protected by actMu.
 	lastLineAt time.Time
+
+	// autoKilledForPROpen is set by KillAfterPROpened before the kill signal
+	// is sent. tailAndParse uses it to override StateFailed → StateCompleted
+	// so the worktree is preserved on the normal Completed cleanup path.
+	// Protected by actMu.
+	autoKilledForPROpen bool
 }
 
 // sessionCmd is the §10.5 abstraction over both spawn strategies. The
@@ -842,6 +848,16 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 		waitErr = <-done
 	}
 	rs.sess.State = mapTerminalState(rs.sess.State, waitErr)
+	rs.actMu.Lock()
+	autoKilled := rs.autoKilledForPROpen
+	rs.actMu.Unlock()
+	if autoKilled && rs.sess.State == types.StateFailed {
+		// Worker was killed by KillAfterPROpened after emitting PR_OPENED.
+		// Treat as Completed so the worktree is preserved on the normal path.
+		log.Printf("auto-cancel: PR opened; execute session %s for issue #%d completed after %.0fs",
+			rs.sess.ID, rs.sess.IssueNumber, time.Since(rs.sess.StartedAt).Seconds())
+		rs.sess.State = types.StateCompleted
+	}
 	end := time.Now()
 	rs.sess.EndedAt = &end
 	if m.store != nil {
@@ -1205,6 +1221,40 @@ func (m *Manager) KillGraceful(sessionID string) error {
 		_ = proc.Kill()
 	}()
 	return nil
+}
+
+// KillAfterPROpened finds the running or waiting execute session for
+// (workspaceID, issueNumber), marks it as auto-killed so tailAndParse will
+// record it as Completed (preserving the worktree), kills the process, and
+// returns the session ID, start time, and a best-effort estimated cost in
+// cents. Returns found=false when no active execute session exists (safe to
+// call concurrently). Issue #118.
+func (m *Manager) KillAfterPROpened(workspaceID string, issueNumber int) (id string, startedAt time.Time, estimatedCostCents float64, found bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, rs := range m.sessions {
+		s := rs.sess
+		if s.WorkspaceID != workspaceID || s.IssueNumber != issueNumber || s.Mode != types.ModeExecute {
+			continue
+		}
+		if s.State != types.StateRunning && s.State != types.StateWaitingForInput {
+			continue
+		}
+		rs.actMu.Lock()
+		rs.autoKilledForPROpen = true
+		hIn := rs.harnessInputTokens
+		hOut := rs.harnessOutputTokens
+		rs.actMu.Unlock()
+		_, _, costCents := ResolveUsage(rs.parser.LastCost(), hIn, hOut, rs.poolModel)
+		if rs.cancel != nil {
+			rs.cancel()
+		}
+		if rs.cmd != nil {
+			_ = rs.cmd.Kill()
+		}
+		return s.ID, s.StartedAt, costCents, true
+	}
+	return "", time.Time{}, 0, false
 }
 
 // SendInput is a no-op since #54. The spawn path no longer allocates a PTY,

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -332,6 +333,160 @@ func TestSpawnPersistsPoolID(t *testing.T) {
 	saved := store.saves[0]
 	if saved.PoolID != "pool-xyz" {
 		t.Errorf("persisted PoolID = %q, want %q", saved.PoolID, "pool-xyz")
+	}
+}
+
+// fakeKillCmd is a sessionCmd stub that records whether Kill was called.
+type fakeKillCmd struct {
+	killed bool
+}
+
+func (f *fakeKillCmd) Wait() error { return nil }
+func (f *fakeKillCmd) Kill() error { f.killed = true; return nil }
+func (f *fakeKillCmd) Pid() int    { return 0 }
+
+// TestKillAfterPROpened verifies that KillAfterPROpened finds a running
+// execute session, marks it autoKilledForPROpen, kills the process, and
+// returns found=true with the session id and start time (issue #118).
+func TestKillAfterPROpened(t *testing.T) {
+	fakeCmd := &fakeKillCmd{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startedAt := time.Now().Add(-30 * time.Second)
+	m := &Manager{sessions: map[string]*runtimeSession{}, inFlight: map[string]bool{}}
+	rs := &runtimeSession{
+		sess: &types.Session{
+			ID:          "sess-pr118",
+			WorkspaceID: "ws-118",
+			IssueNumber: 118,
+			Mode:        types.ModeExecute,
+			State:       types.StateRunning,
+			StartedAt:   startedAt,
+		},
+		parser: NewStreamParser(),
+		cmd:    fakeCmd,
+		cancel: cancel,
+	}
+	m.mu.Lock()
+	m.sessions["sess-pr118"] = rs
+	m.mu.Unlock()
+
+	id, start, _, found := m.KillAfterPROpened("ws-118", 118)
+	if !found {
+		t.Fatal("KillAfterPROpened returned found=false, want true")
+	}
+	if id != "sess-pr118" {
+		t.Errorf("id = %q, want sess-pr118", id)
+	}
+	if !start.Equal(startedAt) {
+		t.Errorf("startedAt mismatch: got %v, want %v", start, startedAt)
+	}
+	if !fakeCmd.killed {
+		t.Error("expected sessionCmd.Kill() to be called")
+	}
+	rs.actMu.Lock()
+	auto := rs.autoKilledForPROpen
+	rs.actMu.Unlock()
+	if !auto {
+		t.Error("expected autoKilledForPROpen to be set to true")
+	}
+	// ctx should be cancelled by the cancel call inside KillAfterPROpened.
+	select {
+	case <-ctx.Done():
+	default:
+		t.Error("expected session context to be cancelled")
+	}
+
+	// No-op on a session with a different issue number.
+	_, _, _, found2 := m.KillAfterPROpened("ws-118", 999)
+	if found2 {
+		t.Error("KillAfterPROpened for unknown issue should return found=false")
+	}
+
+	// No-op on a plan-mode session (different issue to avoid collision with the still-registered execute session above).
+	m.mu.Lock()
+	m.sessions["sess-plan-only"] = &runtimeSession{
+		sess: &types.Session{
+			ID:          "sess-plan-only",
+			WorkspaceID: "ws-118",
+			IssueNumber: 200,
+			Mode:        types.ModePlan,
+			State:       types.StateRunning,
+		},
+		parser: NewStreamParser(),
+		cmd:    &fakeKillCmd{},
+		cancel: func() {},
+	}
+	m.mu.Unlock()
+	_, _, _, found3 := m.KillAfterPROpened("ws-118", 200)
+	if found3 {
+		t.Error("KillAfterPROpened should ignore plan sessions")
+	}
+}
+
+// TestTailAndParseAutoKillLandsOnCompleted verifies the end-to-end auto-kill
+// flow: a running execute session that receives Kill via KillAfterPROpened
+// should record terminal state Completed (not Failed) so the worktree is
+// preserved (issue #118).
+func TestTailAndParseAutoKillLandsOnCompleted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX-only")
+	}
+	tdir := t.TempDir()
+	store := &fakePersister{}
+	m := NewManager(nil, nil)
+	m.Configure(filepath.Join(tdir, "transcripts"), store, nil)
+
+	ws := types.Workspace{ID: "ws-118", RepoPath: tdir}
+	issue := types.Issue{Number: 118, WorkspaceID: ws.ID}
+
+	// Spawn a long-running execute session so tailAndParse is live.
+	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute,
+		[]string{"/bin/sh", "-c", "echo PR_OPENED: https://github.com/o/r/pull/1; sleep 10"},
+		"", "", "", types.Pool{}, "")
+	if err != nil {
+		t.Fatalf("spawnWithDir: %v", err)
+	}
+
+	// Give tailAndParse a moment to start reading.
+	time.Sleep(50 * time.Millisecond)
+
+	// Kill via the PR-opened path.
+	_, _, _, found := m.KillAfterPROpened(ws.ID, issue.Number)
+	if !found {
+		t.Fatal("KillAfterPROpened: session not found")
+	}
+
+	// Wait for tailAndParse to finish.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		m.mu.RLock()
+		_, still := m.sessions[sess.ID]
+		m.mu.RUnlock()
+		if !still {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	m.mu.RLock()
+	_, still := m.sessions[sess.ID]
+	m.mu.RUnlock()
+	if still {
+		t.Fatal("tailAndParse goroutine never exited")
+	}
+
+	// Terminal state must be completed, not failed.
+	foundCompleted := false
+	for _, upd := range store.stateUpd {
+		if upd == sess.ID+":completed" {
+			foundCompleted = true
+		}
+		if upd == sess.ID+":failed" {
+			t.Errorf("state was set to failed; auto-kill should override to completed")
+		}
+	}
+	if !foundCompleted {
+		t.Errorf("expected completed state update, got %v", store.stateUpd)
 	}
 }
 


### PR DESCRIPTION
## Summary

- When a worker emits `PR_OPENED:`, the execute session is immediately terminated to stop wasting tokens/tool time after the PR is already open.
- Session lands in `Completed` (not `Failed`) so the worktree is preserved and Continue Work can resume in-place.
- A secondary toast informs the user how long the worker ran and the estimated cost.

## Files modified

- `internal/session/manager.go` — added `autoKilledForPROpen` field to `runtimeSession`; added `KillAfterPROpened` method; `tailAndParse` overrides `StateFailed → StateCompleted` when flag is set.
- `app.go` — `handlePROpened` calls `KillAfterPROpened` after `MarkPROpened` succeeds and emits the auto-cancel toast.
- `internal/session/manager_test.go` — `TestKillAfterPROpened` (unit) and `TestTailAndParseAutoKillLandsOnCompleted` (integration, POSIX-only).

## Verification

- **Lint:** `go vet ./internal/session/... && go vet ./...` (excluding embed-only `main.go`) → pass
- **Build:** `wails build` → pass (8.3s)
- **Smoke test:** skipped — `tests/e2e/startup.spec.ts` not present in this worktree
- **Tests:** `go test ./internal/... -timeout 60s` → all packages pass; new tests `TestKillAfterPROpened` and `TestTailAndParseAutoKillLandsOnCompleted` pass

Workspace mode: per-execute worktree at /tmp/prismconductor-118-recover

Closes #118