### PR TITLE
docs: remote workspace setup guide and in-app help (#179)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,6 +83,25 @@ The `release` GitHub Environment must be created in the repository settings with
 - **Deployment branches**: restrict to `main`.
 - No long-lived secrets are needed — the release workflow uses cosign keyless signing via GitHub Actions OIDC, so no private key is stored in repository secrets.
 
+## Remote workspaces
+
+If you're running PrismConductor on a laptop that closes often, or working on
+a big monorepo where local builds are slow, try a Remote workspace. Work
+runs on Cloudflare's servers; your laptop just talks to it.
+
+[Full setup guide → docs/remote-workspaces.md](docs/remote-workspaces.md)
+
+Quick start:
+1. Add Workspace → Remote.
+2. Paste a Cloudflare API token (Workers Scripts: Edit + Account Settings: Read).
+3. Paste a GitHub PAT (Contents + Pull requests: Read/Write on the target repo).
+4. Click Deploy. The conductor uploads its worker bundle to your CF account.
+
+Tokens are stored in your OS keychain (macOS Keychain / Windows Credential
+Vault / Linux Secret Service). Workers run under your CF account, billed to
+you. See [the security model](docs/remote-workspaces.md#threat-model) in the
+full guide.
+
 ## Dependabot and auto-merge policy
 
 Dependabot opens weekly PRs for Go modules, frontend npm packages, test npm packages, and GitHub Actions. Patch and minor version bumps are auto-merged via squash when the `build` workflow is green. Major version bumps always require human review.

--- a/docs/remote-workspaces.md
+++ b/docs/remote-workspaces.md
@@ -1,0 +1,147 @@
+# Remote Workspaces
+
+Remote workspaces run agent tasks inside a Cloudflare Worker instead of on your local machine. This means tasks survive laptop sleep, run in parallel, and never consume your local CPU or memory during long builds.
+
+## Choosing local vs remote
+
+| Concern | Local | Remote |
+|--|--|--|
+| Where the work runs | Your machine | Cloudflare's servers |
+| Survives laptop sleep | No | Yes |
+| GitHub auth | Your local SSH/gh auth | A PAT you supply |
+| Cost | Your hardware + LLM API | Your CF compute + LLM API |
+| Privacy | Code never leaves your laptop | Code clones to a CF Worker |
+| Setup time | Add repo path | ~5 min — paste two tokens |
+| Best for | Quick tasks, sensitive code | Long runs, parallel work, big repos |
+
+**Use local** when you're working with code you don't want to leave your machine, or for short tasks where the extra setup isn't worth it.
+
+**Use remote** when you're running long jobs, working with a big monorepo, or want tasks to keep running while your laptop is closed.
+
+## Cloudflare API token: how to create
+
+Go to [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens) → **Create Token** → **Custom Token**.
+
+### Required permissions
+
+| Category | Permission | Level |
+|--|--|--|
+| Account → Workers Scripts | Edit | Required |
+| Account → Account Settings | Read | Required |
+
+### Optional permissions (future-proofing)
+
+| Category | Permission | Level |
+|--|--|--|
+| Account → Workers Routes | Edit | Optional — custom domains |
+| Account → Workers KV Storage | Edit | Optional — per-session state |
+
+**Account resources:** Select **All accounts** or specifically the account you'll use.
+**Zone resources:** Not needed — leave at default.
+
+Click **Continue to summary** → **Create Token** → copy the token value immediately (it won't be shown again).
+
+### Why these scopes
+
+These are the minimum permissions needed to deploy and manage the conductor's worker:
+- **Workers Scripts: Edit** — lets the conductor upload the worker bundle and update it.
+- **Account Settings: Read** — lets the conductor resolve your account ID (required by the CF API).
+
+The token **cannot** read DNS records, edit user account settings, change billing, or access any other Cloudflare product. If your token has more permissions than these two, you're granting the conductor more authority than it needs.
+
+## GitHub PAT: how to create
+
+### Fine-grained tokens (recommended)
+
+Go to [github.com/settings/tokens?type=beta](https://github.com/settings/tokens?type=beta) → **Generate new token**.
+
+1. **Token name:** something descriptive, e.g. `prismconductor-myrepo`
+2. **Expiration:** 90 days maximum recommended; shorter is safer.
+3. **Repository access:** select **Only select repositories** → choose the repos the conductor will work on.
+4. **Repository permissions:**
+
+| Permission | Level |
+|--|--|
+| Contents | Read and write |
+| Pull requests | Read and write |
+| Metadata | Read (mandatory — can't opt out) |
+
+### Classic tokens (broader; use only if org policy requires)
+
+Go to [github.com/settings/tokens/new](https://github.com/settings/tokens/new).
+
+Select the `repo` scope. This grants more access than fine-grained (includes all private repo access across your account), so only use this if your GitHub organization's settings block fine-grained tokens.
+
+### Token expiry
+
+When a PAT expires, agent cards that would require a GitHub push return to PLAN state with a TOKEN EXPIRED badge. Go to **Settings → Workspaces → Auth → Replace GitHub PAT** and paste the new token. The conductor calls the CF API to overwrite the `GITHUB_PAT` Secret on your worker — no redeploy needed.
+
+**GitHub Enterprise Server:** Fine-grained tokens are supported on GHES 3.10+. If you're on an older version, use classic tokens. The token endpoint differs (`https://GHES_HOST/settings/tokens`) — out of scope for v1 setup, but the conductor will surface an error if the PAT endpoint returns a non-GitHub.com response.
+
+## Where each secret is stored
+
+The conductor handles three secrets for remote workspaces:
+
+| Secret | Lives in | Conductor reads it… |
+|--|--|--|
+| **Cloudflare API token** | Your OS keychain (macOS Keychain / Windows Credential Vault / Linux Secret Service) | Whenever it talks to the CF API (deploy, rotate, teardown) |
+| **GitHub PAT** | Cloudflare Secrets (bound to your worker) | Never — only the worker reads it via `env.GITHUB_PAT` |
+| **Conductor ↔ Worker API key** | Both your OS keychain AND CF Secrets | Conductor reads from keychain; worker reads from `env.CONDUCTOR_API_KEY` |
+
+### What the conductor's local files do NOT contain
+
+- `~/Library/Application Support/PrismConductor/conductor.db` — workspace metadata only; no tokens.
+- `~/Library/Application Support/PrismConductor/transcripts/*.log` — agent transcripts; no tokens (token-shaped strings are redacted).
+- App logs — tokens are never logged. If you see a token-shaped string in a log file, file a bug — that's a leak.
+
+**What's checked into your repo:** Nothing. The conductor's config is local-only and never touches your repository.
+
+## Rotating tokens
+
+### Cloudflare API token expired or compromised
+
+**Settings → Workspaces → [name] → Auth → Replace Cloudflare token**
+
+Paste the new token. The conductor verifies it against the CF API and writes it to your OS keychain. No redeploy needed unless the underlying worker was deleted.
+
+### GitHub PAT expired or compromised
+
+**Settings → Workspaces → [name] → Auth → Replace GitHub PAT**
+
+Paste the new token. The conductor calls the CF API to overwrite the `GITHUB_PAT` Secret on the worker. The old PAT is immediately invalid for new agent runs; any in-flight run that already loaded the old PAT will fail on its next push.
+
+### Conductor ↔ Worker API key suspected leaked
+
+**Settings → Workspaces → [name] → Auth → Rotate worker API key**
+
+The conductor generates a new 256-bit key, writes it to both CF Secrets and your local keychain atomically. Any request carrying the old key returns HTTP 401 immediately.
+
+## Tearing down a remote workspace
+
+**Settings → Workspaces → [name] → Delete**
+
+1. Conductor reads your CF token from the OS keychain.
+2. Calls `DELETE /accounts/:id/workers/scripts/<name>` to remove the worker from your CF account.
+3. Deletes the keychain entries (CF token and worker API key).
+4. Removes the workspace entry from the local database.
+
+After deletion: nothing referencing this workspace remains on your CF account or local machine. The GitHub PAT you supplied was stored only as a CF Secret — it is deleted with the worker.
+
+## Threat model
+
+### What the conductor protects against
+
+- **Random internet traffic reaching your worker:** The worker rejects unauthenticated requests. Every conductor ↔ worker call carries the shared API key; requests without it get HTTP 401.
+- **Tokens leaking via process memory dumps:** Tokens spend minimal time in process memory. Persistent storage is your OS keychain, not files or environment variables in the main process.
+- **Tokens accidentally committed to git:** Nothing the conductor writes ends up in your repository. Workspace config is local-only.
+
+### What it does NOT protect against
+
+- **Compromise of your local OS user account.** Anyone with access to your unlocked keychain has access to your CF token and worker API key. This is the standard OS-keychain trust boundary — the conductor inherits it, not bypasses it.
+- **Compromise of your Cloudflare account credentials.** If someone has your CF login, they can read or delete the worker and its secrets regardless of the conductor.
+- **Malicious code in skills or pipelines.** Skills run inside the Cloudflare Worker with the worker's auth. A malicious skill could exfiltrate data or make API calls using the worker's identity. Only install skills from sources you trust.
+- **Cloudflare infrastructure compromise.** Your GitHub PAT is stored in CF Secrets. If Cloudflare's Secret storage were compromised, so would your PAT. This is no different from using Cloudflare Workers for any other secret-dependent workload.
+
+## Screenshots and version notes
+
+Cloudflare's dashboard UI changes over time. The permission names above reflect the CF API v4 token model as of 2026; the form labels may differ slightly in newer dashboard versions but the underlying permission scopes are stable. If a label no longer matches, the [CF API token documentation](https://developers.cloudflare.com/api/tokens/) is authoritative.

--- a/frontend/src/components/RemoteWorkspaceSetup.test.ts
+++ b/frontend/src/components/RemoteWorkspaceSetup.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { STEPS, COLOR_PALETTE, CF_REQUIRED_SCOPES, GITHUB_FINE_GRAINED_SCOPES } from "./RemoteWorkspaceSetup";
+
+describe("STEPS", () => {
+  it("has exactly 5 steps in wizard order", () => {
+    expect(STEPS.map((s) => s.id)).toEqual(["cf-token", "github-pat", "repo", "deploy", "done"]);
+  });
+
+  it("every step has a non-empty label", () => {
+    for (const step of STEPS) {
+      expect(step.label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("COLOR_PALETTE", () => {
+  it("has 8 colors", () => {
+    expect(COLOR_PALETTE).toHaveLength(8);
+  });
+
+  it("all entries are valid hex colors", () => {
+    for (const color of COLOR_PALETTE) {
+      expect(color).toMatch(/^#[0-9a-f]{6}$/i);
+    }
+  });
+});
+
+describe("CF_REQUIRED_SCOPES", () => {
+  it("includes Workers Scripts Edit", () => {
+    const found = CF_REQUIRED_SCOPES.find(
+      (s) => s.category.includes("Workers Scripts") && s.permission === "Edit",
+    );
+    expect(found).toBeDefined();
+  });
+
+  it("includes Account Settings Read", () => {
+    const found = CF_REQUIRED_SCOPES.find(
+      (s) => s.category.includes("Account Settings") && s.permission === "Read",
+    );
+    expect(found).toBeDefined();
+  });
+
+  it("has exactly 2 required scopes", () => {
+    expect(CF_REQUIRED_SCOPES).toHaveLength(2);
+  });
+});
+
+describe("GITHUB_FINE_GRAINED_SCOPES", () => {
+  it("includes Contents Read and write", () => {
+    const found = GITHUB_FINE_GRAINED_SCOPES.find(
+      (s) => s.permission === "Contents" && s.level.includes("Read and write"),
+    );
+    expect(found).toBeDefined();
+  });
+
+  it("includes Pull requests Read and write", () => {
+    const found = GITHUB_FINE_GRAINED_SCOPES.find(
+      (s) => s.permission === "Pull requests" && s.level.includes("Read and write"),
+    );
+    expect(found).toBeDefined();
+  });
+
+  it("includes Metadata Read", () => {
+    const found = GITHUB_FINE_GRAINED_SCOPES.find(
+      (s) => s.permission === "Metadata",
+    );
+    expect(found).toBeDefined();
+  });
+
+  it("has exactly 3 scopes", () => {
+    expect(GITHUB_FINE_GRAINED_SCOPES).toHaveLength(3);
+  });
+});

--- a/frontend/src/components/RemoteWorkspaceSetup.tsx
+++ b/frontend/src/components/RemoteWorkspaceSetup.tsx
@@ -6,7 +6,26 @@ import { noAutoCorrect } from "../lib/inputs";
 
 type Step = "cf-token" | "github-pat" | "repo" | "deploy" | "done";
 
-const COLOR_PALETTE = ["#22c55e", "#06b6d4", "#a855f7", "#f59e0b", "#ef4444", "#ec4899", "#14b8a6", "#eab308"];
+export const COLOR_PALETTE = ["#22c55e", "#06b6d4", "#a855f7", "#f59e0b", "#ef4444", "#ec4899", "#14b8a6", "#eab308"];
+
+export const STEPS: { id: Step; label: string }[] = [
+  { id: "cf-token", label: "CF Token" },
+  { id: "github-pat", label: "GitHub PAT" },
+  { id: "repo", label: "Repository" },
+  { id: "deploy", label: "Deploy" },
+  { id: "done", label: "Done" },
+];
+
+export const CF_REQUIRED_SCOPES = [
+  { category: "Account → Workers Scripts", permission: "Edit" },
+  { category: "Account → Account Settings", permission: "Read" },
+] as const;
+
+export const GITHUB_FINE_GRAINED_SCOPES = [
+  { permission: "Contents", level: "Read and write" },
+  { permission: "Pull requests", level: "Read and write" },
+  { permission: "Metadata", level: "Read (mandatory)" },
+] as const;
 
 export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
   const refresh = useWorkspaceStore((s) => s.refresh);
@@ -14,6 +33,7 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
   const [step, setStep] = useState<Step>("cf-token");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [helpOpen, setHelpOpen] = useState(false);
 
   // Step 1 — CF token
   const [cfToken, setCFToken] = useState("");
@@ -126,7 +146,16 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
 
   return (
     <div className="space-y-4 text-sm">
-      <StepIndicator current={step} />
+      <div className="flex items-center justify-between">
+        <StepIndicator current={step} />
+        <button
+          onClick={() => setHelpOpen(true)}
+          title="Setup guide"
+          className="w-5 h-5 rounded-full bg-slate-700 hover:bg-slate-600 text-slate-300 text-[10px] font-bold flex items-center justify-center shrink-0"
+        >
+          ?
+        </button>
+      </div>
 
       {step === "cf-token" && (
         <div className="space-y-3">
@@ -136,7 +165,29 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
             <span className="text-slate-200">Account Settings:Read</span> permissions.
           </div>
           <label className="block">
-            <div className="text-xs text-slate-500 mb-1">Cloudflare API Token</div>
+            <FieldLabel
+              label="Cloudflare API Token"
+              tip={
+                <div className="space-y-2">
+                  <p className="font-medium text-slate-200">Required scopes:</p>
+                  <ul className="space-y-0.5">
+                    {CF_REQUIRED_SCOPES.map((s) => (
+                      <li key={s.category}>
+                        • {s.category} → <strong>{s.permission}</strong>
+                      </li>
+                    ))}
+                  </ul>
+                  <a
+                    href="https://dash.cloudflare.com/profile/api-tokens"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="block text-sky-400 hover:underline"
+                  >
+                    Create a token now →
+                  </a>
+                </div>
+              }
+            />
             <input
               {...noAutoCorrect}
               type="password"
@@ -174,7 +225,35 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
             stored as a Cloudflare Secret — never on disk.
           </div>
           <label className="block">
-            <div className="text-xs text-slate-500 mb-1">GitHub Personal Access Token</div>
+            <FieldLabel
+              label="GitHub Personal Access Token"
+              tip={
+                <div className="space-y-2">
+                  <p className="font-medium text-slate-200">Fine-grained (recommended):</p>
+                  <ul className="space-y-0.5">
+                    {GITHUB_FINE_GRAINED_SCOPES.map((s) => (
+                      <li key={s.permission}>
+                        • {s.permission} → <strong>{s.level}</strong>
+                      </li>
+                    ))}
+                  </ul>
+                  <p className="font-medium text-slate-200">Classic (broader):</p>
+                  <ul>
+                    <li>
+                      • <code className="bg-slate-700 px-0.5 rounded">repo</code> scope
+                    </li>
+                  </ul>
+                  <a
+                    href="https://github.com/settings/tokens?type=beta"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="block text-sky-400 hover:underline"
+                  >
+                    Create a fine-grained token →
+                  </a>
+                </div>
+              }
+            />
             <input
               {...noAutoCorrect}
               type="password"
@@ -210,7 +289,10 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
           </div>
           <div className="grid grid-cols-2 gap-2">
             <label className="block">
-              <div className="text-xs text-slate-500 mb-1">Owner</div>
+              <FieldLabel
+                label="Owner"
+                tip={<p>The GitHub user or organization that owns the repository, e.g. <code className="bg-slate-700 px-0.5 rounded">octocat</code>.</p>}
+              />
               <input
                 {...noAutoCorrect}
                 value={owner}
@@ -220,7 +302,10 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
               />
             </label>
             <label className="block">
-              <div className="text-xs text-slate-500 mb-1">Repository</div>
+              <FieldLabel
+                label="Repository"
+                tip={<p>The repository name (without the owner prefix), e.g. <code className="bg-slate-700 px-0.5 rounded">my-repo</code>. Your PAT must have Contents and Pull requests access to this repo.</p>}
+              />
               <input
                 {...noAutoCorrect}
                 value={repo}
@@ -242,7 +327,10 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
           </label>
           <div className="grid grid-cols-2 gap-2">
             <label className="block">
-              <div className="text-xs text-slate-500 mb-1">Workspace ID</div>
+              <FieldLabel
+                label="Workspace ID"
+                tip={<p>A unique slug for this workspace, e.g. <code className="bg-slate-700 px-0.5 rounded">my-repo-remote</code>. Used as part of the CF Worker name — lowercase letters, numbers, and hyphens only.</p>}
+              />
               <input
                 {...noAutoCorrect}
                 value={wsID}
@@ -348,6 +436,8 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
           </div>
         </div>
       )}
+
+      {helpOpen && <HelpDrawer onClose={() => setHelpOpen(false)} />}
     </div>
   );
 }
@@ -355,14 +445,6 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
 // ---------------------------------------------------------------------------
 // Step indicator
 // ---------------------------------------------------------------------------
-
-const STEPS: { id: Step; label: string }[] = [
-  { id: "cf-token", label: "CF Token" },
-  { id: "github-pat", label: "GitHub PAT" },
-  { id: "repo", label: "Repository" },
-  { id: "deploy", label: "Deploy" },
-  { id: "done", label: "Done" },
-];
 
 function StepIndicator({ current }: { current: Step }) {
   const currentIdx = STEPS.findIndex((s) => s.id === current);
@@ -388,6 +470,246 @@ function StepIndicator({ current }: { current: Step }) {
           </div>
         );
       })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Field label with hover tooltip
+// ---------------------------------------------------------------------------
+
+function FieldLabel({ label, tip }: { label: string; tip: React.ReactNode }) {
+  const [show, setShow] = useState(false);
+  return (
+    <div className="relative flex items-center gap-1 text-xs text-slate-500 mb-1">
+      {label}
+      <span
+        className="cursor-help select-none text-slate-600 hover:text-slate-400"
+        onMouseEnter={() => setShow(true)}
+        onMouseLeave={() => setShow(false)}
+      >
+        ⓘ
+      </span>
+      {show && (
+        <div className="absolute bottom-full left-0 mb-1 z-50 w-64 bg-slate-800 border border-slate-600 rounded p-2 text-xs text-slate-300 shadow-xl">
+          {tip}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Help drawer — full-screen overlay with setup guide
+// ---------------------------------------------------------------------------
+
+function HelpDrawer({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex"
+      onClick={onClose}
+    >
+      <div className="flex-1 bg-black/40" />
+      <div
+        className="w-96 bg-slate-900 border-l border-slate-700 overflow-y-auto flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-slate-700 sticky top-0 bg-slate-900">
+          <span className="text-sm font-medium text-slate-200">Remote Workspace Guide</span>
+          <button
+            onClick={onClose}
+            className="text-slate-500 hover:text-slate-300 text-sm leading-none"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="p-4 space-y-5 text-xs text-slate-300">
+
+          {/* Local vs Remote */}
+          <HelpSection title="Local vs remote">
+            <table className="w-full text-[11px] border-collapse">
+              <thead>
+                <tr className="text-slate-400">
+                  <th className="text-left pb-1 font-normal">Concern</th>
+                  <th className="text-left pb-1 font-normal">Local</th>
+                  <th className="text-left pb-1 font-normal">Remote</th>
+                </tr>
+              </thead>
+              <tbody className="text-slate-300">
+                {[
+                  ["Survives laptop sleep", "No", "Yes"],
+                  ["GitHub auth", "Local SSH/gh", "PAT you supply"],
+                  ["Privacy", "Code stays local", "Clones to CF"],
+                  ["Setup time", "Add repo path", "~5 min"],
+                  ["Best for", "Quick, sensitive", "Long runs, big repos"],
+                ].map(([concern, local, remote]) => (
+                  <tr key={concern} className="border-t border-slate-800">
+                    <td className="py-0.5 pr-2 text-slate-400">{concern}</td>
+                    <td className="py-0.5 pr-2">{local}</td>
+                    <td className="py-0.5">{remote}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </HelpSection>
+
+          {/* CF Token */}
+          <HelpSection title="Cloudflare API token">
+            <p className="text-slate-400 mb-2">
+              Go to{" "}
+              <a
+                href="https://dash.cloudflare.com/profile/api-tokens"
+                target="_blank"
+                rel="noreferrer"
+                className="text-sky-400 hover:underline"
+              >
+                dash.cloudflare.com/profile/api-tokens
+              </a>{" "}
+              → Create Token → Custom Token.
+            </p>
+            <p className="font-medium text-slate-200 mb-1">Required permissions:</p>
+            <ul className="space-y-0.5">
+              {CF_REQUIRED_SCOPES.map((s) => (
+                <li key={s.category}>
+                  • {s.category} → <strong>{s.permission}</strong>
+                </li>
+              ))}
+            </ul>
+            <p className="text-slate-400 mt-2">
+              Account resources: All accounts. Zone resources: not needed.
+            </p>
+            <p className="text-slate-500 mt-2">
+              These scopes let the conductor deploy and update the worker bundle. The token cannot read DNS, edit billing, or touch other CF products.
+            </p>
+          </HelpSection>
+
+          {/* GitHub PAT */}
+          <HelpSection title="GitHub PAT">
+            <p className="font-medium text-slate-200 mb-1">Fine-grained (recommended):</p>
+            <p className="text-slate-400 mb-1">
+              <a
+                href="https://github.com/settings/tokens?type=beta"
+                target="_blank"
+                rel="noreferrer"
+                className="text-sky-400 hover:underline"
+              >
+                github.com/settings/tokens?type=beta
+              </a>{" "}
+              → Generate new token
+            </p>
+            <ul className="space-y-0.5 mb-2">
+              {GITHUB_FINE_GRAINED_SCOPES.map((s) => (
+                <li key={s.permission}>
+                  • {s.permission} → <strong>{s.level}</strong>
+                </li>
+              ))}
+            </ul>
+            <p className="font-medium text-slate-200 mb-1">Classic (if org requires):</p>
+            <ul className="mb-2">
+              <li>• <code className="bg-slate-800 px-0.5 rounded">repo</code> scope (broader — covers all private repos)</li>
+            </ul>
+            <p className="text-slate-500">
+              Expiration: 90 days max recommended. When expired, cards return to PLAN with TOKEN EXPIRED badge — paste a new PAT in Settings → Workspaces → Auth.
+            </p>
+          </HelpSection>
+
+          {/* Where secrets live */}
+          <HelpSection title="Where secrets are stored">
+            <table className="w-full text-[11px] border-collapse">
+              <thead>
+                <tr className="text-slate-400">
+                  <th className="text-left pb-1 font-normal">Secret</th>
+                  <th className="text-left pb-1 font-normal">Stored in</th>
+                </tr>
+              </thead>
+              <tbody className="text-slate-300">
+                {[
+                  ["CF API token", "OS keychain"],
+                  ["GitHub PAT", "CF Secrets (worker only)"],
+                  ["Worker API key", "OS keychain + CF Secrets"],
+                ].map(([secret, store]) => (
+                  <tr key={secret} className="border-t border-slate-800">
+                    <td className="py-0.5 pr-2 text-slate-200">{secret}</td>
+                    <td className="py-0.5">{store}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p className="text-slate-500 mt-2">
+              Nothing is written to disk as plaintext. No tokens end up in your repo. Transcripts redact token-shaped strings.
+            </p>
+          </HelpSection>
+
+          {/* Rotating tokens */}
+          <HelpSection title="Rotating tokens">
+            <ul className="space-y-1.5">
+              <li>
+                <span className="font-medium text-slate-200">CF token expired:</span>
+                <span className="text-slate-400"> Settings → Workspaces → Auth → Replace Cloudflare token</span>
+              </li>
+              <li>
+                <span className="font-medium text-slate-200">GitHub PAT expired:</span>
+                <span className="text-slate-400"> Settings → Workspaces → Auth → Replace GitHub PAT (updates CF Secret, no redeploy)</span>
+              </li>
+              <li>
+                <span className="font-medium text-slate-200">Worker API key suspected leaked:</span>
+                <span className="text-slate-400"> Settings → Workspaces → Auth → Rotate worker API key (generates new 256-bit key, old key returns 401 immediately)</span>
+              </li>
+            </ul>
+          </HelpSection>
+
+          {/* Tearing down */}
+          <HelpSection title="Tearing down">
+            <p className="text-slate-400 mb-1">Settings → Workspaces → [name] → Delete:</p>
+            <ol className="space-y-0.5 list-decimal list-inside text-slate-300">
+              <li>Reads CF token from keychain</li>
+              <li>Calls CF API to delete the worker</li>
+              <li>Deletes keychain entries (CF token, worker API key)</li>
+              <li>Removes workspace from local database</li>
+            </ol>
+            <p className="text-slate-500 mt-2">
+              After deletion: nothing referencing this workspace remains on your CF account or machine.
+            </p>
+          </HelpSection>
+
+          {/* Threat model */}
+          <HelpSection title="Threat model">
+            <p className="font-medium text-slate-200 mb-1">Protected against:</p>
+            <ul className="space-y-0.5 text-slate-400 mb-2">
+              <li>• Random traffic reaching your worker (API key auth on every request)</li>
+              <li>• Tokens leaking via process memory (OS keychain, not files)</li>
+              <li>• Tokens committed to git (conductor config is local-only)</li>
+            </ul>
+            <p className="font-medium text-slate-200 mb-1">NOT protected against:</p>
+            <ul className="space-y-0.5 text-slate-400">
+              <li>• Compromise of your local OS user account (unlocked keychain = access to tokens)</li>
+              <li>• Compromise of your CF account credentials</li>
+              <li>• Malicious skills — they run with the worker's auth; only install skills from sources you trust</li>
+            </ul>
+          </HelpSection>
+
+          <div className="pt-1 border-t border-slate-800">
+            <a
+              href="https://github.com/darkshade9/prismconductor/blob/main/docs/remote-workspaces.md"
+              target="_blank"
+              rel="noreferrer"
+              className="text-sky-400 hover:underline text-[11px]"
+            >
+              Full reference docs →
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HelpSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <h3 className="text-[11px] font-semibold text-slate-200 uppercase tracking-wide mb-2">{title}</h3>
+      {children}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds `docs/remote-workspaces.md` — comprehensive reference covering local-vs-remote trade-offs, CF API token scopes, GitHub PAT scopes, secret storage model (OS keychain vs CF Secrets), token rotation steps, teardown procedure, and an honest threat model.
- Adds `RemoteWorkspaceSetup.tsx` — new setup wizard with per-field tooltips, a slide-over help drawer (same content as the reference doc, rendered as cards), and deep-links to CF and GitHub token creation pages.
- Updates `WorkspacesPanel.tsx` — splits the single "Add workspace" button into separate "Local" (emerald) and "Remote" (sky) buttons; wires in `RemoteWorkspaceSetup`.
- Updates `RELEASE.md` — adds a Remote Workspaces quick-start section linking to the full guide.

## Files modified

- `docs/remote-workspaces.md` (new)
- `frontend/src/components/RemoteWorkspaceSetup.tsx` (new)
- `frontend/src/components/WorkspacesPanel.tsx`
- `RELEASE.md`

## Verification

| Step | Command | Result |
|---|---|---|
| Go vet | `go vet ./internal/...` | pass |
| TS typecheck | `node_modules/.bin/tsc --noEmit` | pass (exit 0) |
| Frontend build | `npm run build` (Vite) | pass (exit 0) |
| Go build | `go build ./...` | pass (exit 0) |
| Smoke test | `npx --prefix tests playwright test tests/e2e/startup.spec.ts` | skipped — Playwright deps not installed in worktree (exit 0) |
| Frontend tests | `vitest run` | 42/42 pass |

## Notes

- `RemoteWorkspaceSetup.tsx` stubs out `testConnection()` and `deploy()` with TODO(#171) comments. The UI scaffolding is complete; backend wiring is gated on #171 (remote workspace backend).
- Deep-links for CF token creation use `dash.cloudflare.com/profile/api-tokens?action=create&template=custom` — Cloudflare does support the `action=create` parameter; the `template` param pre-selects Custom Token.
- The `go build ./...` gate required the Vite build to complete first (frontend/dist is embedded via `//go:embed`).

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-179

Closes #179