### PR TITLE
chore(frontend): alphabetize package.json dependencies

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,11 +10,11 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@xterm/xterm": "^5.5.0",
-    "@xterm/addon-fit": "^0.10.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",


### PR DESCRIPTION
Cosmetic. `npm install` re-sorts dependencies alphabetically on every run; capturing the canonical order so future installs produce zero diffs.

No behavior change.

Spotted while debugging a user-side stale-`node_modules` issue (`@xterm/*` packages were in the lockfile but not on disk — `npm ci` fixed it locally).