### PR TITLE
feat: three-tier signed-commit fallback (#175)

### DIFF
--- a/app.go
+++ b/app.go
@@ -2150,11 +2150,27 @@ func (a *App) handleNeedsPR(sess types.Session, branch, worktreeDir, reason stri
 			break
 		}
 	}
+	// Read the Tier-3 commit message file written by the worker (issue #175).
+	// The worker writes it to <worktreeDir>/.prismconductor/commit-msg/<issueNum>.txt.
+	commitMsgFile := filepath.Join(worktreeDir, ".prismconductor", "commit-msg",
+		fmt.Sprintf("%d.txt", sess.IssueNumber))
+	var commitMsg string
+	if raw, err := os.ReadFile(commitMsgFile); err == nil {
+		if len(raw) > 500 {
+			commitMsg = string(raw[:500])
+		} else {
+			commitMsg = string(raw)
+		}
+	} else {
+		commitMsgFile = "" // file absent — clear path so UI knows it's missing
+	}
 	info := types.NeedsPRInfo{
-		Branch:      branch,
-		WorktreeDir: worktreeDir,
-		Reason:      reason,
-		Kind:        kind,
+		Branch:        branch,
+		WorktreeDir:   worktreeDir,
+		Reason:        reason,
+		Kind:          kind,
+		CommitMsgFile: commitMsgFile,
+		CommitMsg:     commitMsg,
 	}
 	if err := a.store.MarkNeedsPR(sess.WorkspaceID, sess.IssueNumber, info); err != nil {
 		log.Printf("NEEDS_PR: MarkNeedsPR failed for #%d: %v", sess.IssueNumber, err)
@@ -2178,6 +2194,22 @@ func (a *App) handleNeedsPR(sess types.Session, branch, worktreeDir, reason stri
 			"issue_number": sess.IssueNumber,
 			"action":       "focus_card",
 		})
+}
+
+// PrepareManualPushCommand returns the exact shell command the user should paste
+// to complete a NEEDS_PR card's commit+push from the preserved worktree (#175).
+func (a *App) PrepareManualPushCommand(workspaceID string, issueNumber int) (string, error) {
+	if a.store == nil {
+		return "", fmt.Errorf("store unavailable")
+	}
+	issue, err := a.store.LoadIssue(workspaceID, issueNumber)
+	if err != nil {
+		return "", fmt.Errorf("issue not found: %w", err)
+	}
+	if issue.NeedsPRInfo == nil {
+		return "", fmt.Errorf("issue #%d has no NEEDS_PR info", issueNumber)
+	}
+	return handlers.BuildManualPushCommand(issue.NeedsPRInfo), nil
 }
 
 // AttachManualPR allows the user to paste a PR URL for a NEEDS_PR card,

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { BrowserOpenURL } from "../../wailsjs/runtime/runtime";
-import { Replan, ReplanForce, ClearIssueFailure, SelfHeal, CancelSession, SpawnPlanForIssue, ResolveConflicts, AttachManualPR } from "../../wailsjs/go/main/App";
+import { Replan, ReplanForce, ClearIssueFailure, SelfHeal, CancelSession, SpawnPlanForIssue, ResolveConflicts, AttachManualPR, PrepareManualPushCommand } from "../../wailsjs/go/main/App";
 import { ClipboardSetText } from "../../wailsjs/runtime/runtime";
 import { RecoverButton } from "./RecoverButton";
 import { types } from "../../wailsjs/go/models";
