### PR TITLE
docs: rewrite README with capabilities, build, setup, use, status

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,33 +1,208 @@
 # PrismConductor
 
-A goal-driven, multi-workspace agent orchestration desktop app.
+A goal-driven, multi-workspace agent orchestration desktop app. Plan, execute, review, and ship GitHub issues across one or many repos with a kanban board that tracks Claude / OpenAI / Gemini / Ollama agents on your behalf.
 
-See `PRISMCONDUCTOR_PLAN.md` for the full design.
+[![build](https://github.com/darkshade9/prismconductor/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/darkshade9/prismconductor/actions/workflows/build.yml)
+[![smoke](https://github.com/darkshade9/prismconductor/actions/workflows/smoke.yml/badge.svg?branch=main)](https://github.com/darkshade9/prismconductor/actions/workflows/smoke.yml)
 
-## Stack
+> **Status: pre-1.0, actively under development.** Daily-driver-usable for the maintainer; some features in flight (remote workspaces, agent-terminal panel, three-tier signed-commit fallback). See [open issues](https://github.com/darkshade9/prismconductor/issues) for the roadmap.
 
-- **Wails v2** (Go backend + React/TS frontend, single binary)
-- **Tailwind + shadcn/ui** for the board
-- **dnd-kit** for drag-and-drop
-- **modernc.org/sqlite** for local persistence
-- **creack/pty** for spawning `claude` worker subprocesses
-- **Ollama / Qwen 2.5 14B** as the orchestrator LLM (local, free)
+See [`PRISMCONDUCTOR_PLAN.md`](PRISMCONDUCTOR_PLAN.md) for the full design spec.
 
-## Develop
+## Capabilities
+
+PrismConductor turns GitHub issues into a kanban board where AI agents do the bulk of the engineering work, and you only step in for plan review and final approval.
+
+**Core flow**
+
+- **Multi-workspace board.** Aggregate issues across many repos into one TODO / PLAN / IN_PROGRESS / REVIEW / DONE pipeline. Filter by workspace chip, by active goal, by labels (AND / OR), by title search.
+- **Goal-driven backlog ranking.** Define a Goal scoping which issues are in play; the orchestrator ranks the backlog by dependency-awareness so you always work the right thing next.
+- **Auto-pull from TODO.** Workers spawn into PLAN automatically when a slot frees and an unblocked top-of-backlog issue is waiting.
+- **Plan / execute / close pipeline.** Each card moves through a configurable pipeline of skills: `conductor-plan` → `conductor-execute` → `conductor-close`, with optional adversarial-review and conflict-resolver steps.
+- **Per-pool worker pools.** Configure many LLM providers / models / capacities per workspace. Plan, work, and orchestrator roles route to dedicated pools. Drag-to-reorder preference, per-pool budgets, per-pool temperature overrides.
+- **Mid-run questions.** A worker that needs clarification mid-execute pauses and asks the user via a structured question form; answer flows back to the worker and resumes.
+- **Continue Work.** Re-engage on a REVIEW-column PR with reviewer feedback or a free-form note; the worker picks up on the same branch with the same context.
+- **Plan re-ingest.** Plans live in `.prismconductor/plans/<n>-rev<N>.json` so revisions are persistent and re-spawnable.
+
+**Reliability and recovery**
+
+- **Worktree preservation on failure** so a worker that completed substantial work but couldn't commit/push (GPG signing failed, branch protection rejected, etc.) leaves its diff on disk for manual recovery — the conductor never auto-deletes user-paid-for work.
+- **Atomic duplicate-spawn guard** prevents two concurrent workers from running on the same `(workspace, issue, mode)` and double-billing.
+- **Self-healing pool counters** reconcile against DB ground truth on every terminal session event so slot-leak ghosts ("Workers 1/2 with no actual worker") can't accumulate.
+- **Stale-state reconcilers** at startup clean up any session rows left in `running` after a crash, any `waiting_for_pool` flags pinned across PR-merge, any orphan paused-for-question sessions.
+- **Re-attach across restarts.** Live PIDs at shutdown are picked back up at next startup; transcripts seamlessly continue.
+
+**GitHub integration**
+
+- **5-minute poll** of every workspace's open issues + PR state. Auto-detect: PR opened, PR merged, PR closed unmerged, checks failed, checks recovered, merge conflicts (with the precise conflicting file list via `git merge-tree`, not the full PR changeset), comments added.
+- **Auto-heal on test failure** (`#116`) — when CI fails on a REVIEW PR, the conductor can auto-spawn a self-heal session up to N times.
+- **Resolve Conflicts button** (`#124`) — surface a card-level red badge with the actually-conflicting file list and one-click rebase + merge worker.
+- **Auto-cancel zombie workers** (`#113`, `#118`) when a PR merges/closes/opens, so workers don't keep burning tokens after the deliverable is shipped.
+- **Bundled mode** (`#15.8` of the plan) — a bare repo with no `.claude/` or `CLAUDE.md` works on day one. No setup tax for new repos.
+
+**Cost and observability**
+
+- Per-session token + cost tracking, surfaced on each card with a tooltip breakdown.
+- Per-pool / per-workspace / per-goal spend rollups, today and this week.
+- Live activity strip on every running card showing the agent's most recent tool calls and a Stop button.
+
+**In flight (see open issues)**
+
+- **Remote workspaces** (`#171`) — execute on Cloudflare Workers instead of your laptop, so big runs aren't gated by your local CPU. Requires #177 (worker auth, security blocker) before merge.
+- **Agent terminal panel** (`#161`) — embedded PTY for chatting directly with `claude` / `aider` / `gemini` from inside the conductor.
+- **Three-tier signed-commit fallback** (`#175`) — GitHub-API commits → local signing → NEEDS_PR with prepared push command.
+- **Theming + customizable glow colors** (`#142`).
+- **PR comment UX inside the conductor** (`#159`) — full GitHub-stand-in for review feedback.
+
+## Test coverage
+
+- **Backend (Go):** ~25 packages. Unit + integration tests covering the session manager, pool registry, store migrations, GitHub poller, IssueView assembler, orchestrator, harness loop, conflict detection, etc. CI runs `go test ./...` on every push.
+- **Frontend (TS):** typecheck via `tsc --noEmit` in CI; component tests via Vitest.
+- **Smoke (E2E):** Playwright boots the app under `xvfb-run`, asserts React mounts and there are no console errors. Runs on every push to `feat/issue-*` and `main`.
+- **Multi-platform build matrix:** `build.yml` builds the Wails binary on Linux, macOS, and Windows. Linux additionally runs the Playwright smoke against the headless app.
+- **Security:** `gosec`, `govulncheck`, `npm audit`, `Trivy`, and `gitleaks` in the `security` job. High-severity findings fail the build.
+
+## Install (end-user)
+
+> Pre-built binaries are not yet published. Build from source using the steps below until v1.0.
+
+## Build from source
+
+### Prerequisites
+
+| Tool | Notes |
+|--|--|
+| Go ≥ 1.25 | `brew install go` (macOS) / your distro's package manager |
+| Node ≥ 20 | `brew install node` |
+| Wails v2 | `go install github.com/wailsapp/wails/v2/cmd/wails@latest` |
+| `gh` CLI | Required at runtime for GitHub API calls. Authenticate with `gh auth login` |
+| Git ≥ 2.38 | `git merge-tree --name-only` flags require this version |
+| Platform deps |  See per-platform notes below |
+
+**macOS:** `brew install pkg-config`
+
+**Linux:** `sudo apt-get install libgtk-3-dev libwebkit2gtk-4.0-dev build-essential pkg-config`
+
+**Windows:** `choco install mingw`
+
+### Build
 
 ```bash
-wails dev      # hot-reloading dev server
-wails build    # produces build/bin/prismconductor.app
+git clone https://github.com/darkshade9/prismconductor.git
+cd prismconductor
+wails build
 ```
 
-## Tests
+Produces `build/bin/prismconductor.app` (macOS), `build/bin/prismconductor` (Linux), or `build/bin/prismconductor.exe` (Windows).
+
+For development with hot-reload:
 
 ```bash
-cd tests && npm install && npm run smoke:install && npm run smoke
+wails dev
 ```
 
-Playwright smoke test: boots the app via `wails dev`, asserts React mounts into `#root`, and checks for console errors. Runs automatically in CI on every push to `feat/issue-*` and `main`.
+For a release-style build that wipes and rebuilds the app bundle (handy when frontend caches go stale):
 
-## Status
+```bash
+./scripts/restart.sh             # release build
+./scripts/restart.sh --debug     # debug build with DevTools enabled (Cmd+Opt+I)
+./scripts/restart.sh --no-pull   # offline build
+```
 
-Day 1 of Phase 1 complete: scaffold + bound demo (`SpawnDemo` calls `claude --version` via PTY and streams output to the SessionDrawer). See open issues for remaining phases.
+### Run tests
+
+```bash
+go test ./...                          # backend unit + integration
+cd frontend && npx tsc --noEmit        # frontend typecheck
+cd tests && npm install && npm run smoke:install && npm run smoke   # Playwright smoke
+```
+
+## Setup
+
+On first launch:
+
+1. **Add a workspace.** Click `+ Add Workspace`. Provide a name, a local repo path (must be a clone of a GitHub repo), the GitHub owner, the GitHub repo, and a workspace color. The conductor's `gh` CLI auth handles GitHub access; you don't paste tokens for local workspaces.
+
+2. **Add at least one work pool.** Settings → Pools → `+ Add Pool`. Provide:
+   - Name (free-form, e.g. `claude-sonnet-4-6`)
+   - Provider (`Claude`, `OpenAI`, `Gemini`, `Ollama`, `LMStudio`, `LiteLLM`)
+   - Model (auto-listed on `Test connection`)
+   - Endpoint + API key (provider-specific)
+   - Capacity (how many concurrent workers this pool can run)
+   - Role (`work`, `plan`, or `orchestrator`)
+
+   Drag rows to reorder preference. Multiple pools per role are supported; the orchestrator routes by priority + capacity.
+
+3. **(Optional) Set a goal.** Click `+ New Goal` in the top bar. Give it a one-line title; the orchestrator will scope backlog ranking to issues that look related.
+
+4. **Wait for the GitHub poll** (or click Refresh in the workspace switcher). Open issues from the configured repo populate the TODO column.
+
+## Use
+
+### Plan an issue
+
+Drag an issue from TODO into PLAN — or wait for auto-pull to drag it for you when a planner slot frees. The plan worker spawns; the card glows blue while it runs. When the plan is ready, the card glows amber and a `(rev N) ready` badge appears.
+
+Click the card to open the Plan modal. Review the proposed file changes, the structured questions, and the cost estimate. Either:
+
+- **Approve** to spawn the execute worker on a fresh feature branch
+- **Refine** with a free-form note and re-spawn the planner
+- **Reject** to discard the plan and move the card back
+
+### Execute and review
+
+The execute worker writes code, runs lints/tests, commits, pushes, and opens a PR. Card moves to REVIEW with a green PR chip. The activity strip shows live tool calls.
+
+If checks fail or merge conflicts appear, the conductor surfaces a red banner with one-click recovery (`Self-heal`, `Resolve Conflicts`, `Continue Work`).
+
+### Merge
+
+Merge the PR on GitHub. The conductor's poller detects the merge within ~5 minutes and moves the card to DONE. (In-app merge button is on the roadmap; see #146.)
+
+### Stop / cancel
+
+Every running card has a Stop button on its activity strip. Stops the worker, releases the slot. The session is marked `failed` with reason `cancelled by user`; the worktree is preserved so you can pick up the work manually if needed.
+
+## Layout
+
+```
+internal/
+  agentterm/        # embedded PTY agent panel
+  archiver/         # auto-archive DONE cards by age
+  eventbus/         # in-process event bus
+  git/              # worktree + merge-tree helpers
+  github/           # poller + REST/GraphQL client
+  harness/          # in-process LLM agent loop (non-Claude providers)
+  issueview/        # canonical IssueView assembler
+  llm/              # provider-agnostic LLM client interface
+  orchestrator/     # backlog ranking + auto-pull
+  pipeline/         # configurable per-workspace step pipeline
+  remoteworker/     # Cloudflare Workers execution backend (in flight)
+  secretstore/      # OS-keychain wrapper
+  session/          # session manager (subprocess + harness paths)
+  skills/bundle/    # bundled conductor-* skill markdown
+  store/            # SQLite persistence + migrations
+  workerpool/       # role-keyed pool registry
+frontend/src/
+  components/       # Board, Card, PlanModal, Settings, etc.
+  stores/           # zustand stores (workspace, issueview, session)
+worker/             # Cloudflare Worker bundle (in flight, #171)
+scripts/restart.sh  # one-shot rebuild + relaunch
+```
+
+## Hard rules (also see [`CLAUDE.md`](CLAUDE.md))
+
+- **Schemas are contracts.** §9.1 (plan JSON) and §6.4 (Question shape) are wire formats between worker, orchestrator, and UI. Don't change a field without updating all three.
+- **No polling inside the orchestrator.** The 5-min GitHub fetch is the only polling loop. Everything else is event-driven.
+- **Bundled mode is the default.** Bare repos work on day one; we never block on missing repo enrichment.
+- **One active goal at a time.** Enforced via SQL transaction in `Store.SetGoalActive`.
+
+## Contributing
+
+Open issues are tracked at [github.com/darkshade9/prismconductor/issues](https://github.com/darkshade9/prismconductor/issues). The conductor itself is dogfooded on its own development — many of those issues are filed by the conductor running on this repo.
+
+PRs welcome; please ensure `go test ./...` and `npx tsc --noEmit` pass.
+
+## License
+
+Not yet licensed for public redistribution. See repository owner for details.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ Open issues are tracked at [github.com/darkshade9/prismconductor/issues](https:/
 
 PRs welcome; please ensure `go test ./...` and `npx tsc --noEmit` pass.
 
+## Why the name "PrismConductor"?
+
+I thought the idea that multiple sources (Humans, LLMs, Ideas, Data, etc.) were represented as multiple colors converging into a Prism and the output is whatever the Orchestrator (you!) want.  This means it doesn't matter which model you use, with provider, where the idea came from, which data sources you use, it all comes together here and you make what you want out of it.
+
 ## License
 
 PrismConductor is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0)**. See [`LICENSE`](LICENSE) for the full text.

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ PrismConductor turns GitHub issues into a kanban board where AI agents do the bu
 **GitHub integration**
 
 - **5-minute poll** of every workspace's open issues + PR state. Auto-detect: PR opened, PR merged, PR closed unmerged, checks failed, checks recovered, merge conflicts (with the precise conflicting file list via `git merge-tree`, not the full PR changeset), comments added.
-- **Auto-heal on test failure** (`#116`) — when CI fails on a REVIEW PR, the conductor can auto-spawn a self-heal session up to N times.
-- **Resolve Conflicts button** (`#124`) — surface a card-level red badge with the actually-conflicting file list and one-click rebase + merge worker.
-- **Auto-cancel zombie workers** (`#113`, `#118`) when a PR merges/closes/opens, so workers don't keep burning tokens after the deliverable is shipped.
-- **Bundled mode** (`#15.8` of the plan) — a bare repo with no `.claude/` or `CLAUDE.md` works on day one. No setup tax for new repos.
+- **Auto-heal on test failure** — when CI fails on a REVIEW PR, the conductor can auto-spawn a self-heal session up to N times.
+- **Resolve Conflicts button** — surface a card-level red badge with the actually-conflicting file list and one-click rebase + merge worker.
+- **Auto-cancel zombie workers** when a PR merges/closes/opens, so workers don't keep burning tokens after the deliverable is shipped.
+- **Bundled mode** — a bare repo with no `.claude/` or `CLAUDE.md` works on day one. No setup tax for new repos.
 
 **Cost and observability**
 
@@ -48,11 +48,11 @@ PrismConductor turns GitHub issues into a kanban board where AI agents do the bu
 
 **In flight (see open issues)**
 
-- **Remote workspaces** (`#171`) — execute on Cloudflare Workers instead of your laptop, so big runs aren't gated by your local CPU. Requires #177 (worker auth, security blocker) before merge.
-- **Agent terminal panel** (`#161`) — embedded PTY for chatting directly with `claude` / `aider` / `gemini` from inside the conductor.
-- **Three-tier signed-commit fallback** (`#175`) — GitHub-API commits → local signing → NEEDS_PR with prepared push command.
-- **Theming + customizable glow colors** (`#142`).
-- **PR comment UX inside the conductor** (`#159`) — full GitHub-stand-in for review feedback.
+- **Remote workspaces** — execute on Cloudflare Workers instead of your laptop, so big runs aren't gated by your local CPU. Pending worker-auth security work before merge.
+- **Agent terminal panel** — embedded PTY for chatting directly with `claude` / `aider` / `gemini` from inside the conductor.
+- **Three-tier signed-commit fallback** — GitHub-API commits → local signing → NEEDS_PR with prepared push command.
+- **Theming + customizable glow colors.**
+- **PR comment UX inside the conductor** — full GitHub-stand-in for review feedback.
 
 ## Test coverage
 
@@ -157,7 +157,7 @@ If checks fail or merge conflicts appear, the conductor surfaces a red banner wi
 
 ### Merge
 
-Merge the PR on GitHub. The conductor's poller detects the merge within ~5 minutes and moves the card to DONE. (In-app merge button is on the roadmap; see #146.)
+Merge the PR on GitHub. The conductor's poller detects the merge within ~5 minutes and moves the card to DONE. (In-app merge button is on the roadmap.)
 
 ### Stop / cancel
 
@@ -186,7 +186,7 @@ internal/
 frontend/src/
   components/       # Board, Card, PlanModal, Settings, etc.
   stores/           # zustand stores (workspace, issueview, session)
-worker/             # Cloudflare Worker bundle (in flight, #171)
+worker/             # Cloudflare Worker bundle (in flight)
 scripts/restart.sh  # one-shot rebuild + relaunch
 ```
 
@@ -205,4 +205,20 @@ PRs welcome; please ensure `go test ./...` and `npx tsc --noEmit` pass.
 
 ## License
 
-Not yet licensed for public redistribution. See repository owner for details.
+PrismConductor is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0)**. See [`LICENSE`](LICENSE) for the full text.
+
+In short: you may use, modify, and redistribute this software freely, **but any derivative work — including a modified version offered as a hosted service over a network** — must be released under AGPL-3.0 with full source available to its users. This is intentional: it keeps PrismConductor open and prevents closed-source forks or proprietary SaaS rebrands.
+
+### No warranty, no liability
+
+> **THIS SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.** See sections 15 and 16 of the [LICENSE](LICENSE) for the legally binding text.
+
+PrismConductor spawns autonomous AI agents that **spend money** (LLM API tokens), **modify your code**, **push commits**, **open pull requests**, and (optionally) **execute on remote infrastructure you configure**. You are solely responsible for:
+
+- **Cost.** Workers can run for hours and burn through hundreds of thousands of tokens. Set per-pool budgets. Watch the spend rollups. The maintainer is not responsible if your bill is larger than expected.
+- **Code changes.** Agents commit and push on your behalf. Review every PR before merging. The maintainer is not responsible for bad code, broken builds, lost work, or merged regressions.
+- **Credentials.** You provide API keys, GitHub tokens, and (for remote workspaces) Cloudflare credentials. PrismConductor stores them in your OS keychain on a best-effort basis; the maintainer makes no warranty about credential confidentiality and is not responsible for credential leakage, theft, or misuse.
+- **Auth and access control.** The remote-workspace path is pre-1.0 and security hardening is in flight. Do not expose remote workers to the public internet without your own review of the auth model.
+- **Compliance.** You are responsible for ensuring your use complies with the terms of every LLM provider, GitHub, your employer, and any applicable law.
+
+If you are not comfortable with any of the above, **do not use this software.** By running PrismConductor you accept full responsibility for everything its agents do under your credentials, in your repos, on your infrastructure, and on your bill.


### PR DESCRIPTION
## Summary

Previous README was `Day 1 of Phase 1 complete: scaffold + bound demo (\`SpawnDemo\` calls \`claude --version\`...)` — months out of date and didn't reflect any of the shipped functionality.

Refresh covers:
- Status badges (build + smoke from CI)
- Pre-1.0 status callout with link to open issues for the in-flight roadmap
- **Capabilities** section grouped by:
  - Core flow (multi-workspace, goal-driven ranking, auto-pull, plan/execute/close pipeline, mid-run questions, Continue Work)
  - Reliability and recovery (worktree preservation, atomic duplicate-spawn guard, self-healing pool counters, stale-state reconcilers, re-attach across restarts)
  - GitHub integration (5-min poll, auto-heal on test failure, Resolve Conflicts, auto-cancel zombies, bundled mode)
  - Cost and observability (per-session token + cost, per-pool/workspace/goal rollups, live activity strip)
  - In-flight features with issue numbers (#171 remote workspaces, #161 agent terminal, #175 signed-commit fallback, #142 theming, #159 PR comment UX)
- **Test coverage** summary (~25 Go packages, frontend tsc + vitest, Playwright smoke, cross-platform matrix, security scans via gosec/govulncheck/npm audit/Trivy/gitleaks)
- **Build from source** with per-platform prereqs (macOS / Linux / Windows)
- **Setup** walkthrough (add workspace → add pool → set goal)
- **Use** walkthrough (plan → execute → review → merge → stop)
- **Layout map** of internal/ and frontend/

The existing `PRISMCONDUCTOR_PLAN.md` (design spec) and `CLAUDE.md` (hard rules) are referenced as authoritative for deeper context.