### PR TITLE
feat(store): versioned migration framework, backups, JSON round-trip preservation (#172)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: go test
         run: go test ./...
+        # includes internal/store migration framework tests and v0-baseline
+        # fixture tests (internal/store/migrations_test.go)
 
       - name: typecheck frontend
         working-directory: frontend

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -1,0 +1,75 @@
+# PrismConductor DB Recovery Guide
+
+## Pre-migration backups
+
+Before applying any pending schema migrations, PrismConductor automatically
+copies `conductor.db` to a timestamped backup file in the same directory:
+
+```
+conductor.db.pre-20250504T123456Z.bak
+conductor.db.pre-20250503T091000Z.bak
+conductor.db.pre-20250502T080000Z.bak
+```
+
+By default the three most recent backups are retained; older ones are removed.
+
+## When you need to restore
+
+**Scenario A: Migration failed mid-apply**
+
+The migration runner wraps each migration in a transaction, so a partial
+migration leaves the DB unchanged. Restore is still available if something
+went wrong before the migration started:
+
+```sh
+# Quit PrismConductor first, then:
+cp conductor.db conductor.db.broken
+cp conductor.db.pre-<most-recent-timestamp>.bak conductor.db
+```
+
+Restart PrismConductor. If the migration error persists, file an issue at
+https://github.com/darkshade9/prismconductor/issues.
+
+**Scenario B: Downgrade — newer binary wrote the DB**
+
+If you see this error at startup:
+
+```
+conductor.db schema version "20251201_01_..." is newer than this binary (max known: "20250504_00_...")
+```
+
+…it means `conductor.db` was last opened by a newer version of PrismConductor
+than the one you are running now. Options:
+
+1. **Upgrade**: install the latest PrismConductor release.
+2. **Restore from backup**: copy the most recent `.bak` file written by the
+   older binary (i.e., the last backup whose timestamp predates the upgrade)
+   over `conductor.db`.
+
+```sh
+cp conductor.db.pre-<timestamp-before-upgrade>.bak conductor.db
+```
+
+3. **Fresh start**: rename or delete `conductor.db`. You will lose local board
+   state but the GitHub issues will re-sync on next startup.
+
+## Finding your data directory
+
+The data directory containing `conductor.db` is shown at startup in the logs
+(`store: open …`). On macOS it is typically:
+
+```
+~/Library/Application Support/PrismConductor/
+```
+
+On Linux:
+
+```
+~/.local/share/PrismConductor/
+```
+
+## Backup location and rotation
+
+Backups live in the same directory as `conductor.db`. The default retention is
+3 backups. To keep more, set the `PRISMCONDUCTOR_BACKUP_KEEP` environment
+variable before launching (not yet wired; tracked in a future issue).

--- a/internal/store/backup.go
+++ b/internal/store/backup.go
@@ -1,0 +1,77 @@
+package store
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// createBackup copies src to <dir>/conductor.db.pre-<ts>.bak and rotates
+// old backup files so that at most keep copies are retained.
+// src must be an existing regular file; if not, this is a no-op.
+func createBackup(src string, keep int) error {
+	if _, err := os.Stat(src); os.IsNotExist(err) {
+		return nil
+	}
+
+	dir := filepath.Dir(src)
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	dst := filepath.Join(dir, fmt.Sprintf("conductor.db.pre-%s.bak", ts))
+
+	if err := copyFile(src, dst); err != nil {
+		return fmt.Errorf("backup %s → %s: %w", src, dst, err)
+	}
+
+	return rotateBackups(dir, keep)
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.CreateTemp(filepath.Dir(dst), ".backup-*")
+	if err != nil {
+		return err
+	}
+	tmp := out.Name()
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, dst)
+}
+
+// rotateBackups removes the oldest conductor.db.pre-*.bak files beyond keep.
+func rotateBackups(dir string, keep int) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	var backups []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), "conductor.db.pre-") && strings.HasSuffix(e.Name(), ".bak") {
+			backups = append(backups, filepath.Join(dir, e.Name()))
+		}
+	}
+	sort.Strings(backups) // lexicographic = chronological for our timestamp format
+	for len(backups) > keep {
+		if err := os.Remove(backups[0]); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		backups = backups[1:]
+	}
+	return nil
+}

--- a/internal/store/goals.go
+++ b/internal/store/goals.go
@@ -2,9 +2,9 @@ package store
 
 import (
 	"database/sql"
-	"encoding/json"
 	"errors"
 
+	"prismconductor/internal/store/jsonutil"
 	"prismconductor/internal/types"
 )
 
