### PR TITLE
fix(conflicts): clear conflictsInfo when resolver completes; poke poller

### DIFF
--- a/app.go
+++ b/app.go
@@ -453,6 +453,27 @@ func (a *App) handleSessionStateChange(sess types.Session, prev types.SessionSta
 	if prev == sess.State {
 		return
 	}
+
+	// When an execute session COMPLETES on a card that had merge conflicts
+	// recorded, optimistically clear the conflict info so the card doesn't
+	// stay glowing red after the resolver demonstrably finished. The
+	// poller's next cycle will re-detect via probeConflicts if the
+	// resolver actually didn't fix it. Without this, the badge persists
+	// for up to 5 minutes after the resolver session terminates because
+	// EvtPRConflictsResolved only fires when GitHub's mergeable_state
+	// transitions out of "dirty" — which the conductor only learns about
+	// at the next poll tick. Witnessed on issue #177.
+	if sess.Mode == types.ModeExecute && sess.State == types.StateCompleted &&
+		a.assembler != nil && a.assembler.HasConflictsInfo(sess.WorkspaceID, sess.IssueNumber) {
+		a.assembler.ClearConflictsInfo(sess.WorkspaceID, sess.IssueNumber)
+		// Kick the poller for definitive verification on the next cycle.
+		// If the conflict actually persists, probeConflicts will re-fire
+		// EvtPRConflictsDetected and the badge comes back. If it's gone,
+		// nothing happens and the badge stays cleared.
+		if a.poller != nil {
+			a.poller.PokeNow()
+		}
+	}
 	switch sess.State {
 	case types.StateWaitingForInput, types.StatePausedForQuestion, types.StateBlocked, types.StateCompleted, types.StateFailed:
 		// One notification per transition; dedupe identical kicks within 2s.

--- a/internal/issueview/assembler.go
+++ b/internal/issueview/assembler.go
@@ -182,6 +182,45 @@ func (a *Assembler) Reassemble(wsID string, issueNum int) {
 	a.reassembleAndForceEmit(wsID, issueNum)
 }
 
+// ClearConflictsInfo optimistically removes the in-memory conflict-files
+// state for an issue and re-emits the IssueView. Called from app.go's
+// session-state handler when an execute session completes on a card
+// that previously had merge conflicts — the resolver worker just pushed
+// a fixup, so we drop the red badge immediately rather than waiting up
+// to 5 minutes for the next GitHub poll to confirm via mergeable_state.
+//
+// If the resolver actually failed to fix the conflict, the next poll
+// re-detects via probeConflicts and re-sets this entry. Worst case: a
+// brief window (one poll cycle) where the badge is gone but the
+// conflict is still present. Prefer that over the previous behavior —
+// card stuck glowing red after the resolver demonstrably succeeded.
+//
+// No-op if no conflict was recorded for this issue.
+func (a *Assembler) ClearConflictsInfo(workspaceID string, issueNumber int) {
+	key := workspaceID + "#" + strconv.Itoa(issueNumber)
+	a.mu.Lock()
+	_, had := a.conflictFails[key]
+	if had {
+		delete(a.conflictFails, key)
+	}
+	a.mu.Unlock()
+	if had {
+		a.reassembleAndForceEmit(workspaceID, issueNumber)
+	}
+}
+
+// HasConflictsInfo reports whether the assembler currently has merge-
+// conflict state recorded for the given issue. Used by app.go's
+// session-state handler to decide whether to invoke ClearConflictsInfo
+// after a successful execute completion.
+func (a *Assembler) HasConflictsInfo(workspaceID string, issueNumber int) bool {
+	key := workspaceID + "#" + strconv.Itoa(issueNumber)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	_, ok := a.conflictFails[key]
+	return ok
+}
+
 // reassembleAndForceEmit runs Assemble + Publish unconditionally.
 // Used when the caller knows a load-bearing state change occurred and
 // can't trust the cache-diff to detect it — e.g. session state

--- a/internal/issueview/assembler_test.go
+++ b/internal/issueview/assembler_test.go
@@ -597,3 +597,54 @@ func TestSelectSessions_BlockedInDoneIsSuppressed_ScenarioFromIssue113(t *testin
 		t.Errorf("DONE column suppression must clear lastFail, got %+v", lastFail)
 	}
 }
+
+// TestClearConflictsInfo_RemovesEntry exercises the optimistic-clear path
+// used by app.go's session-state handler when a resolver completes. Pre-fix
+// the conflictFails entry persisted until the next GitHub poll detected
+// mergeable_state going clean — up to 5 minutes of stale red badge after
+// the resolver session demonstrably finished. Witnessed on issue #177.
+func TestClearConflictsInfo_RemovesEntry(t *testing.T) {
+	bus := eventbus.New()
+	st := &fakeStore{
+		issues: map[int]types.Issue{42: {Number: 42, WorkspaceID: "ws1", Column: types.ColInProgress}},
+	}
+	a := New(bus, st)
+
+	// Simulate the conflict detection event that populates conflictFails.
+	bus.Publish(eventbus.EvtPRConflictsDetected, eventbus.PRConflictsDetected{
+		WorkspaceID:      "ws1",
+		IssueNumber:      42,
+		PRNumber:         99,
+		Base:             "main",
+		Head:             "feat/issue-42",
+		ConflictingFiles: []string{"types.go"},
+	})
+	// Sleep briefly: bus.Publish is async (each subscriber in its own
+	// goroutine). The probeConflicts handler needs a tick to write
+	// conflictFails.
+	time.Sleep(20 * time.Millisecond)
+
+	if !a.HasConflictsInfo("ws1", 42) {
+		t.Fatal("setup: expected HasConflictsInfo true after EvtPRConflictsDetected")
+	}
+
+	a.ClearConflictsInfo("ws1", 42)
+
+	if a.HasConflictsInfo("ws1", 42) {
+		t.Error("ClearConflictsInfo should have removed the entry; HasConflictsInfo still true")
+	}
+}
+
+// TestClearConflictsInfo_NoOpWhenAbsent verifies idempotency: clearing
+// when nothing was set must not crash.
+func TestClearConflictsInfo_NoOpWhenAbsent(t *testing.T) {
+	bus := eventbus.New()
+	st := &fakeStore{
+		issues: map[int]types.Issue{1: {Number: 1, WorkspaceID: "ws1", Column: types.ColTodo}},
+	}
+	a := New(bus, st)
+	a.ClearConflictsInfo("ws1", 1) // must not panic
+	if a.HasConflictsInfo("ws1", 1) {
+		t.Error("HasConflictsInfo on a never-set issue should be false")
+	}
+}


### PR DESCRIPTION
## Summary

Witnessed on issue #177: card with merge conflicts went MERGE CONFLICT → IN_PROGRESS (resolver running) → REVIEW, but on landing in REVIEW the red MERGE CONFLICT badge was still showing. Resolve Conflicts had worked, the resolver pushed the fix, the session terminated — but the card stayed painted red until the next 5-minute poll cycle caught up.

## Root cause

The assembler's `conflictFails[key]` cache clears only on three events:
- `EvtPRConflictsResolved` (poller fires when GitHub's `mergeable_state` flips out of `dirty`)
- `EvtPRMerged`
- `EvtPRClosedUnmerged`

None fire when the resolver session itself completes. So for up to 5 minutes after the worker demonstrably succeeded, the card carried stale conflict state.

## Fix

Two new public methods on Assembler:
- `HasConflictsInfo(ws, issue) bool` — cheap predicate
- `ClearConflictsInfo(ws, issue)` — atomic clear + re-emit via `reassembleAndForceEmit`. Idempotent (no-op when nothing recorded).

`app.go::handleSessionStateChange` now: when an execute session transitions to `Completed` AND the assembler has `conflictsInfo` for the same issue, **optimistically clear** + **PokeNow the poller**. Next poll either confirms the conflict is gone (no event re-fires, badge stays cleared) OR re-detects via probeConflicts (badge comes back via `EvtPRConflictsDetected`).

Worst case: brief window between resolver completion and the poke-triggered fanOut where the badge is gone but the conflict is still present. Better than the previous 5-min stale-red window after a successful resolve.

## Tests

- `TestClearConflictsInfo_RemovesEntry` — full Detected → Clear flow, asserts entry gone
- `TestClearConflictsInfo_NoOpWhenAbsent` — idempotency

`go test ./...` clean.

## Test plan
- [ ] Force a merge conflict on a feature branch. Click Resolve Conflicts. Worker pushes fix. Card returns to REVIEW WITHOUT the red MERGE CONFLICT badge (within 1s of session completion, no need to wait 5 min)
- [ ] Force a conflict the resolver CAN'T fix (e.g. semantic conflict the model misses). Worker exits, badge briefly disappears, then comes back on the next poke cycle
- [ ] Regular execute session (no prior conflict) completes — no spurious clears

## Related
- #167, #169, #183, #185 — earlier conflict-detection fixes
- #150, #151, #170 — same-family stale-state-on-column-transition bugs