### PR TITLE
fix(agentterm): set subprocess cwd to workspace.RepoPath

### DIFF
--- a/app.go
+++ b/app.go
@@ -3610,11 +3610,29 @@ func (a *App) ListAvailableAgents() []types.AgentInfo {
 
 // StartAgentSession spawns an ephemeral PTY-backed agent for the workspace.
 // Any existing session for that workspace is killed first.
+//
+// Resolves the workspace's RepoPath as the subprocess cwd. Without this,
+// the agent inherits the conductor's own cwd (on macOS Wails: typically
+// `/` because Finder-launched .app bundles start there), so `claude` /
+// `aider` / etc. open with `pwd` pointing at the wrong directory and
+// can't see the user's repo until they manually `cd`. We refuse to spawn
+// without a resolvable workspace — the agent panel is workspace-scoped.
 func (a *App) StartAgentSession(workspaceID, agentBin string, args []string, cols, rows uint16) (*types.AgentTermSession, error) {
 	if a.agentTerm == nil {
 		return nil, fmt.Errorf("agent terminal manager unavailable")
 	}
-	pid, err := a.agentTerm.Start(workspaceID, agentBin, args, cols, rows)
+	if a.wsReg == nil {
+		return nil, fmt.Errorf("workspace registry unavailable")
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return nil, fmt.Errorf("unknown workspace %q", workspaceID)
+	}
+	cwd := ws.RepoPath
+	if cwd == "" {
+		return nil, fmt.Errorf("workspace %q has no repo_path configured", workspaceID)
+	}
+	pid, err := a.agentTerm.Start(workspaceID, agentBin, args, cwd, cols, rows)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agentterm/agentterm.go
+++ b/internal/agentterm/agentterm.go
@@ -61,7 +61,15 @@ func New(onData DataHandler, onExit ExitHandler) *Manager {
 
 // Start spawns a PTY-backed subprocess for workspaceID, killing any existing
 // session first. Returns the child PID.
-func (m *Manager) Start(workspaceID, bin string, args []string, cols, rows uint16) (int, error) {
+//
+// cwd is the working directory the subprocess inherits — almost always the
+// workspace's RepoPath. When empty, the subprocess inherits the conductor's
+// own cwd (which on macOS Wails is typically `/` because the app bundle
+// launches from Finder); that produced a real bug where `claude`, `aider`,
+// etc. opened with `pwd` pointing at the wrong directory and couldn't see
+// the user's repo until they manually `cd`'d. Always pass the workspace
+// RepoPath from app.go's StartAgentSession.
+func (m *Manager) Start(workspaceID, bin string, args []string, cwd string, cols, rows uint16) (int, error) {
 	m.mu.Lock()
 	old, hadOld := m.sessions[workspaceID]
 	if hadOld {
@@ -75,6 +83,9 @@ func (m *Manager) Start(workspaceID, bin string, args []string, cols, rows uint1
 
 	cmd := exec.Command(bin, args...)
 	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
 
 	ptmx, err := pty.Start(cmd)
 	if err != nil {

--- a/internal/agentterm/manager_test.go
+++ b/internal/agentterm/manager_test.go
@@ -36,7 +36,7 @@ func TestManagerStartAndOutput(t *testing.T) {
 		nil,
 	)
 
-	pid, err := mgr.Start("ws1", "echo", []string{"hello"}, 80, 24)
+	pid, err := mgr.Start("ws1", "echo", []string{"hello"}, "", 80, 24)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestManagerExitCallback(t *testing.T) {
 		func(_ string, code int) { done <- code },
 	)
 
-	if _, err := mgr.Start("ws2", "true", nil, 80, 24); err != nil {
+	if _, err := mgr.Start("ws2", "true", nil, "", 80, 24); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 
@@ -111,7 +111,7 @@ func TestManagerResizeNoSession(t *testing.T) {
 func TestManagerKill(t *testing.T) {
 	mgr := agentterm.New(nil, nil)
 
-	if _, err := mgr.Start("ws3", "cat", nil, 80, 24); err != nil {
+	if _, err := mgr.Start("ws3", "cat", nil, "", 80, 24); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	if !mgr.HasSession("ws3") {
@@ -130,4 +130,66 @@ func TestManagerKill(t *testing.T) {
 func TestAgentInfoShape(_ *testing.T) {
 	_ = types.AgentInfo{Name: "claude", Binary: "/usr/local/bin/claude"}
 	_ = types.AgentTermSession{WorkspaceID: "ws1", SessionID: "s1", AgentBin: "claude", PID: 123}
+}
+
+// TestStartUsesCwd verifies the spawned subprocess inherits the requested
+// cwd. Pre-fix bug: the agent inherited the conductor's own cwd (on
+// macOS Wails: typically `/`) so `claude`/`aider` opened with `pwd`
+// pointing at the wrong place. The fix threads workspace.RepoPath
+// through Start as the cwd argument; this test pins that contract.
+func TestStartUsesCwd(t *testing.T) {
+	tmp := t.TempDir()
+	var mu sync.Mutex
+	var received []byte
+	mgr := agentterm.New(
+		func(_ string, dataB64 string) {
+			data, _ := base64.StdEncoding.DecodeString(dataB64)
+			mu.Lock()
+			received = append(received, data...)
+			mu.Unlock()
+		},
+		nil,
+	)
+
+	// `pwd` prints the cwd to stdout. If Start ignored cwd the output
+	// would be the test runner's directory, not tmp.
+	if _, err := mgr.Start("ws-cwd", "pwd", nil, tmp, 80, 24); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(received)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	mu.Lock()
+	got := string(received)
+	mu.Unlock()
+
+	// On macOS the resolved tmp path is under /private/var/folders even
+	// though `t.TempDir()` returns /var/folders/...; tolerate both.
+	if got == "" {
+		t.Fatal("expected pwd output, got none")
+	}
+	wantSuffix := tmp[len("/private"):]
+	if !contains(got, tmp) && !contains(got, wantSuffix) {
+		t.Errorf("pwd output = %q, want it to contain %q", got, tmp)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (func() bool {
+		for i := 0; i+len(needle) <= len(haystack); i++ {
+			if haystack[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	}())
 }


### PR DESCRIPTION
## Summary

Embedded agent terminal panel spawned the agent (`claude`, `aider`, etc.) with cwd inherited from the conductor process — which on macOS Wails is typically `/` because Finder-launched .app bundles start there. The agent's `pwd` returned the wrong directory and it couldn't see the workspace's repo until the user manually `cd`'d.

## Fix

- `agentterm.Manager.Start` takes a new `cwd string` parameter. Sets `cmd.Dir = cwd` before `pty.Start` when non-empty.
- `app.go` `StartAgentSession` resolves the workspace via `wsReg.Get(workspaceID)`, refuses to spawn if the workspace is unknown or has no `RepoPath` configured, and passes the resolved path through. Replaces silent fall-through behavior with a real error.

## Tests

- Updated existing tests to pass an empty cwd (preserves prior inherited-cwd behavior for the test runner).
- New `TestStartUsesCwd`: spawns `pwd` with `cwd=tmpdir`, verifies the PTY output contains tmpdir. Locks down the contract.

`go test ./...` clean.

## Test plan
- [ ] Open the agent terminal panel for a workspace, run `pwd` — output is the workspace's repo path
- [ ] Open the panel for a workspace with empty `RepoPath` — error toast `workspace "X" has no repo_path configured`, no spawn
- [ ] Open the panel for an unknown workspace ID — error toast `unknown workspace "X"`, no spawn

## Related
- #161 — original embedded agent terminal feature this fixes