### PR TITLE
fix: clear waiting_for_pool + pending_pool_for on PR merged/closed

### DIFF
--- a/app.go
+++ b/app.go
@@ -372,6 +372,20 @@ func (a *App) startup(ctx context.Context) {
 			log.Printf("reconciled %d stale running sessions to failed\n", n)
 		}
 
+		// Self-heal stuck waiting_for_pool flags + leftover
+		// pending_pool_for rows on REVIEW/DONE cards. Witnessed on #118:
+		// PR merged, card moved to DONE, but waiting_for_pool=1 + a stale
+		// pending_pool_for row from the original approve-execute enqueue
+		// stuck around → card glowed pink "waiting for available agent
+		// pool" in DONE forever. The fix in MarkPRMerged /
+		// MarkPRClosedUnmerged prevents future leaks; this reconciles
+		// any pre-fix data that's already in this state.
+		if iss, q, err := a.store.ReconcileStalePoolQueueForClosedIssues(); err != nil {
+			log.Printf("reconcile stale pool queue: %v\n", err)
+		} else if iss > 0 || q > 0 {
+			log.Printf("reconciled stale pool-queue state: cleared waiting_for_pool on %d closed/review issues, deleted %d pending_pool_for rows\n", iss, q)
+		}
+
 		// Reconcile pool registry's in-memory `active` counter against DB
 		// truth. The hand-maintained TryAcquire/Release counter leaks on
 		// any acquire-without-matching-release (witnessed: planner 1/2

--- a/internal/github/poll.go
+++ b/internal/github/poll.go
@@ -38,9 +38,16 @@ type checkStateCacheEntry struct {
 }
 
 // conflictStateCacheEntry is stored per (wsID, prNumber) to detect conflict
-// falling-edge transitions across poller ticks (issue #124).
+// falling-edge transitions across poller ticks (issue #124) AND to hold the
+// last conflict-file list so we can detect when the set of conflicting
+// files CHANGES while the PR remains in dirty state (e.g. main moves and
+// new files start conflicting). Without that diff, a PR locked in
+// `dirty` keeps the original ConflictingFiles list forever even if the
+// list is now wrong — and a binary upgrade that fixes the file-detection
+// algorithm (#167) doesn't take effect on already-dirty PRs.
 type conflictStateCacheEntry struct {
-	mergeableState string // "clean", "dirty", "blocked", "unknown", or ""
+	mergeableState string   // "clean", "dirty", "blocked", "unknown", or ""
+	files          []string // last-emitted conflicting files, sorted
 }
 
 // Poller fans out per-workspace fetches every Interval. Each tick:
@@ -426,79 +433,129 @@ func (p *Poller) probeCheckRuns(ctx context.Context, ws types.Workspace, iss typ
 	}
 }
 
