### PR TITLE
fix(conflicts): parse merge-tree output correctly + accept exit 1 as conflict-present

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -132,11 +132,20 @@ func MergeConflictFiles(repoPath, baseRef, headRef string) ([]string, error) {
 	if repoPath == "" || baseRef == "" || headRef == "" {
 		return nil, fmt.Errorf("MergeConflictFiles: repoPath/baseRef/headRef all required")
 	}
-	// `git merge-tree --name-only --merge-base=<base> <head> <other>` writes
-	// one path per line for files that conflict during the simulated
-	// 3-way merge. Empty stdout = no conflicts. Non-zero exit = error
-	// running the merge (e.g. unrelated histories) or git too old to
-	// support these flags.
+	// `git merge-tree --name-only --merge-base=<mb> <base> <head>` output:
+	//   - Line 1: tree SHA of the merge result (NOT a filename — must skip).
+	//   - Subsequent lines: paths of files with conflicts, one per line.
+	//   - Exit status 0 when there are NO conflicts (clean merge).
+	//   - Exit status 1 when there ARE conflicts. THIS IS THE HAPPY PATH
+	//     for our use case; it tells us the merge would conflict and
+	//     gives us the list. Exit > 1 (128 etc.) is a real error
+	//     (fatal git problem, refs missing, etc.).
+	//
+	// Previously we treated exit 1 as failure and fell back to the
+	// GitHub PR-files API for every dirty PR — listing every file the
+	// PR touched instead of the actually-conflicting subset. That's
+	// the user-reported bug on PR #181 (showed 11 files when only
+	// internal/types/types.go actually conflicts).
 	mergeBase, err := run(repoPath, "git", "merge-base", baseRef, headRef)
 	if err != nil {
 		return nil, fmt.Errorf("merge-base %s %s: %w", baseRef, headRef, err)
@@ -145,21 +154,61 @@ func MergeConflictFiles(repoPath, baseRef, headRef string) ([]string, error) {
 	if mergeBase == "" {
 		return nil, fmt.Errorf("merge-base returned empty for %s..%s", baseRef, headRef)
 	}
-	out, err := run(repoPath, "git",
+	out, exitCode, err := runWithExit(repoPath, "git",
 		"merge-tree",
 		"--name-only",
 		"--merge-base="+mergeBase,
 		baseRef, headRef)
-	if err != nil {
-		// Older git or unrelated histories: surface a typed error so the
-		// caller can fall back rather than treating an empty list as
-		// "no conflicts."
-		return nil, fmt.Errorf("merge-tree %s %s: %w", baseRef, headRef, err)
+	switch exitCode {
+	case 0:
+		// Clean merge — no conflicts. Caller already gates on
+		// pr.MergeableState=='dirty' so this branch is rare in practice
+		// but harmless: return empty list.
+		return nil, nil
+	case 1:
+		// Conflict path — parse output. Continue below.
+	default:
+		// Real error: older git that doesn't support --merge-base,
+		// missing refs, fatal repo state, etc. Surface to caller for
+		// fallback to FetchPRFiles.
+		if err != nil {
+			return nil, fmt.Errorf("merge-tree %s %s: %w (exit %d)", baseRef, headRef, err, exitCode)
+		}
+		return nil, fmt.Errorf("merge-tree %s %s: unexpected exit %d", baseRef, headRef, exitCode)
 	}
+
+	// Parse the conflict-path list. The actual stdout format from
+	// `git merge-tree --name-only` is:
+	//
+	//   <tree-sha>
+	//   <path1>
+	//   <path2>
+	//   ...
+	//                          <-- BLANK LINE (separator)
+	//   Auto-merging <path1>   <-- human-readable summary; ignore
+	//   CONFLICT (content): Merge conflict in <path1>
+	//   ...
+	//
+	// We read line-by-line: skip the first non-empty line (tree SHA),
+	// collect non-empty lines into `files`, and STOP at the first
+	// blank line — anything after that is human-readable summary
+	// (Auto-merging / CONFLICT) which would otherwise pollute the
+	// list with non-paths.
 	var files []string
+	seenSHA := false
 	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
+		line = strings.TrimRight(line, "\r")
 		if line == "" {
+			if seenSHA {
+				// Hit the separator after we've started reading paths.
+				// Everything after this is summary noise — stop.
+				break
+			}
+			// Leading blank lines (rare but tolerate) — skip.
+			continue
+		}
+		if !seenSHA {
+			seenSHA = true // tree SHA, discard
 			continue
 		}
 		files = append(files, line)
@@ -230,4 +279,26 @@ func run(dir, name string, args ...string) (string, error) {
 	}
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+// runWithExit is run() + the process exit code. Used by callers that need
+// to distinguish meaningful non-zero exits (e.g. `git merge-tree` exits 1
+// when there are conflicts — which is the case we actually want output
+// for) from real errors. Returns STDOUT only (not combined output) so
+// stderr noise like git's "Auto-merging X" / "CONFLICT" status lines
+// doesn't pollute the parseable stdout. exitCode is 0 on success, the
+// process exit on non-zero exit, or -1 if the process never started.
+func runWithExit(dir, name string, args ...string) (string, int, error) {
+	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
+	if err == nil {
+		return string(out), 0, nil
+	}
+	if ee, ok := err.(*exec.ExitError); ok {
+		return string(out), ee.ExitCode(), err
+	}
+	return string(out), -1, err
 }

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -58,4 +59,65 @@ func TestParseWorktreeList(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMergeConflictFiles_RealRepo runs against a fixture repo built fresh in
+// a temp dir. Two branches diverge with a conflicting edit on one file and
+// a non-conflicting addition on another. MergeConflictFiles must return
+// only the conflicting file — NOT the additional file the head branch
+// touched. Pre-fix the function returned the merge-tree SHA as a "file"
+// AND treated git's exit-1 (conflicts present) as an error → caller fell
+// back to the GitHub PR-files API which lists every modified file.
+// Witnessed live on PR #181 (1 actual conflict, 11 reported).
+func TestMergeConflictFiles_RealRepo(t *testing.T) {
+	dir := t.TempDir()
+	mustRun := func(args ...string) {
+		t.Helper()
+		if _, err := run(dir, args[0], args[1:]...); err != nil {
+			t.Fatalf("%v: %v", args, err)
+		}
+	}
+	write := func(path, body string) {
+		t.Helper()
+		if _, err := run(dir, "sh", "-c", "printf %s "+shellQuote(body)+" > "+shellQuote(path)); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	// Init repo, configure user (required for commit).
+	mustRun("git", "init", "-q", "-b", "main")
+	mustRun("git", "config", "user.email", "test@example.com")
+	mustRun("git", "config", "user.name", "Test")
+
+	// Initial commit on main.
+	write("a.txt", "main version 1\n")
+	write("b.txt", "shared\n")
+	mustRun("git", "add", ".")
+	mustRun("git", "commit", "-q", "-m", "initial")
+
+	// Branch off, edit a.txt and add c.txt.
+	mustRun("git", "checkout", "-q", "-b", "feature")
+	write("a.txt", "feature edit\n")
+	write("c.txt", "added by feature\n")
+	mustRun("git", "add", ".")
+	mustRun("git", "commit", "-q", "-m", "feature changes")
+
+	// Back to main, edit a.txt differently → conflicts on a.txt only.
+	mustRun("git", "checkout", "-q", "main")
+	write("a.txt", "main edit\n")
+	mustRun("git", "commit", "-aq", "-m", "main changes")
+
+	got, err := MergeConflictFiles(dir, "main", "feature")
+	if err != nil {
+		t.Fatalf("MergeConflictFiles: %v", err)
+	}
+	want := []string{"a.txt"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("MergeConflictFiles = %v, want %v (must include only the conflicting path, NOT the merge-tree SHA, NOT non-conflicting changes like c.txt)", got, want)
+	}
+}
+
+// shellQuote wraps a string for safe sh -c interpolation.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }


### PR DESCRIPTION
## Summary

Card showed 11 files under MERGE CONFLICT for PR #181 when the actual count was **1** (`internal/types/types.go`). #167 + #169 supposedly fixed this; turns out the precise-detection was silently falling through to the GitHub PR-files API on every dirty PR. Two parsing bugs.

## Bug 1: exit status 1 was treated as failure

`git merge-tree --name-only` exits status 1 when there ARE conflicts — which is the case we actually want output for. Our `run()` wrapper treated non-zero as a failure → `MergeConflictFiles` returned err → poller's fallback to `Client.FetchPRFiles` (full PR changeset) fired.

**Fix**: new `runWithExit` helper that returns the exit code separately from the error. `MergeConflictFiles` treats:
- Exit 0 → clean merge, no conflict files (rare in our caller because we gate on `pr.MergeableState=='dirty'`)
- Exit 1 → conflicts present, parse the output (the happy path for our use case)
- Other → real error, surface to caller for fallback

## Bug 2: parser included tree SHA + summary lines as fake filenames

`git merge-tree --name-only` stdout format is:

```
<tree-sha>
<path1>
<path2>
                            ← blank line separator
Auto-merging <path1>        ← human-readable summary
CONFLICT (content): Merge conflict in <path1>
```

Old parser added every non-empty line to the file list, so even when the call "succeeded" we'd get the tree SHA AND the "Auto-merging"/"CONFLICT" summary lines as bogus filenames.

**Fix**: skip the first non-empty line (tree SHA), STOP at the first blank line (beginning of summary block).

Also switched `runWithExit` to `cmd.Output()` (stdout only) so stderr noise stays out of the parseable buffer.

## Tests

`TestMergeConflictFiles_RealRepo` builds a fixture repo in `t.TempDir()` with a real 3-way merge conflict on one file plus a non-conflicting addition on another. Asserts `MergeConflictFiles` returns exactly the conflicting path — no SHA, no summary noise, no non-conflicting changes. Real-git integration; doesn't mock anything.

`go test ./...` clean.

## Test plan
- [ ] Restart conductor with PR #181 still dirty. Within one poll cycle, MERGE CONFLICT badge updates from 11 files to 1 (`internal/types/types.go`)
- [ ] No fallback log line (`falling back to PR file list`) in logs for any dirty PR running on git ≥ 2.38

## Related
- #167 — original precise-detection (this PR fixes its parser)
- #169 — re-detect on every poll (still correct; this just makes the underlying call work)