@@ -437,6 +437,8 @@ type NeedsPRInfo = {
   worktree_dir: string;
   reason: string;
   kind: string;
+  commit_msg_file?: string;
+  commit_msg?: string;
 };
 
 function StatusRow({
@@ -608,13 +610,27 @@ function StatusRow({
   // NEEDS_PR badge: show when NeedsPRInfo is set and no PR has been attached yet.
   const showNeedsPR = needsPRInfo && !prNumber && !activeSession && !pausedSession && !waitingForPool;
   if (showNeedsPR && needsPRInfo) {
-    const pushCmd = `cd ${needsPRInfo.worktree_dir} && git push -u origin ${needsPRInfo.branch}`;
-    const isCommitSigning = needsPRInfo.kind === "commit_signing";
-    const fullCmd = isCommitSigning
-      ? `cd ${needsPRInfo.worktree_dir} && git add -A && git commit -S -m 'feat: implement changes' && git push -u origin ${needsPRInfo.branch}`
-      : pushCmd;
+    const info = needsPRInfo; // capture for closures — TypeScript can't narrow through async boundaries
+    const isCommitSigning = info.kind === "commit_signing";
     const [attachOpen, setAttachOpen] = useState(false);
     const [prURLInput, setPRURLInput] = useState("");
+    const [msgExpanded, setMsgExpanded] = useState(false);
+
+    function copyPushCmd(e: React.MouseEvent) {
+      e.stopPropagation();
+      PrepareManualPushCommand(workspaceID, issueNumber)
+        .then((cmd) => ClipboardSetText(cmd))
+        .catch(() => {
+          // Fall back to constructing the command locally if the binding fails.
+          const fallback = isCommitSigning && info.commit_msg_file
+            ? `cd "${info.worktree_dir}" && git add -A && git commit -S -F "${info.commit_msg_file}" && git push -u origin ${info.branch}`
+            : isCommitSigning
+              ? `cd "${info.worktree_dir}" && git add -A && git commit -S -m 'feat: implement changes' && git push -u origin ${info.branch}`
+              : `cd "${info.worktree_dir}" && git push -u origin ${info.branch}`;
+          ClipboardSetText(fallback);
+        });
+    }
+
     return (
       <>
         <div className="text-[11px] mt-1.5 space-y-1">
@@ -623,25 +639,41 @@ function StatusRow({
             <span className="text-emerald-400 font-medium">push needed</span>
             <span className="text-slate-500">— commits in worktree</span>
           </div>
-          <div className="text-slate-400 text-[10px] truncate pl-3.5" title={needsPRInfo.reason}>
-            {needsPRInfo.reason || "could not push"}
+          <div className="text-slate-400 text-[10px] truncate pl-3.5" title={info.reason}>
+            {info.reason || "could not push"}
           </div>
+          {info.commit_msg && (
+            <div className="pl-3.5">
+              <button
+                onClick={(e) => { e.stopPropagation(); setMsgExpanded(!msgExpanded); }}
+                onMouseDown={(e) => e.stopPropagation()}
+                onPointerDown={(e) => e.stopPropagation()}
+                className="text-[10px] text-slate-500 hover:text-slate-300"
+              >
+                {msgExpanded ? "▾ hide commit message" : "▸ show commit message"}
+              </button>
+              {msgExpanded && (
+                <pre className="mt-1 text-[10px] text-slate-400 bg-slate-900 rounded p-1.5 whitespace-pre-wrap break-words max-h-32 overflow-y-auto">
+                  {info.commit_msg}
+                </pre>
+              )}
+            </div>
+          )}
           <div className="flex gap-1.5 flex-wrap pl-3.5">
             <button
-              onClick={(e) => { e.stopPropagation(); ClipboardSetText(fullCmd); }}
+              onClick={copyPushCmd}
               onMouseDown={(e) => e.stopPropagation()}
               onPointerDown={(e) => e.stopPropagation()}
               className="px-1.5 py-0.5 rounded text-[10px] border border-emerald-800 text-emerald-400 hover:border-emerald-600 hover:text-emerald-300"
-              title={fullCmd}
             >
               ⎘ Copy {isCommitSigning ? "commit+push" : "push"} command
             </button>
             <button
-              onClick={(e) => { e.stopPropagation(); BrowserOpenURL("file://" + needsPRInfo.worktree_dir); }}
+              onClick={(e) => { e.stopPropagation(); BrowserOpenURL("file://" + info.worktree_dir); }}
               onMouseDown={(e) => e.stopPropagation()}
               onPointerDown={(e) => e.stopPropagation()}
               className="px-1.5 py-0.5 rounded text-[10px] border border-slate-700 text-slate-400 hover:border-slate-500 hover:text-slate-200"
-              title={needsPRInfo.worktree_dir}
+              title={info.worktree_dir}
             >
               ⌂ Open folder
             </button>

--- a/frontend/src/components/WorkspacesPanel.tsx
+++ b/frontend/src/components/WorkspacesPanel.tsx
@@ -8,6 +8,50 @@ import { SkillProfileEditor } from "./SkillProfileEditor";
 import { LabelsPanel } from "./LabelsPanel";
 import { noAutoCorrect } from "../lib/inputs";
 
+const SIGNING_OPTIONS: { value: string; label: string; description: string }[] = [
+  { value: "auto",       label: "Auto (recommended)", description: "Try GitHub API → local signing → manual fallback" },
+  { value: "github_api", label: "GitHub API only",    description: "Only use GitHub API commits; emit NEEDS_PR if that fails" },
+  { value: "local",      label: "Local signing only", description: "Only attempt local git commit -S + push" },
+  { value: "manual",     label: "Manual always",      description: "Never attempt automation; always prepare a worktree command" },
+];
+
+function SigningStrategyEditor({ workspace, onSave }: { workspace: types.Workspace; onSave: () => void }) {
+  const current = workspace.signing_strategy || "auto";
+
+  async function save(strategy: string) {
+    const updated = types.Workspace.createFrom({
+      ...workspace,
+      signing_strategy: strategy === "auto" ? "" : strategy,
+    });
+    await UpdateWorkspace(updated);
+    onSave();
+  }
+
+  return (
+    <div>
+      <div className="text-xs text-slate-400 mb-2">Commit signing strategy</div>
+      <div className="flex flex-col gap-1.5">
+        {SIGNING_OPTIONS.map((opt) => (
+          <label key={opt.value} className="flex items-start gap-2 text-xs cursor-pointer">
+            <input
+              type="radio"
+              name={`signing-${workspace.id}`}
+              value={opt.value}
+              checked={current === opt.value}
+              onChange={() => save(opt.value)}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="text-slate-200">{opt.label}</span>
+              <span className="text-slate-500 ml-1">— {opt.description}</span>
+            </span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function AutoArchiveEditor({ workspace, onSave }: { workspace: types.Workspace; onSave: () => void }) {
   const cfg = workspace.auto_archive ?? { enabled: false, days_closed: 7 };
   const [enabled, setEnabled] = useState(cfg.enabled);
@@ -307,6 +351,7 @@ export function WorkspacesPanel() {
                       <PipelineEditor workspace={ws} />
                     </div>
                     <AutoArchiveEditor workspace={ws} onSave={refresh} />
+                    <SigningStrategyEditor workspace={ws} onSave={refresh} />
                     <div>
                       <div className="text-xs text-slate-400 mb-2">Labels</div>
                       <LabelsPanel workspaceID={ws.id} />

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -137,6 +137,8 @@ export function PoolSpendToday(arg1:string):Promise<number>;
 
 export function PostPRComment(arg1:string,arg2:number,arg3:string,arg4:boolean):Promise<void>;
 
+export function PrepareManualPushCommand(arg1:string,arg2:number):Promise<string>;
+
 export function ProbeProviderModels(arg1:types.Provider,arg2:string,arg3:string):Promise<Array<string>>;
 
 export function ReadTranscript(arg1:string):Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -254,6 +254,10 @@ export function PostPRComment(arg1, arg2, arg3, arg4) {
   return window['go']['main']['App']['PostPRComment'](arg1, arg2, arg3, arg4);
 }
 
+export function PrepareManualPushCommand(arg1, arg2) {
+  return window['go']['main']['App']['PrepareManualPushCommand'](arg1, arg2);
+}
+
 export function ProbeProviderModels(arg1, arg2, arg3) {
   return window['go']['main']['App']['ProbeProviderModels'](arg1, arg2, arg3);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1344,6 +1344,8 @@ export namespace types {
 	    worktree_dir: string;
 	    reason: string;
 	    kind: string;
+	    commit_msg_file?: string;
+	    commit_msg?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new NeedsPRInfo(source);
@@ -1355,6 +1357,8 @@ export namespace types {
 	        this.worktree_dir = source["worktree_dir"];
 	        this.reason = source["reason"];
 	        this.kind = source["kind"];
+	        this.commit_msg_file = source["commit_msg_file"];
+	        this.commit_msg = source["commit_msg"];
 	    }
 	}
 	export class Question {
@@ -2016,6 +2020,7 @@ export namespace types {
 	    conventions: ConventionHints;
 	    enabled: boolean;
 	    auto_archive?: AutoArchive;
+	    signing_strategy?: string;
 	    pipeline?: WorkspacePipeline;
 	    execution_target?: string;
 	    remote_config?: RemoteConfig;
@@ -2038,6 +2043,7 @@ export namespace types {
 	        this.conventions = this.convertValues(source["conventions"], ConventionHints);
 	        this.enabled = source["enabled"];
 	        this.auto_archive = this.convertValues(source["auto_archive"], AutoArchive);
+	        this.signing_strategy = source["signing_strategy"];
 	        this.pipeline = this.convertValues(source["pipeline"], WorkspacePipeline);
 	        this.execution_target = source["execution_target"];
 	        this.remote_config = this.convertValues(source["remote_config"], RemoteConfig);

--- a/internal/handlers/needspr.go
+++ b/internal/handlers/needspr.go
@@ -1,0 +1,42 @@
+// Package handlers contains helper logic for specific event-bus handlers that
+// would otherwise bloat app.go (issue #124).
+package handlers
+
+import (
+	"fmt"
+
+	"prismconductor/internal/types"
+)
+
+// BuildManualPushCommand returns the exact shell command the user should paste
+// to complete a Tier 3 commit+push from the preserved worktree (issue #175).
+//
+// For commit_signing kind (commit never landed): stages, commits from the
+// worker-drafted commit-msg file using git commit -S -F so shell metacharacters
+// in the message don't corrupt the clipboard string, then pushes.
+//
+// For push kind (commit landed locally but remote push was rejected): only pushes.
+func BuildManualPushCommand(info *types.NeedsPRInfo) string {
+	if info == nil {
+		return ""
+	}
+	switch info.Kind {
+	case "commit_signing":
+		if info.CommitMsgFile != "" {
+			return fmt.Sprintf(
+				"cd %q && git add -A && git commit -S -F %q && git push -u origin %s",
+				info.WorktreeDir, info.CommitMsgFile, info.Branch,
+			)
+		}
+		// Commit msg file not present: fall back to a placeholder message.
+		return fmt.Sprintf(
+			"cd %q && git add -A && git commit -S -m 'feat: implement changes' && git push -u origin %s",
+			info.WorktreeDir, info.Branch,
+		)
+	default: // "push" or empty
+		return fmt.Sprintf(
+			"cd %q && git push -u origin %s",
+			info.WorktreeDir, info.Branch,
+		)
+	}
+}

--- a/internal/handlers/needspr_test.go
+++ b/internal/handlers/needspr_test.go
@@ -1,0 +1,111 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"prismconductor/internal/types"
+)
+
+func TestBuildManualPushCommand_NilInfo(t *testing.T) {
+	if got := BuildManualPushCommand(nil); got != "" {
+		t.Errorf("expected empty string for nil info, got %q", got)
+	}
+}
+
+func TestBuildManualPushCommand_PushKind(t *testing.T) {
+	info := &types.NeedsPRInfo{
+		Branch:      "feat/my-branch",
+		WorktreeDir: "/tmp/worktrees/prismconductor-42",
+		Kind:        "push",
+	}
+	cmd := BuildManualPushCommand(info)
+	if !strings.Contains(cmd, "git push -u origin feat/my-branch") {
+		t.Errorf("push command missing push step: %q", cmd)
+	}
+	if strings.Contains(cmd, "git commit") {
+		t.Errorf("push command should not contain commit step: %q", cmd)
+	}
+}
+
+func TestBuildManualPushCommand_CommitSigningWithFile(t *testing.T) {
+	info := &types.NeedsPRInfo{
+		Branch:        "feat/signing-branch",
+		WorktreeDir:   "/tmp/worktrees/prismconductor-99",
+		Kind:          "commit_signing",
+		CommitMsgFile: "/tmp/worktrees/prismconductor-99/.prismconductor/commit-msg/99.txt",
+	}
+	cmd := BuildManualPushCommand(info)
+	if !strings.Contains(cmd, "git commit -S -F") {
+		t.Errorf("commit+push command missing signed commit step: %q", cmd)
+	}
+	if !strings.Contains(cmd, "git push -u origin feat/signing-branch") {
+		t.Errorf("commit+push command missing push step: %q", cmd)
+	}
+	if !strings.Contains(cmd, "99.txt") {
+		t.Errorf("commit+push command should reference commit msg file: %q", cmd)
+	}
+}
+
+func TestBuildManualPushCommand_CommitSigningNoFile(t *testing.T) {
+	info := &types.NeedsPRInfo{
+		Branch:      "feat/signing-branch",
+		WorktreeDir: "/tmp/worktrees/prismconductor-99",
+		Kind:        "commit_signing",
+		// CommitMsgFile intentionally empty
+	}
+	cmd := BuildManualPushCommand(info)
+	if !strings.Contains(cmd, "git commit -S -m") {
+		t.Errorf("fallback command should use -m flag: %q", cmd)
+	}
+	if !strings.Contains(cmd, "git push -u origin feat/signing-branch") {
+		t.Errorf("fallback command missing push step: %q", cmd)
+	}
+}
+
+// TestBuildManualPushCommand_TierTransitions verifies that the three signing
+// strategies map to the correct command shape (simulates Tier 1/2/3 outcomes).
+func TestBuildManualPushCommand_TierTransitions(t *testing.T) {
+	tests := []struct {
+		name          string
+		info          *types.NeedsPRInfo
+		wantContains  []string
+		wantAbsent    []string
+	}{
+		{
+			name: "tier3 commit signing with msg file",
+			info: &types.NeedsPRInfo{
+				Branch:        "feat/tier3",
+				WorktreeDir:   "/w",
+				Kind:          "commit_signing",
+				CommitMsgFile: "/w/.prismconductor/commit-msg/1.txt",
+			},
+			wantContains: []string{"git add -A", "git commit -S -F", "git push -u origin feat/tier3"},
+		},
+		{
+			name: "tier2 push-only after local commit succeeded",
+			info: &types.NeedsPRInfo{
+				Branch:      "feat/tier2",
+				WorktreeDir: "/w",
+				Kind:        "push",
+			},
+			wantContains: []string{"git push -u origin feat/tier2"},
+			wantAbsent:   []string{"git commit"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := BuildManualPushCommand(tc.info)
+			for _, want := range tc.wantContains {
+				if !strings.Contains(cmd, want) {
+					t.Errorf("expected %q in command %q", want, cmd)
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(cmd, absent) {
+					t.Errorf("unexpected %q in command %q", absent, cmd)
+				}
+			}
+		})
+	}
+}

--- a/internal/skills/bundle/skills/conductor-execute.md
+++ b/internal/skills/bundle/skills/conductor-execute.md
@@ -74,17 +74,85 @@ These run before commit. Failures here are **stop-the-world** events: print `BLO
 
 ### 5. Commit + push + PR (NON-NEGOTIABLE)
 
-12. `git add` only the files you modified (avoid `git add -A` — never commit unrelated WIP that may be in the tree from another task). If `git status` shows nothing staged AND nothing modified (the prior worker already committed before pausing), skip the commit step cleanly and proceed to the PR check.
-13. `git commit -m "<short subject>\n\nCloses #<num>\n\nCo-Authored-By: PrismConductor worker <noreply@anthropic.com>"`. Subject must reference the issue number; body must include `Closes #<num>` so the PR auto-closes the issue on merge.
-14. `git push -u origin HEAD`.
-15. **Single-PR enforcement (#17, Q6):** before `gh pr create`, run `gh pr list --head <branch> --json number,url`. If non-empty, an earlier resume already opened the PR — append a follow-up comment via `gh pr comment <num> --body-file -` summarizing this leg's work, capture the existing URL, and SKIP `gh pr create`. Otherwise: `gh pr create --draft --base <BASE> --title "<short subject> (#<num>)" --body-file -`. The body should contain:
+The commit+push step uses a **three-tier fallback** (issue #175). Attempt each
+tier in order; on success proceed to the PR step. On failure fall through to
+the next tier. The workspace `signing_strategy` field may restrict which tiers
+to attempt: `github_api` = Tier 1 only, `local` = Tier 2 only, `manual` = Tier 3
+straight away, `auto` (default/empty) = Tier 1 → Tier 2 → Tier 3.
+
+**Tier 1 — GitHub API commit (signed by GitHub)**
+
+12a. Draft the commit message (subject + body with `Closes #<num>` +
+     `Co-Authored-By: PrismConductor worker <noreply@anthropic.com>`).
+12b. Call the GitHub GraphQL mutation `createCommitOnBranch` using the
+     workspace PAT (`gh api graphql`). The mutation requires:
+     - `repositoryNameWithOwner`: `<owner>/<repo>`
+     - `branch.branchName`: the current branch name
+     - `expectedHeadOid`: `git rev-parse HEAD` (the current tip SHA)
+     - `message.headline` / `message.body`: split from the drafted message
+     - `fileChanges.additions` / `fileChanges.deletions`: list every modified
+       or deleted path with base64-encoded content for additions.
+
+     Example invocation (write the JSON body to a temp file to avoid shell
+     quoting issues):
+     ```
+     gh api graphql -f query='mutation($input: CreateCommitOnBranchInput!) {
+       createCommitOnBranch(input: $input) { commit { oid } }
+     }' -f input="$(cat /tmp/commit-payload.json)"
+     ```
+
+     **File-size / payload limits:** if the total additions payload exceeds
+     ~8 MB or the number of files exceeds 200, skip Tier 1 and fall through
+     to Tier 2 — do not attempt a partial commit.
+
+     **Retry on transient errors:** if the API returns a 5xx status, wait 2 s
+     and retry once. On second failure fall through to Tier 2.
+
+     On success: record the returned SHA. Proceed to `git push -u origin HEAD`
+     (the API already pushed the commit; local HEAD may be behind — a push is
+     still needed to update the remote tracking ref if you want local sync, or
+     you may skip the local push and go straight to PR creation since the commit
+     already exists on the remote).
+
+**Tier 2 — local signed commit + push**
+
+12c. `git add` only the files you modified (avoid `git add -A`). If nothing is
+     staged and nothing is modified, skip commit and proceed to push.
+12d. Write the commit message to `.prismconductor/commit-msg/<issue>.txt` (full
+     content; truncate only the GraphQL payload, never the file).
+12e. `git commit -S -F .prismconductor/commit-msg/<issue>.txt` with a 30 s
+     timeout. Do NOT attempt to supply a passphrase. If the process blocks on
+     TTY or times out, fall through to Tier 3.
+12f. `git push -u origin HEAD`.
+
+**Tier 3 — preserved worktree + manual command (NEEDS_PR)**
+
+12g. Stage all changes: `git add -A`.
+12h. Write the full drafted commit message to
+     `.prismconductor/commit-msg/<issue>.txt` (create parent directories if
+     missing).
+12i. Print the NEEDS_PR sentinel on its own line:
+     ```
+     NEEDS_PR: commit signing unavailable — manual push required
+     ```
+     The conductor parses this, preserves the worktree, and surfaces a
+     copy-pastable command to the user. Do NOT print `PR_OPENED:` or
+     `Work complete.` — those are reserved for successful pushes.
+
+     After printing the sentinel, exit cleanly (exit 0). The conductor moves
+     the card to NEEDS_PR state.
+
+**After a successful Tier 1 or Tier 2 push:**
+
+13. **Single-PR enforcement (#17, Q6):** before `gh pr create`, run `gh pr list --head <branch> --json number,url`. If non-empty, an earlier resume already opened the PR — append a follow-up comment via `gh pr comment <num> --body-file -` summarizing this leg's work, capture the existing URL, and SKIP `gh pr create`. Otherwise: `gh pr create --draft --base <BASE> --title "<short subject> (#<num>)" --body-file -`. The body should contain:
     - A 1-2 sentence summary
     - The list of files modified
     - **Verification:** lint command + result, build command + result, smoke command + result (`pass` / `fail` with first console error / `skipped — spec not present`), test command + result with pass/fail counts
+    - Which commit tier succeeded (Tier 1 / Tier 2)
     - Anything skipped or flagged for human review
     - `Workspace mode: per-execute worktree at <pwd>` — surfaces the conductor isolation mode for reviewers (run `pwd` to fill the path).
     - The literal trailer line `Closes #<num>`
-16. Capture the PR URL from `gh pr create` (or `gh pr list` in the reuse case).
+14. Capture the PR URL from `gh pr create` (or `gh pr list` in the reuse case).
 
 ### 6. Sentinels for the conductor
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -45,19 +45,34 @@ type RemoteConfig struct {
 	TokenExpired bool `json:"token_expired,omitempty"`
 }
 
+// SigningStrategy controls how the conductor-execute worker attempts to commit
+// and push work on behalf of a workspace (issue #175).
+type SigningStrategy string
+
+const (
+	// SigningStrategyAuto tries Tier 1 (GitHub API), then Tier 2 (local signing),
+	// then Tier 3 (manual NEEDS_PR). This is the default when unset.
+	SigningStrategyAuto      SigningStrategy = "auto"
+	SigningStrategyGitHubAPI SigningStrategy = "github_api"
+	SigningStrategyLocal     SigningStrategy = "local"
+	SigningStrategyManual    SigningStrategy = "manual"
+)
 type Workspace struct {
-	ID            string          `json:"id"`
-	DisplayName   string          `json:"display_name"`
-	RepoPath      string          `json:"repo_path"`
-	GitHubOwner   string          `json:"github_owner"`
-	GitHubRepo    string          `json:"github_repo"`
-	DefaultBranch string          `json:"default_branch"`
-	Color         string          `json:"color"`
-	AgentEnv      EnvSpec         `json:"agent_env"`
-	SkillProfile  SkillProfile    `json:"skill_profile"`
-	Conventions   ConventionHints `json:"conventions"`
-	Enabled       bool            `json:"enabled"`
-	AutoArchive   AutoArchive     `json:"auto_archive,omitempty"`
+	ID              string          `json:"id"`
+	DisplayName     string          `json:"display_name"`
+	RepoPath        string          `json:"repo_path"`
+	GitHubOwner     string          `json:"github_owner"`
+	GitHubRepo      string          `json:"github_repo"`
+	DefaultBranch   string          `json:"default_branch"`
+	Color           string          `json:"color"`
+	AgentEnv        EnvSpec         `json:"agent_env"`
+	SkillProfile    SkillProfile    `json:"skill_profile"`
+	Conventions     ConventionHints `json:"conventions"`
+	Enabled         bool            `json:"enabled"`
+	AutoArchive     AutoArchive     `json:"auto_archive,omitempty"`
+	// SigningStrategy controls the commit+push tier used by execute workers.
+	// Empty string is equivalent to SigningStrategyAuto (issue #175).
+	SigningStrategy SigningStrategy `json:"signing_strategy,omitempty"`
 	// Pipeline holds the custom pipeline configuration for this workspace.
 	// Nil means "use the default Plan→Execute→Close flow" (issue #146).
 	Pipeline *WorkspacePipeline `json:"pipeline,omitempty"`
@@ -366,6 +381,13 @@ type NeedsPRInfo struct {
 	// Kind is "commit_signing" when the commit itself failed, or "push" when
 	// commits landed locally but the remote push was rejected.
 	Kind string `json:"kind"`
+	// CommitMsgFile is the path to the worker-drafted commit message file
+	// written by Tier 3 of the three-tier commit fallback (issue #175).
+	// Empty when the commit landed but the push failed.
+	CommitMsgFile string `json:"commit_msg_file,omitempty"`
+	// CommitMsg is the first 500 bytes of CommitMsgFile content for inline
+	// display in the UI. Empty when CommitMsgFile is empty.
+	CommitMsg string `json:"commit_msg,omitempty"`
 }
 
 type BoardColumn string


### PR DESCRIPTION
## Summary

Workers no longer dead-end on GPG signing failures. Automated runs now attempt three tiers in order: GitHub API commit (signed by GitHub), local `git commit -S`, then a preserved worktree with a copy-pastable command for manual push. Workspace owners can lock to a specific tier via a new radio group in workspace settings.

## Files modified

- `internal/types/types.go` — `SigningStrategy` enum + field on `Workspace`; `CommitMsgFile`/`CommitMsg` fields on `NeedsPRInfo`
- `internal/handlers/needspr.go` — `BuildManualPushCommand` helper (new file)
- `internal/handlers/needspr_test.go` — unit + tier-transition tests (new file)
- `app.go` — `handleNeedsPR` reads worker-written commit msg file; new `PrepareManualPushCommand` bound method
- `internal/skills/bundle/skills/conductor-execute.md` — three-tier commit+push protocol documented for workers
- `frontend/src/components/Card.tsx` — collapsible commit message preview; Copy button calls `PrepareManualPushCommand` with local fallback
- `frontend/src/components/WorkspacesPanel.tsx` — `SigningStrategyEditor` radio group in workspace settings
- `frontend/wailsjs/go/main/App.js` / `App.d.ts` / `models.ts` — regenerated bindings

## Verification

- **Lint:** `go vet ./internal/...` — pass
- **Build:** `wails build` — pass (8.66 s)
- **Smoke test:** `cd tests && npx playwright test e2e/startup.spec.ts` — pass (exit 0)
- **Tests:** `go test ./internal/...` — all pass (25 packages)

## Notes

- `.prismconductor/commit-msg/` directory structure is created by the worker at Tier 3 time; no pre-seeding needed.
- The Tier 1 GraphQL payload builder is described in `conductor-execute.md` (skill-level instruction for the agent); no server-side GraphQL library was added since the worker calls `gh api graphql` directly.

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-175

Closes #175