@@ -13,7 +13,7 @@ func (s *Store) SaveGoal(g types.Goal) error {
 	if s == nil || s.DB == nil {
 		return errors.New("store unavailable")
 	}
-	b, err := json.Marshal(g)
+	b, err := jsonutil.Save(nil, g)
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func (s *Store) GetGoal(id string) (types.Goal, error) {
 		return types.Goal{}, err
 	}
 	var g types.Goal
-	if err := json.Unmarshal([]byte(raw), &g); err != nil {
+	if _, err := jsonutil.Load([]byte(raw), &g); err != nil {
 		return types.Goal{}, err
 	}
 	return g, nil
@@ -68,7 +68,7 @@ END, "order" ASC`)
 			return nil, err
 		}
 		var g types.Goal
-		if err := json.Unmarshal([]byte(raw), &g); err != nil {
+		if _, err := jsonutil.Load([]byte(raw), &g); err != nil {
 			continue
 		}
 		out = append(out, g)
@@ -146,9 +146,9 @@ func bumpStatusJSON(tx *sql.Tx, from, to string) error {
 	rows.Close()
 	for _, r := range batch {
 		var g types.Goal
-		_ = json.Unmarshal([]byte(r.raw), &g)
+		rawMap, _ := jsonutil.Load([]byte(r.raw), &g)
 		g.Status = types.GoalStatus(to)
-		b, _ := json.Marshal(g)
+		b, _ := jsonutil.Save(rawMap, g)
 		if _, err := tx.Exec(`UPDATE goals SET status = ?, json = ? WHERE id = ?`, to, string(b), r.id); err != nil {
 			return err
 		}
@@ -162,12 +162,13 @@ func setGoalStatus(tx *sql.Tx, id, status string) error {
 		return err
 	}
 	var g types.Goal
-	if err := json.Unmarshal([]byte(raw), &g); err != nil {
+	rawMap, err := jsonutil.Load([]byte(raw), &g)
+	if err != nil {
 		return err
 	}
 	g.Status = types.GoalStatus(status)
-	b, _ := json.Marshal(g)
-	_, err := tx.Exec(`UPDATE goals SET status = ?, json = ? WHERE id = ?`, status, string(b), id)
+	b, _ := jsonutil.Save(rawMap, g)
+	_, err = tx.Exec(`UPDATE goals SET status = ?, json = ? WHERE id = ?`, status, string(b), id)
 	return err
 }
 

--- a/internal/store/issues.go
+++ b/internal/store/issues.go
@@ -2,10 +2,10 @@ package store
 
 import (
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"time"
 
+	"prismconductor/internal/store/jsonutil"
 	"prismconductor/internal/types"
 )
 
@@ -24,7 +24,7 @@ func (s *Store) LoadIssue(workspaceID string, number int) (types.Issue, error) {
 		return types.Issue{}, err
 	}
 	var iss types.Issue
-	if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+	if _, err := jsonutil.Load([]byte(raw), &iss); err != nil {
 		return types.Issue{}, err
 	}
 	iss.Column = types.BoardColumn(col)
@@ -63,9 +63,12 @@ func (s *Store) SaveIssue(iss types.Issue) (bool, error) {
 	if existingCol.Valid {
 		col = types.BoardColumn(existingCol.String)
 	}
+	var rawMap map[string]any
 	if existingJSON.Valid {
 		var prev types.Issue
-		if err := json.Unmarshal([]byte(existingJSON.String), &prev); err == nil {
+		var err error
+		rawMap, err = jsonutil.Load([]byte(existingJSON.String), &prev)
+		if err == nil {
 			if prev.PRNumber != nil {
 				iss.PRNumber = prev.PRNumber
 			}
@@ -138,7 +141,7 @@ func (s *Store) SaveIssue(iss types.Issue) (bool, error) {
 		iss.ClosedAt = nil
 	}
 
-	b, err := json.Marshal(iss)
+	b, err := jsonutil.Save(rawMap, iss)
 	if err != nil {
 		return false, err
 	}
@@ -191,7 +194,7 @@ func (s *Store) ListIssues(workspaceID string) ([]types.Issue, error) {
 			return nil, err
 		}
 		var iss types.Issue
-		if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+		if _, err := jsonutil.Load([]byte(raw), &iss); err != nil {
 			continue
 		}
 		iss.Column = types.BoardColumn(col)
@@ -234,7 +237,7 @@ func (s *Store) ListArchivedIssues(workspaceID string) ([]types.Issue, error) {
 			return nil, err
 		}
 		var iss types.Issue
-		if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+		if _, err := jsonutil.Load([]byte(raw), &iss); err != nil {
 			continue
 		}
 		iss.Column = types.BoardColumn(col)
@@ -355,9 +358,9 @@ func (s *Store) MoveIssueColumn(workspaceID string, number int, column types.Boa
 	var raw string
 	if err := tx.QueryRow(`SELECT json FROM issues WHERE workspace_id = ? AND number = ?`, workspaceID, number).Scan(&raw); err == nil {
 		var iss types.Issue
-		if err := json.Unmarshal([]byte(raw), &iss); err == nil {
+		if rawMap, err := jsonutil.Load([]byte(raw), &iss); err == nil {
 			iss.Column = column
-			b, _ := json.Marshal(iss)
+			b, _ := jsonutil.Save(rawMap, iss)
 			_, _ = tx.Exec(`UPDATE issues SET json = ? WHERE workspace_id = ? AND number = ?`, string(b), workspaceID, number)
 		}
 	}
@@ -407,7 +410,8 @@ func (s *Store) AccumulateIssueWork(workspaceID string, number int, mode types.S
 		return err
 	}
 	var iss types.Issue
-	if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+	rawMap, err := jsonutil.Load([]byte(raw), &iss)
+	if err != nil {
 		return err
 	}
 	iss.WorkSeconds += seconds
@@ -417,7 +421,7 @@ func (s *Store) AccumulateIssueWork(workspaceID string, number int, mode types.S
 	case types.ModeExecute:
 		iss.WorkSecondsExecute += seconds
 	}
-	b, err := json.Marshal(iss)
+	b, err := jsonutil.Save(rawMap, iss)
 	if err != nil {
 		return err
 	}
@@ -448,11 +452,12 @@ func (s *Store) AccumulateIssueCost(workspaceID string, number int, costUSD floa
 		return err
 	}
 	var iss types.Issue
-	if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+	rawMap, err := jsonutil.Load([]byte(raw), &iss)
+	if err != nil {
 		return err
 	}
 	iss.CostUSD += costUSD
-	b, err := json.Marshal(iss)
+	b, err := jsonutil.Save(rawMap, iss)
 	if err != nil {
 		return err
 	}
@@ -568,7 +573,7 @@ func (s *Store) ReconcileClosedIssues() (int, error) {
 			return 0, err
 		}
 		var iss types.Issue
-		if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+		if _, err := jsonutil.Load([]byte(raw), &iss); err != nil {
 			continue
 		}
 		if iss.State == "closed" {
@@ -604,14 +609,15 @@ func (s *Store) MarkPROpened(workspaceID string, number int, prNumber int, prURL
 		return err
 	}
 	var iss types.Issue
-	if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+	rawMap, err := jsonutil.Load([]byte(raw), &iss)
+	if err != nil {
 		return err
 	}
 	iss.PRNumber = &prNumber
 	iss.PRURL = prURL
 	iss.Column = types.ColReview
 	iss.NeedsPRInfo = nil // clear the NEEDS_PR badge now that a PR is attached
-	b, _ := json.Marshal(iss)
+	b, _ := jsonutil.Save(rawMap, iss)
 
 	var maxOrder sql.NullInt64
 	if err := tx.QueryRow(
@@ -648,12 +654,13 @@ func (s *Store) MarkNeedsPR(workspaceID string, number int, info types.NeedsPRIn
 		return err
 	}
 	var iss types.Issue
-	if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+	rawMap, err := jsonutil.Load([]byte(raw), &iss)
+	if err != nil {
 		return err
 	}
 	iss.NeedsPRInfo = &info
 	iss.Column = types.ColReview
-	b, _ := json.Marshal(iss)
+	b, _ := jsonutil.Save(rawMap, iss)
 
 	var maxOrder sql.NullInt64
 	if err := tx.QueryRow(
@@ -693,7 +700,8 @@ func (s *Store) MarkPRMerged(workspaceID string, number int) error {
 		return err
 	}
 	var iss types.Issue
-	if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+	rawMap, err := jsonutil.Load([]byte(raw), &iss)
+	if err != nil {
 		return err
 	}
 	iss.State = "closed"
@@ -717,7 +725,7 @@ func (s *Store) MarkPRMerged(workspaceID string, number int) error {
 		iss.ClosedAt = &now
 	}
 
-	b, _ := json.Marshal(iss)
+	b, _ := jsonutil.Save(rawMap, iss)
 
 	var maxOrder sql.NullInt64
 	if err := tx.QueryRow(
@@ -766,7 +774,8 @@ func (s *Store) MarkPRClosedUnmerged(workspaceID string, number int) error {
 		return err
 	}
 	var iss types.Issue
-	if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+	rawMap, err := jsonutil.Load([]byte(raw), &iss)
+	if err != nil {
 		return err
 	}
 	iss.PRNumber = nil
@@ -774,7 +783,7 @@ func (s *Store) MarkPRClosedUnmerged(workspaceID string, number int) error {
 	// PR closed without merging → any queued pool spawn is moot. Same
 	// reaping as MarkPRMerged.
 	iss.WaitingForPool = false
-	b, _ := json.Marshal(iss)
+	b, _ := jsonutil.Save(rawMap, iss)
 	if _, err := tx.Exec(
 		`UPDATE issues SET json = ? WHERE workspace_id = ? AND number = ?`,
 		string(b), workspaceID, number,
@@ -817,7 +826,8 @@ func (s *Store) MarkIssueClosed(workspaceID string, number int) error {
 		return nil
 	}
 	var iss types.Issue
-	if err := json.Unmarshal([]byte(raw), &iss); err != nil {
+	rawMap, err := jsonutil.Load([]byte(raw), &iss)
+	if err != nil {
 		return err
 	}
 	iss.State = "closed"
@@ -835,7 +845,7 @@ func (s *Store) MarkIssueClosed(workspaceID string, number int) error {
 		iss.ClosedAt = &now
 	}
 
-	b, _ := json.Marshal(iss)
+	b, _ := jsonutil.Save(rawMap, iss)
 	if _, err := tx.Exec(
 		`UPDATE issues SET column_name = ?, json = ?, closed_at = ? WHERE workspace_id = ? AND number = ?`,
 		string(types.ColDone), string(b), newClosedAt, workspaceID, number,

--- a/internal/store/jsonutil/passthrough.go
+++ b/internal/store/jsonutil/passthrough.go
@@ -1,0 +1,104 @@
+// Package jsonutil provides a round-trip-preserving JSON helper for the store layer.
+// It keeps unknown fields from a newer-binary-written row alive when an older binary
+// reads and re-saves the same row, preventing downgrade-induced field loss.
+package jsonutil
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+)
+
+// Load decodes raw into v and returns the original decoded map so unknown fields
+// survive a future Save call. Errors from either decode are returned.
+func Load(raw []byte, v any) (map[string]any, error) {
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(raw, v); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// Save marshals v and merges unknown fields from prior (the map returned by a
+// previous Load call) onto the marshaled result. "Unknown" means a key present
+// in prior that does not belong to v's struct schema (i.e., it was written by a
+// newer binary and the current struct definition doesn't have that field yet).
+//
+// Known struct fields that were intentionally cleared (zero / nil with omitempty)
+// are NOT restored from prior — the struct's marshaled form is authoritative for
+// all fields the struct knows about.
+//
+// If prior is nil, Save falls back to plain json.Marshal(v).
+func Save(prior map[string]any, v any) ([]byte, error) {
+	if prior == nil {
+		return json.Marshal(v)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var typed map[string]any
+	if err := json.Unmarshal(b, &typed); err != nil {
+		return nil, err
+	}
+
+	// Determine which keys belong to v's struct schema (known fields).
+	// Only preserve prior keys that are NOT in the schema (future/unknown fields).
+	schema := structJSONKeys(v)
+	for k, val := range prior {
+		if _, inSchema := schema[k]; !inSchema {
+			// Unknown future field — preserve it only if the current binary
+			// didn't write a value for it.
+			if _, inTyped := typed[k]; !inTyped {
+				typed[k] = val
+			}
+		}
+		// Known schema key absent from typed = intentionally zeroed; do not restore.
+	}
+	return json.Marshal(typed)
+}
+
+// structJSONKeys returns the set of JSON key names for v's struct type,
+// following embedded structs. Only works for struct types; returns empty map otherwise.
+func structJSONKeys(v any) map[string]struct{} {
+	t := reflect.TypeOf(v)
+	if t == nil {
+		return nil
+	}
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+	keys := make(map[string]struct{})
+	collectKeys(t, keys)
+	return keys
+}
+
+func collectKeys(t reflect.Type, out map[string]struct{}) {
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		tag := f.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" {
+			name = f.Name
+		}
+		ft := f.Type
+		for ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+		// Inline anonymous (embedded) structs.
+		if f.Anonymous && ft.Kind() == reflect.Struct {
+			collectKeys(ft, out)
+			continue
+		}
+		out[name] = struct{}{}
+	}
+}

--- a/internal/store/migrations/migration.go
+++ b/internal/store/migrations/migration.go
@@ -1,0 +1,13 @@
+// Package migrations defines the versioned migration framework for conductor.db.
+// Migration IDs sort lexicographically in application order (YYYYMMDD_NN_desc).
+package migrations
+
+import "database/sql"
+
+// Migration is one unit of schema change. Either SQL or Up (or both) must be set.
+type Migration struct {
+	ID          string
+	Description string
+	SQL         string               // executed verbatim inside a transaction if non-empty
+	Up          func(*sql.Tx) error  // called inside the same transaction after SQL
+}

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -1,0 +1,24 @@
+package migrations
+
+// all is the ordered list of every migration this binary knows about.
+// IDs must be lexicographically ordered (YYYYMMDD_NN_description).
+// Never remove or reorder entries; only append.
+var all = []Migration{
+	{
+		ID:          "20250504_00_initial_migration_framework",
+		Description: "baseline: record all pre-framework schema (created by legacy migrate()) as applied",
+		// No SQL/Up — the schema already exists via the legacy migrate() call.
+		// Recording this entry means any future binary can detect a downgrade.
+	},
+}
+
+// All returns every known migration in application order.
+func All() []Migration { return all }
+
+// MaxID returns the highest known migration ID (the binary's schema level).
+func MaxID() string {
+	if len(all) == 0 {
+		return ""
+	}
+	return all[len(all)-1].ID
+}

--- a/internal/store/migrations/runner.go
+++ b/internal/store/migrations/runner.go
@@ -1,0 +1,113 @@
+package migrations
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+const createSchemamigrations = `
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    id         TEXT    PRIMARY KEY,
+    applied_at INTEGER NOT NULL
+);`
+
+// HasPending reports whether any registered migration has not yet been applied.
+// Returns true whenever schema_migrations does not exist (fresh or pre-framework DB).
+func HasPending(db *sql.DB) bool {
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM schema_migrations").Scan(&count); err != nil {
+		return true // table doesn't exist → migrations pending
+	}
+	for _, m := range All() {
+		var exists int
+		_ = db.QueryRow("SELECT COUNT(*) FROM schema_migrations WHERE id = ?", m.ID).Scan(&exists)
+		if exists == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckVersion reads the schema_version from the settings table and returns an
+// error if the DB was written by a newer binary than the current one.
+// Returns nil if schema_version is absent (pre-framework DB).
+func CheckVersion(db *sql.DB) error {
+	var version string
+	err := db.QueryRow("SELECT value FROM settings WHERE key = 'schema_version'").Scan(&version)
+	if err != nil {
+		return nil // missing = pre-framework DB, always acceptable
+	}
+	max := MaxID()
+	if max == "" {
+		return nil
+	}
+	if version > max {
+		return fmt.Errorf(
+			"conductor.db schema version %q is newer than this binary (max known: %q);\n"+
+				"upgrade PrismConductor to at least the version that introduced %q,\n"+
+				"or restore from a backup created before the upgrade (see RECOVERY.md)",
+			version, max, version,
+		)
+	}
+	return nil
+}
+
+// Run creates the schema_migrations table if absent, applies any pending
+// migrations in lexicographic order, and stamps schema_version in settings.
+func Run(db *sql.DB) error {
+	if _, err := db.Exec(createSchemamigrations); err != nil {
+		return fmt.Errorf("create schema_migrations: %w", err)
+	}
+
+	for _, m := range All() {
+		var exists int
+		_ = db.QueryRow("SELECT COUNT(*) FROM schema_migrations WHERE id = ?", m.ID).Scan(&exists)
+		if exists > 0 {
+			continue
+		}
+
+		tx, err := db.Begin()
+		if err != nil {
+			return fmt.Errorf("migration %s: begin: %w", m.ID, err)
+		}
+
+		if m.SQL != "" {
+			if _, err := tx.Exec(m.SQL); err != nil {
+				_ = tx.Rollback()
+				return fmt.Errorf("migration %s: sql: %w", m.ID, err)
+			}
+		}
+		if m.Up != nil {
+			if err := m.Up(tx); err != nil {
+				_ = tx.Rollback()
+				return fmt.Errorf("migration %s: up: %w", m.ID, err)
+			}
+		}
+
+		if _, err := tx.Exec(
+			"INSERT INTO schema_migrations (id, applied_at) VALUES (?, ?)",
+			m.ID, time.Now().Unix(),
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("migration %s: record: %w", m.ID, err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("migration %s: commit: %w", m.ID, err)
+		}
+	}
+
+	// Stamp the DB with the highest applied migration ID.
+	maxID := MaxID()
+	if maxID != "" {
+		_, err := db.Exec(
+			"INSERT INTO settings (key, value) VALUES ('schema_version', ?) "+
+				"ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+			maxID,
+		)
+		if err != nil {
+			return fmt.Errorf("stamp schema_version: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/store/migrations_test.go
+++ b/internal/store/migrations_test.go
@@ -1,0 +1,258 @@
+package store
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"prismconductor/internal/store/migrations"
+
+	_ "modernc.org/sqlite"
+)
+
+// openLegacyDB creates an in-memory (or file) SQLite DB from a SQL fixture file,
+// simulating a database written by a pre-framework binary.
+func openLegacyDB(t *testing.T, fixturePath string) *sql.DB {
+	t.Helper()
+	sqlBytes, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", fixturePath, err)
+	}
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	// SQLite's multi-statement Exec support varies; split on semicolons.
+	for _, stmt := range strings.Split(string(sqlBytes), ";") {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" || strings.HasPrefix(stmt, "--") {
+			continue
+		}
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("apply fixture stmt %q: %v", stmt, err)
+		}
+	}
+	return db
+}
+
+// TestMigrationRunIdempotent verifies that calling migrations.Run twice does
+// not error — every migration is guarded by the schema_migrations table so
+// replaying is safe.
+func TestMigrationRunIdempotent(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Seed the settings table (needed for CheckVersion + schema_version stamp).
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := migrations.Run(db); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if err := migrations.Run(db); err != nil {
+		t.Fatalf("second Run (idempotent): %v", err)
+	}
+}
+
+// TestMigrationBaselineRecorded verifies that after migrations.Run a fresh DB
+// has the baseline migration ID in schema_migrations.
+func TestMigrationBaselineRecorded(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := migrations.Run(db); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM schema_migrations WHERE id = ?`, migrations.MaxID(),
+	).Scan(&count); err != nil {
+		t.Fatalf("query schema_migrations: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected baseline migration recorded, got count=%d", count)
+	}
+}
+
+// TestSchemaVersionStamped verifies that schema_version is written to settings.
+func TestSchemaVersionStamped(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := migrations.Run(db); err != nil {
+		t.Fatal(err)
+	}
+
+	var version string
+	if err := db.QueryRow(`SELECT value FROM settings WHERE key = 'schema_version'`).Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != migrations.MaxID() {
+		t.Errorf("schema_version = %q, want %q", version, migrations.MaxID())
+	}
+}
+
+// TestDowngradeDetected verifies that CheckVersion returns an error when the
+// DB's schema_version exceeds the binary's known max migration ID.
+func TestDowngradeDetected(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	// Stamp a future version that this binary doesn't know about.
+	futureVersion := "99991231_99_future_migration"
+	if _, err := db.Exec(
+		`INSERT INTO settings (key, value) VALUES ('schema_version', ?)`,
+		futureVersion,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := migrations.CheckVersion(db); err == nil {
+		t.Error("expected downgrade error, got nil")
+	}
+}
+
+// TestCheckVersionAbsentOK verifies that CheckVersion is a no-op when
+// schema_version is absent (pre-framework DB).
+func TestCheckVersionAbsentOK(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := migrations.CheckVersion(db); err != nil {
+		t.Errorf("unexpected error for pre-framework DB: %v", err)
+	}
+}
+
+// TestMigrateV0Baseline applies migrations.Run on top of a legacy v0 DB (the
+// schema produced before the migration framework existed) and asserts no errors.
+func TestMigrateV0Baseline(t *testing.T) {
+	fixture := filepath.Join("testdata", "db_fixtures", "v0_baseline.sql")
+	db := openLegacyDB(t, fixture)
+
+	if err := migrations.Run(db); err != nil {
+		t.Fatalf("Run on v0 baseline fixture: %v", err)
+	}
+
+	// schema_migrations must exist and contain the baseline entry.
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
+		t.Fatalf("query schema_migrations: %v", err)
+	}
+	if count == 0 {
+		t.Error("no migrations recorded after Run on v0 baseline")
+	}
+}
+
+// TestBackupCreated verifies that createBackup writes a .bak file next to the source.
+func TestBackupCreated(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "conductor.db")
+	if err := os.WriteFile(dbPath, []byte("fake db content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := createBackup(dbPath, 3); err != nil {
+		t.Fatalf("createBackup: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var bakCount int
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "conductor.db.pre-") && strings.HasSuffix(e.Name(), ".bak") {
+			bakCount++
+		}
+	}
+	if bakCount != 1 {
+		t.Errorf("expected 1 backup file, got %d", bakCount)
+	}
+}
+
+// TestBackupRotation verifies that old backups are pruned to the keep limit.
+func TestBackupRotation(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "conductor.db")
+	if err := os.WriteFile(dbPath, []byte("fake"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed 4 existing backups with timestamps that sort lexicographically.
+	timestamps := []string{"20240101T000000Z", "20240201T000000Z", "20240301T000000Z", "20240401T000000Z"}
+	for _, ts := range timestamps {
+		name := filepath.Join(dir, "conductor.db.pre-"+ts+".bak")
+		if err := os.WriteFile(name, []byte("old"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// createBackup with keep=3 should leave exactly 3 backups total.
+	if err := createBackup(dbPath, 3); err != nil {
+		t.Fatalf("createBackup: %v", err)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	var baks []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "conductor.db.pre-") && strings.HasSuffix(e.Name(), ".bak") {
+			baks = append(baks, e.Name())
+		}
+	}
+	if len(baks) != 3 {
+		t.Errorf("expected 3 backups after rotation, got %d: %v", len(baks), baks)
+	}
+}
+
+// TestBackupNoopWhenMissing verifies that createBackup is a no-op when the
+// source file does not exist (first run / fresh install).
+func TestBackupNoopWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "conductor.db")
+	// No file created — simulates first run.
+
+	if err := createBackup(dbPath, 3); err != nil {
+		t.Fatalf("createBackup on missing file: %v", err)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Errorf("expected no files in dir, got %d", len(entries))
+	}
+}

--- a/internal/store/plans.go
+++ b/internal/store/plans.go
@@ -2,9 +2,9 @@ package store
 
 import (
 	"database/sql"
-	"encoding/json"
 	"errors"
 
+	"prismconductor/internal/store/jsonutil"
 	"prismconductor/internal/types"
 )
 
@@ -13,7 +13,7 @@ func (s *Store) SavePlan(p types.Plan) error {
 	if s == nil || s.DB == nil {
 		return errors.New("store unavailable")
 	}
-	b, err := json.Marshal(p)
+	b, err := jsonutil.Save(nil, p)
 	if err != nil {
 		return err
 	}
@@ -35,7 +35,7 @@ func (s *Store) GetPlan(workspaceID string, issueNumber, revision int) (types.Pl
 		return types.Plan{}, err
 	}
 	var p types.Plan
-	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+	if _, err := jsonutil.Load([]byte(raw), &p); err != nil {
 		return types.Plan{}, err
 	}
 	return p, nil
@@ -84,7 +84,7 @@ WHERE i.column_name IS NULL OR i.column_name NOT IN ('done','review')`)
 			return nil, err
 		}
 		var plan types.Plan
-		if err := json.Unmarshal([]byte(raw), &plan); err != nil {
+		if _, err := jsonutil.Load([]byte(raw), &plan); err != nil {
 			continue
 		}
 		if plan.ApprovedAt == nil {
@@ -109,7 +109,7 @@ func (s *Store) LatestPlan(workspaceID string, issueNumber int) (*types.Plan, er
 		return nil, err
 	}
 	var p types.Plan
-	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+	if _, err := jsonutil.Load([]byte(raw), &p); err != nil {
 		return nil, err
 	}
 	return &p, nil
@@ -133,7 +133,7 @@ func (s *Store) ListPlans(workspaceID string, issueNumber int) ([]types.Plan, er
 			return nil, err
 		}
 		var p types.Plan
-		if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		if _, err := jsonutil.Load([]byte(raw), &p); err != nil {
 			continue
 		}
 		out = append(out, p)

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -2,13 +2,13 @@ package store
 
 import (
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
+	"prismconductor/internal/store/jsonutil"
 	"prismconductor/internal/types"
 )
 
@@ -17,7 +17,7 @@ func (s *Store) SaveSession(sess *types.Session, transcriptPath string) error {
 	if s == nil || s.DB == nil {
 		return errors.New("store unavailable")
 	}
-	b, err := json.Marshal(sess)
+	b, err := jsonutil.Save(nil, sess)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (s *Store) LoadRunningSessions() ([]types.Session, string, error) {
 			return nil, "", err
 		}
 		var sess types.Session
-		if err := json.Unmarshal([]byte(raw), &sess); err != nil {
+		if _, err := jsonutil.Load([]byte(raw), &sess); err != nil {
 			continue
 		}
 		// The pending_question_id column is the source of truth — the JSON blob
@@ -214,7 +214,7 @@ LIMIT ?`, limit)
 			return nil, err
 		}
 		var sess types.Session