-// probeConflicts checks the PR's mergeable_state and emits EvtPRConflictsDetected
-// on a falling-edge transition to "dirty" (not-dirty → dirty). Emits
-// EvtPRConflictsResolved when the state transitions back to a non-dirty value.
-// Issue #124.
+// probeConflicts checks the PR's mergeable_state and emits
+// EvtPRConflictsDetected when:
+//   - falling edge: PR transitions into dirty state, OR
+//   - PR is already dirty AND the precise conflicting-files list has
+//     changed since the last emit (main moved, conductor was upgraded,
+//     etc.)
+//
+// Emits EvtPRConflictsResolved on the recovery edge. Issue #124, plus
+// the freshness fix that prevents a stale conflict-file list from
+// being pinned forever.
 func (p *Poller) probeConflicts(ctx context.Context, ws types.Workspace, iss types.Issue, prNumber int, pr *PRState) {
 	if p.Bus == nil {
 		return
 	}
 	cacheKey := ws.ID + "#" + strconv.Itoa(prNumber)
 	prev, hasPrev := p.conflictStateCache.Load(cacheKey)
-	prevState := ""
+	var prevState string
+	var prevFiles []string
 	if hasPrev {
-		prevState = prev.(conflictStateCacheEntry).mergeableState
+		prevEntry := prev.(conflictStateCacheEntry)
+		prevState = prevEntry.mergeableState
+		prevFiles = prevEntry.files
 	}
 
-	p.conflictStateCache.Store(cacheKey, conflictStateCacheEntry{mergeableState: pr.MergeableState})
-
 	switch {
-	case pr.MergeableState == "dirty" && prevState != "dirty":
-		// Falling edge: PR became conflicted. Determine the ACTUAL
-		// conflicting files via `git merge-tree` (3-way merge simulation,
-		// no worktree mutation). The earlier implementation listed every
-		// file the PR touched — misleading because most PR files don't
-		// actually conflict. We try the local-git path first; fall back
-		// to the full PR-files API only if git is too old (< 2.38) or
-		// the local repo's refs aren't fetched.
-		var files []string
-		if ws.RepoPath != "" {
-			// Make sure base + head refs are present locally. Best effort;
-			// merge-tree errors will trip the fallback if not.
-			_, _ = pcgit.RunInDir(ws.RepoPath, "git", "fetch", "origin",
-				pr.BaseBranch+":refs/remotes/origin/"+pr.BaseBranch,
-				pr.HeadRef+":refs/remotes/origin/"+pr.HeadRef)
-			conflictFiles, mtErr := pcgit.MergeConflictFiles(
-				ws.RepoPath,
-				"origin/"+pr.BaseBranch,
-				"origin/"+pr.HeadRef,
-			)
-			if mtErr == nil {
-				files = conflictFiles
-			} else {
-				log.Printf("merge-tree %s#%d (pr %d): %v — falling back to PR file list",
-					ws.ID, iss.Number, prNumber, mtErr)
-			}
+	case pr.MergeableState == "dirty":
+		// Compute the current conflict-file list every poll. This makes
+		// the file detection RE-RUN even when the PR has been dirty for
+		// a while — needed because (a) the conflict set can change as
+		// main moves, and (b) a binary upgrade that fixes the detection
+		// algorithm (#167's switch from FetchPRFiles to git merge-tree)
+		// only takes effect on dirty PRs if the post-upgrade poll
+		// re-detects, not just on the original falling edge.
+		files := p.detectConflictFiles(ctx, ws, iss, prNumber, pr)
+
+		// Emit only when something CHANGED — falling edge into dirty,
+		// or same-dirty-state with a different file list. Avoids
+		// flooding the bus with no-op events on every 5min tick.
+		fileSetChanged := !sameStringSet(prevFiles, files)
+		fellingEdge := prevState != "dirty"
+		if fellingEdge || fileSetChanged {
+			p.Bus.Publish(eventbus.EvtPRConflictsDetected, eventbus.PRConflictsDetected{
+				WorkspaceID:      ws.ID,
+				IssueNumber:      iss.Number,
+				PRNumber:         prNumber,
+				Base:             pr.BaseBranch,
+				Head:             pr.HeadRef,
+				ConflictingFiles: files,
+			})
 		}
-		if files == nil {
-			// Fallback: list every file the PR touches. Less precise but
-			// always available regardless of git version. The Card UI
-			// should label this list as "files modified by PR" rather
-			// than "conflicting files" when this fallback fired (caller
-			// concern; not signaled in the event payload yet — TODO).
-			fallback, err := p.Client.FetchPRFiles(ctx, ws, prNumber)
-			if err != nil {
-				log.Printf("pr files %s#%d (pr %d): %v", ws.ID, iss.Number, prNumber, err)
-			}
-			files = fallback
-		}
-		p.Bus.Publish(eventbus.EvtPRConflictsDetected, eventbus.PRConflictsDetected{
-			WorkspaceID:      ws.ID,
-			IssueNumber:      iss.Number,
-			PRNumber:         prNumber,
-			Base:             pr.BaseBranch,
-			Head:             pr.HeadRef,
-			ConflictingFiles: files,
+		p.conflictStateCache.Store(cacheKey, conflictStateCacheEntry{
+			mergeableState: pr.MergeableState,
+			files:          files,
 		})
-	case pr.MergeableState != "dirty" && pr.MergeableState != "" && pr.MergeableState != "unknown" && prevState == "dirty":
+
+	case pr.MergeableState != "" && pr.MergeableState != "unknown" && prevState == "dirty":
 		// Recovery edge: conflicts cleared (clean, blocked, etc.).
 		p.Bus.Publish(eventbus.EvtPRConflictsResolved, eventbus.PRConflictsResolved{
 			WorkspaceID: ws.ID,
 			IssueNumber: iss.Number,
 			PRNumber:    prNumber,
 		})
+		p.conflictStateCache.Store(cacheKey, conflictStateCacheEntry{
+			mergeableState: pr.MergeableState,
+		})
+
+	default:
+		// Not dirty, not transitioning out of dirty — just refresh the
+		// state cache. No emit.
+		p.conflictStateCache.Store(cacheKey, conflictStateCacheEntry{
+			mergeableState: pr.MergeableState,
+		})
 	}
+}
+
+// detectConflictFiles runs the precise `git merge-tree` 3-way merge
+// simulation in the workspace's local repo and returns the conflicting
+// paths sorted alphabetically. Falls back to the GitHub PR-files API
+// (full PR changeset, less precise) when the local-git path errors —
+// e.g. git too old, or the workspace doesn't have a RepoPath.
+func (p *Poller) detectConflictFiles(ctx context.Context, ws types.Workspace, iss types.Issue, prNumber int, pr *PRState) []string {
+	var files []string
+	if ws.RepoPath != "" {
+		_, _ = pcgit.RunInDir(ws.RepoPath, "git", "fetch", "origin",
+			pr.BaseBranch+":refs/remotes/origin/"+pr.BaseBranch,
+			pr.HeadRef+":refs/remotes/origin/"+pr.HeadRef)
+		conflictFiles, mtErr := pcgit.MergeConflictFiles(
+			ws.RepoPath,
+			"origin/"+pr.BaseBranch,
+			"origin/"+pr.HeadRef,
+		)
+		if mtErr == nil {
+			files = conflictFiles
+		} else {
+			log.Printf("merge-tree %s#%d (pr %d): %v — falling back to PR file list",
+				ws.ID, iss.Number, prNumber, mtErr)
+		}
+	}
+	if files == nil {
+		fallback, err := p.Client.FetchPRFiles(ctx, ws, prNumber)
+		if err != nil {
+			log.Printf("pr files %s#%d (pr %d): %v", ws.ID, iss.Number, prNumber, err)
+		}
+		files = fallback
+	}
+	sort.Strings(files)
+	return files
+}
+
+// sameStringSet reports whether two []string slices contain the same
+// elements regardless of order. Both inputs must already be sorted for
+// the simple slice-compare; detectConflictFiles sorts before storing
+// in the cache so this is the cheap path.
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func sameLabels(a, b []string) bool {

--- a/internal/store/issues.go
+++ b/internal/store/issues.go
@@ -471,6 +471,45 @@ func (s *Store) RemoveIssue(workspaceID string, number int) error {
 	return err
 }
 
+// ReconcileStalePoolQueueForClosedIssues clears `waiting_for_pool` and
+// removes `pending_pool_for` rows for any issue whose card is in REVIEW
+// (PR open) or DONE (PR merged/closed). A queued spawn for an issue
+// whose work has already shipped (or whose PR was rejected) is by
+// definition moot; leaving the row + flag around makes the card glow
+// pink "waiting for available agent pool" forever in DONE. Witnessed
+// live on #118 (DONE column, PR #166 closed/merged, but
+// waiting_for_pool=1 + a stale pending_pool_for row from the original
+// approve-execute enqueue).
+//
+// Returns (issuesFixed, queueRowsDeleted).
+func (s *Store) ReconcileStalePoolQueueForClosedIssues() (int, int, error) {
+	if s == nil || s.DB == nil {
+		return 0, 0, errors.New("store unavailable")
+	}
+	res1, err := s.DB.Exec(`
+UPDATE issues
+   SET json = json_set(json, '$.waiting_for_pool', json('false'))
+ WHERE column_name IN ('review','done')
+   AND json_extract(json, '$.waiting_for_pool') = 1`)
+	if err != nil {
+		return 0, 0, err
+	}
+	issuesFixed, _ := res1.RowsAffected()
+	res2, err := s.DB.Exec(`
+DELETE FROM pending_pool_for
+ WHERE EXISTS (
+   SELECT 1 FROM issues
+    WHERE issues.workspace_id = pending_pool_for.workspace_id
+      AND issues.number       = pending_pool_for.issue_number
+      AND issues.column_name IN ('review','done')
+ )`)
+	if err != nil {
+		return int(issuesFixed), 0, err
+	}
+	queueRowsDeleted, _ := res2.RowsAffected()
+	return int(issuesFixed), int(queueRowsDeleted), nil
+}
+
 // ReconcileStaleRunningSessions marks any session row whose state is still
 // `running` or `waiting_for_input` but whose corresponding issue is in
 // REVIEW (PR open) or DONE (PR merged) as failed. Self-healing pass for
@@ -660,6 +699,12 @@ func (s *Store) MarkPRMerged(workspaceID string, number int) error {
 	iss.State = "closed"
 	iss.Column = types.ColDone
 	iss.LastError = ""
+	// PR is merged → any queued pool spawn for this issue is now moot. Clear
+	// the conductor-owned waiting_for_pool flag in the JSON we're about to
+	// write (avoids the SaveIssue preservation rule by going through the
+	// raw blob marshal path). The matching pending_pool_for row gets
+	// deleted below in the same transaction.
+	iss.WaitingForPool = false
 
 	var newClosedAt any
 	if existingClosedAt.Valid {
@@ -684,6 +729,16 @@ func (s *Store) MarkPRMerged(workspaceID string, number int) error {
 	if _, err := tx.Exec(
 		`UPDATE issues SET column_name = ?, manual_order = ?, json = ?, closed_at = ? WHERE workspace_id = ? AND number = ?`,
 		string(types.ColDone), maxOrder.Int64+1, string(b), newClosedAt, workspaceID, number,
+	); err != nil {
+		return err
+	}
+	// Reap any leftover pool-queue rows. Witnessed leak: PR for #118
+	// merged, card moved to DONE, but a stale `pending_pool_for` row from
+	// the original approve-execute enqueue stuck around AND
+	// json.waiting_for_pool stayed true → card glowed pink in DONE forever.
+	if _, err := tx.Exec(
+		`DELETE FROM pending_pool_for WHERE workspace_id = ? AND issue_number = ?`,
+		workspaceID, number,
 	); err != nil {
 		return err
 	}
@@ -716,10 +771,19 @@ func (s *Store) MarkPRClosedUnmerged(workspaceID string, number int) error {
 	}
 	iss.PRNumber = nil
 	iss.PRURL = ""
+	// PR closed without merging → any queued pool spawn is moot. Same
+	// reaping as MarkPRMerged.
+	iss.WaitingForPool = false
 	b, _ := json.Marshal(iss)
 	if _, err := tx.Exec(
 		`UPDATE issues SET json = ? WHERE workspace_id = ? AND number = ?`,
 		string(b), workspaceID, number,
+	); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		`DELETE FROM pending_pool_for WHERE workspace_id = ? AND issue_number = ?`,
+		workspaceID, number,
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Card #118 (DONE column, PR #166 closed) glowed pink "waiting for available agent pool" forever. DB showed `waiting_for_pool=1` AND a stale `pending_pool_for` row from the original approve-execute enqueue that was never reaped.

## Root cause

`MarkPRMerged` and `MarkPRClosedUnmerged` moved the card to DONE / cleared PR fields but did NOT touch:
- `json.waiting_for_pool` — conductor-owned flag set when an approve-execute hit a saturated pool
- `pending_pool_for` table row — the durable queue entry from the same enqueue

Once a card reaches DONE, the orchestrator's drain skips it (already past queue point). Nothing else touched those fields → the card stayed painted pink forever.

## Fix

**Two layers:**

1. **`MarkPRMerged` / `MarkPRClosedUnmerged`** now reap pool-queue state in the same transaction that moves the card / clears PR fields:
   - Set `iss.WaitingForPool = false` in the JSON write
   - `DELETE FROM pending_pool_for WHERE workspace_id=? AND issue_number=?`

2. **Startup reconciler** `Store.ReconcileStalePoolQueueForClosedIssues` runs after the existing reconciles in `app.go` startup. Clears `waiting_for_pool` on every REVIEW/DONE issue that has it set; deletes `pending_pool_for` rows whose owning issue is in REVIEW/DONE. Heals pre-fix data already in the leaked state.

## Live mitigation

Patched #118's stuck row in the running DB so the pink glow clears immediately.

## Test plan
- [ ] Restart conductor → reconciler logs how many rows it cleaned up
- [ ] Approve a plan when work pool is saturated → `waiting_for_pool=true`, `pending_pool_for` row exists. Slot frees, drain spawns, PR opens, PR merges → both fields/rows cleared

## Related
- #150 — atomic SetIssueWaitingForPool (the clear path that didn't run because the merge handler bypassed it)
- #151 — stale running session reconciler (same family of REVIEW/DONE state cleanup)