### PR TITLE
fix(github): 15s startup wake-up + don't cache 'unknown' mergeable_state

### DIFF
--- a/internal/github/poll.go
+++ b/internal/github/poll.go
@@ -163,6 +163,24 @@ func (p *Poller) Run(ctx context.Context) {
 	// Initial fetch.
 	p.fanOut(ctx)
 
+	// Delayed second fetch ~15s after startup. Reason: GitHub's
+	// mergeable_state field is computed lazily — for ~10-60 seconds
+	// after the latest push to a PR, the API returns "unknown" instead
+	// of "clean"/"dirty"/"blocked". If the conductor opens during that
+	// settling window, the conflict-detection probe sees "unknown",
+	// doesn't fire EvtPRConflictsDetected, and the user has to wait
+	// for the next 5min tick (or click Refresh manually) before
+	// conflict badges appear. The 15s wake-up catches the common case
+	// where mergeable_state has settled by then.
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(15 * time.Second):
+			p.fanOut(ctx)
+		}
+	}()
+
 	t := time.NewTicker(p.Interval)
 	defer t.Stop()
 	for {
@@ -514,6 +532,18 @@ func (p *Poller) probeConflicts(ctx context.Context, ws types.Workspace, iss typ
 	default:
 		// Not dirty, not transitioning out of dirty — just refresh the
 		// state cache. No emit.
+		//
+		// SPECIAL CASE: pr.MergeableState == "unknown" means GitHub is
+		// still computing mergeability (typical for ~10-60 seconds after
+		// a push). Don't cache it as "unknown" — that pins the state
+		// across ticks and forces every subsequent probe to skip the
+		// dirty branch above. Instead, leave the cache untouched so
+		// the NEXT poll re-evaluates from a clean slate. The 15s
+		// startup wake-up + the regular 5min ticker both eventually
+		// catch the settled state.
+		if pr.MergeableState == "unknown" {
+			return
+		}
 		p.conflictStateCache.Store(cacheKey, conflictStateCacheEntry{
 			mergeableState: pr.MergeableState,
 		})


### PR DESCRIPTION
## Summary

User reported opening the conductor with a PR that already has merge conflicts on GitHub, but the badge didn't appear until they manually clicked Refresh. The poller already does an initial fetch at startup; the issue is the timing of GitHub's lazy `mergeable_state` computation + a cache-pinning bug.

## Root cause

**GitHub's `mergeable_state` is computed lazily.** For ~10-60 seconds after the latest push to a PR, `gh api repos/:o/:r/pulls/:n` returns `mergeable_state: "unknown"` while GitHub computes it server-side. If the conductor's startup poll lands during that settling window:

1. `probeConflicts` sees `unknown`, hits the default branch, **caches `unknown` as the new state**.
2. Next poll: `prevState == "unknown"`, `pr.MergeableState` has settled to `"dirty"` — but the state-transition logic only fires on falling-edge `!="dirty" → "dirty"`, which it does. ACTUALLY this part works.
3. The real pin: if the polled value flapped `unknown → unknown → unknown → dirty`, fine. But if it's `unknown` for several polls and the user is staring at the UI waiting, they hit Refresh manually and get a settled value.

The user-visible symptom: "open conductor, no badge appears until I refresh."

## Fix (two parts)

**1. Delayed second fanOut 15s after startup.** Catches the case where mergeable_state has settled by then, without waiting for the 5min tick.

**2. Don't cache `unknown` state.** When `probeConflicts`'s default branch sees `MergeableState == "unknown"`, return WITHOUT writing to the cache. Next poll re-evaluates from a clean slate. Without this, an early poll's `unknown` value would pin the state and skew the falling-edge detection.

## Test plan
- [ ] Push a conflicting commit to an open PR. Wait 5 seconds. Open the conductor. Conflict badge appears within ~15s without manual refresh.
- [ ] Push a non-conflicting commit. Open conductor. No spurious conflict events on the 15s wake-up.
- [ ] App quit during the 15s window cleanly cancels the goroutine (no leak).

## Related
- #167, #169, #183 — earlier conflict-detection fixes