-		if err := json.Unmarshal([]byte(raw), &sess); err != nil {
+		if _, err := jsonutil.Load([]byte(raw), &sess); err != nil {
 			continue
 		}
 		if sess.Transcript == "" {
@@ -317,7 +317,7 @@ func (s *Store) MostRecentEndedAtForWorktree(workspaceID, worktreePath string) (
 		return time.Time{}, false, nil
 	}
 	var sess types.Session
-	if err := json.Unmarshal([]byte(raw), &sess); err != nil {
+	if _, err := jsonutil.Load([]byte(raw), &sess); err != nil {
 		return time.Time{}, false, err
 	}
 	if sess.EndedAt == nil {
@@ -334,7 +334,7 @@ func (s *Store) UpdateSessionUsage(sess *types.Session, transcriptPath string) e
 	if s == nil || s.DB == nil {
 		return nil
 	}
-	b, err := json.Marshal(sess)
+	b, err := jsonutil.Save(nil, sess)
 	if err != nil {
 		return err
 	}
@@ -486,7 +486,7 @@ func (s *Store) ListSessionsForIssue(workspaceID string, issueNumber int) ([]typ
 			return nil, err
 		}
 		var sess types.Session
-		if err := json.Unmarshal([]byte(raw), &sess); err != nil {
+		if _, err := jsonutil.Load([]byte(raw), &sess); err != nil {
 			continue
 		}
 		if pendingQID.Valid {
@@ -523,14 +523,15 @@ func (s *Store) TerminateOrphanPausedSession(workspaceID string, issueNumber int
 		return nil, err
 	}
 	var sess types.Session
-	if err := json.Unmarshal([]byte(raw), &sess); err != nil {
+	rawMap, err := jsonutil.Load([]byte(raw), &sess)
+	if err != nil {
 		return nil, err
 	}
 	sess.State = types.StateFailed
 	sess.BlockedReason = reason
 	sess.EndedAt = &now
 	sess.AcknowledgedAt = &nowUnix
-	updated, err := json.Marshal(&sess)
+	updated, err := jsonutil.Save(rawMap, &sess)
 	if err != nil {
 		return nil, err
 	}
@@ -578,11 +579,12 @@ func (s *Store) AcknowledgeLatestFailure(workspaceID string, issueNumber int) (*
 		return nil, err
 	}
 	var sess types.Session
-	if err := json.Unmarshal([]byte(raw), &sess); err != nil {
-		return nil, err
+	rawMap, err2 := jsonutil.Load([]byte(raw), &sess)
+	if err2 != nil {
+		return nil, err2
 	}
 	sess.AcknowledgedAt = &now
-	updated, err := json.Marshal(&sess)
+	updated, err := jsonutil.Save(rawMap, &sess)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -4,9 +4,12 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"prismconductor/internal/store/migrations"
 
 	_ "modernc.org/sqlite"
 )
@@ -22,6 +25,26 @@ func Open(dir string) (*Store, error) {
 		return nil, err
 	}
 	path := filepath.Join(dir, "conductor.db")
+
+	// Pre-migration backup: copy the existing DB file before any DDL runs.
+	// Only runs when the file already exists (not a fresh install) and when
+	// there are pending migrations to apply (avoids creating a backup on
+	// every startup). A failed backup is logged but non-fatal — the user
+	// can still open the DB; a backup failure must not block the app.
+	if _, statErr := os.Stat(path); statErr == nil {
+		// Peek at pending status without opening a full connection.
+		if peekDB, err := sql.Open("sqlite", path); err == nil {
+			if migrations.HasPending(peekDB) {
+				peekDB.Close()
+				if err := createBackup(path, 3); err != nil {
+					log.Printf("store: pre-migration backup failed (non-fatal): %v", err)
+				}
+			} else {
+				peekDB.Close()
+			}
+		}
+	}
+
 	db, err := sql.Open("sqlite", path)
 	if err != nil {
 		return nil, err
@@ -50,10 +73,26 @@ func Open(dir string) (*Store, error) {
 		}
 	}
 	s := &Store{DB: db, Path: path}
+
+	// Legacy idempotent DDL (pre-framework migrations).
 	if err := s.migrate(); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
+
+	// Downgrade guard: refuse to open a DB written by a newer binary.
+	if err := migrations.CheckVersion(db); err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	// Versioned migration framework: creates schema_migrations, applies pending
+	// migrations, stamps schema_version.
+	if err := migrations.Run(db); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("schema migration: %w", err)
+	}
+
 	return s, nil
 }
 

--- a/internal/store/testdata/db_fixtures/v0_baseline.sql
+++ b/internal/store/testdata/db_fixtures/v0_baseline.sql
@@ -1,0 +1,114 @@
+-- v0_baseline.sql: representative pre-framework schema for migration tests.
+-- Matches the schema produced by the legacy migrate() as of the initial
+-- migration framework introduction.  Used by migrations_test.go to create
+-- a minimal "old binary" database and assert that the new migration framework
+-- applies cleanly on top of it.
+
+CREATE TABLE IF NOT EXISTS workspaces (id TEXT PRIMARY KEY, json TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS goals (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT,
+    status TEXT NOT NULL,
+    json TEXT NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS issues (
+    workspace_id TEXT NOT NULL,
+    number INTEGER NOT NULL,
+    column_name TEXT NOT NULL,
+    manual_order INTEGER,
+    json TEXT NOT NULL,
+    archived_at INTEGER,
+    closed_at INTEGER,
+    PRIMARY KEY (workspace_id, number)
+);
+CREATE TABLE IF NOT EXISTS plans (
+    workspace_id TEXT NOT NULL,
+    issue_number INTEGER NOT NULL,
+    revision INTEGER NOT NULL,
+    json TEXT NOT NULL,
+    PRIMARY KEY (workspace_id, issue_number, revision)
+);
+CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL,
+    issue_number INTEGER NOT NULL,
+    pid INTEGER,
+    state TEXT NOT NULL,
+    transcript_path TEXT,
+    pending_question_id TEXT,
+    json TEXT NOT NULL,
+    transcript_offset INTEGER NOT NULL DEFAULT 0,
+    acknowledged_at INTEGER,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    estimated_cost_cents REAL NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    type TEXT NOT NULL,
+    ts INTEGER NOT NULL,
+    payload TEXT
+);
+CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS labels (
+    workspace_id TEXT NOT NULL,
+    name         TEXT NOT NULL,
+    color        TEXT NOT NULL,
+    description  TEXT,
+    PRIMARY KEY (workspace_id, name)
+);
+CREATE TABLE IF NOT EXISTS pools (
+    id           TEXT PRIMARY KEY,
+    name         TEXT NOT NULL,
+    provider     TEXT NOT NULL,
+    endpoint     TEXT NOT NULL DEFAULT '',
+    model        TEXT NOT NULL,
+    capacity     INTEGER NOT NULL DEFAULT 1,
+    enabled      INTEGER NOT NULL DEFAULT 1,
+    api_key      TEXT NOT NULL DEFAULT '',
+    role         TEXT NOT NULL DEFAULT 'work' CHECK(role IN ('plan','work','orchestrator')),
+    created_at   INTEGER NOT NULL,
+    priority     INTEGER NOT NULL DEFAULT 0,
+    temperature  REAL,
+    max_turns    INTEGER,
+    max_input_tokens INTEGER,
+    bash_timeout_ms  INTEGER,
+    output_cap       INTEGER,
+    scope        TEXT NOT NULL DEFAULT 'shared',
+    workspace_id TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE IF NOT EXISTS pending_pool_for (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    workspace_id TEXT NOT NULL,
+    issue_number INTEGER NOT NULL,
+    role         TEXT NOT NULL,
+    action       TEXT NOT NULL,
+    created_at   INTEGER NOT NULL,
+    UNIQUE(workspace_id, issue_number, role, action)
+);
+CREATE TABLE IF NOT EXISTS pool_usage (
+    pool_id     TEXT NOT NULL,
+    window      TEXT NOT NULL,
+    limit_value INTEGER NOT NULL,
+    used        INTEGER NOT NULL,
+    resets_at   INTEGER NOT NULL,
+    captured_at INTEGER NOT NULL,
+    PRIMARY KEY (pool_id, window)
+);
+CREATE TABLE IF NOT EXISTS pr_comments (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    workspace_id TEXT NOT NULL,
+    issue_number INTEGER NOT NULL,
+    comment_id   INTEGER NOT NULL,
+    author       TEXT NOT NULL,
+    body         TEXT NOT NULL,
+    kind         TEXT NOT NULL,
+    file_path    TEXT,
+    line_number  INTEGER,
+    created_at   INTEGER NOT NULL,
+    read_at      INTEGER,
+    pending_post INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(workspace_id, issue_number, comment_id)
+);
+CREATE INDEX IF NOT EXISTS idx_pr_comments_ws_issue ON pr_comments(workspace_id, issue_number);


### PR DESCRIPTION
## Summary

- Adds migration framework (schema_migrations table, lexicographic ordering, per-migration txns, schema_version stamp in settings)
- Adds downgrade detection in Open(): refuses to open a DB whose schema_version exceeds the binary's MaxID
- Adds timestamped pre-migration conductor.db backups with rotation (keep last 3)
- Adds jsonutil passthrough helper: Load/Save preserve unknown JSON fields from future-binary rows across downgrade RMW cycles; uses reflect to correctly clear known omitempty fields
- Wires backup + downgrade check + migration runner into sqlite.Open()
- Updates issues.go, sessions.go, plans.go, goals.go to use jsonutil.Load/Save at all blob RMW sites
- Adds 9 migration tests: idempotent run, baseline recording, schema_version stamp, downgrade detection, v0-baseline fixture migration, backup create/rotate/noop
- Adds internal/store/testdata/db_fixtures/v0_baseline.sql for old-DB x new-binary CI tests
- Adds RECOVERY.md: operator guide for .bak restore and downgrade error handling
- Frontend audit: all backend call sites in Card.tsx and PlanModal.tsx already have .catch()/try-catch; no code changes required

## Files modified

- internal/store/migrations/migration.go (new)
- internal/store/migrations/registry.go (new)
- internal/store/migrations/runner.go (new)
- internal/store/backup.go (new)
- internal/store/jsonutil/passthrough.go (new)
- internal/store/migrations_test.go (new)
- internal/store/testdata/db_fixtures/v0_baseline.sql (new)
- internal/store/sqlite.go (modified)
- internal/store/issues.go (modified)
- internal/store/sessions.go (modified)
- internal/store/plans.go (modified)
- internal/store/goals.go (modified)
- .github/workflows/build.yml (modified)
- RECOVERY.md (new)

## Verification

- **Lint:** go vet prismconductor/internal/... -> pass
- **Build:** go build prismconductor/internal/... -> pass; wails build -> pass (7.2s)
- **Smoke test:** skipped - tests/e2e/startup.spec.ts exists but requires running Wails dev server + browser environment not available in this worktree
- **Tests:** go test prismconductor/internal/store/... -> 64 tests, all PASS (including 9 new migration tests)

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-172

Closes #172
