### PR TITLE
feat: single-URL repo input for remote workspace wizard (#189)

### DIFF
--- a/app.go
+++ b/app.go
@@ -838,6 +838,13 @@ func (a *App) TestGitHubPAT(pat, owner, repo string) error {
 	return remoteworker.VerifyGitHubPAT(pat, owner, repo)
 }
 
+// GetRepoDefaultBranch returns the default branch of owner/repo as reported
+// by the GitHub API. Called by the remote-workspace wizard after the user
+// pastes a repository URL so the branch field can be pre-filled.
+func (a *App) GetRepoDefaultBranch(pat, owner, repo string) (string, error) {
+	return remoteworker.GetRepoDefaultBranch(pat, owner, repo)
+}
+
 // RemoteDeployResult is the frontend-visible result of DeployRemoteWorker.
 type RemoteDeployResult struct {
 	WorkerName          string `json:"worker_name"`

--- a/frontend/src/components/RemoteWorkspaceSetup.tsx
+++ b/frontend/src/components/RemoteWorkspaceSetup.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
-import { AddWorkspace, DeployRemoteWorker, TestCloudflareToken, TestGitHubPAT } from "../../wailsjs/go/main/App";
+import { AddWorkspace, DeployRemoteWorker, GetRepoDefaultBranch, TestCloudflareToken, TestGitHubPAT } from "../../wailsjs/go/main/App";
 import { main, types } from "../../wailsjs/go/models";
 import { useWorkspaceStore } from "../stores/workspaceStore";
 import { noAutoCorrect } from "../lib/inputs";
+import { deriveWorkspaceID, parseRepoURL } from "../lib/parseRepoURL";
 
 type Step = "cf-token" | "github-pat" | "repo" | "deploy" | "done";
 
@@ -29,6 +30,7 @@ export const GITHUB_FINE_GRAINED_SCOPES = [
 
 export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
   const refresh = useWorkspaceStore((s) => s.refresh);
+  const existingWorkspaces = useWorkspaceStore((s) => s.workspaces);
 
   const [step, setStep] = useState<Step>("cf-token");
   const [busy, setBusy] = useState(false);
@@ -41,12 +43,15 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
 
   // Step 2 — GitHub PAT
   const [githubPAT, setGitHubPAT] = useState("");
-  const [patVerified, setPATVerified] = useState(false);
 
-  // Step 3 — repo identity
+  // Step 3 — repo identity (derived from a single URL input)
+  const [repoURL, setRepoURL] = useState("");
+  const [urlError, setURLError] = useState<string | null>(null);
   const [owner, setOwner] = useState("");
   const [repo, setRepo] = useState("");
-  const [defaultBranch, setDefaultBranch] = useState("main");
+  const [defaultBranch, setDefaultBranch] = useState("");
+  const [branchFetchState, setBranchFetchState] = useState<"idle" | "loading" | "error" | "done">("idle");
+  const [branchFetchError, setBranchFetchError] = useState<string | null>(null);
   const [wsID, setWsID] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [color, setColor] = useState(COLOR_PALETTE[1]);
@@ -55,6 +60,46 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
   const [deployResult, setDeployResult] = useState<main.RemoteDeployResult | null>(null);
 
   // ---
+
+  async function handleRepoURLChange(raw: string) {
+    setRepoURL(raw);
+    setURLError(null);
+    setBranchFetchError(null);
+
+    const parsed = parseRepoURL(raw);
+    if (!parsed) {
+      if (raw.trim()) setURLError("Invalid GitHub URL — use https://github.com/owner/repo or git@github.com:owner/repo");
+      setOwner("");
+      setRepo("");
+      setDefaultBranch("");
+      setBranchFetchState("idle");
+      return;
+    }
+
+    setOwner(parsed.owner);
+    setRepo(parsed.repo);
+
+    // Auto-suggest workspace ID and display name immediately.
+    const existingIDs = existingWorkspaces.map((w) => w.id);
+    setWsID((prev) => (!prev || prev === deriveWorkspaceID(owner, repo, existingIDs)) ? deriveWorkspaceID(parsed.owner, parsed.repo, existingIDs) : prev);
+    setDisplayName((prev) => (!prev || prev === `${owner}/${repo}`) ? `${parsed.owner}/${parsed.repo}` : prev);
+
+    // Fetch default branch from GitHub (requires PAT).
+    if (!githubPAT.trim()) {
+      setBranchFetchState("idle");
+      return;
+    }
+
+    setBranchFetchState("loading");
+    try {
+      const branch = await GetRepoDefaultBranch(githubPAT.trim(), parsed.owner, parsed.repo);
+      setDefaultBranch(branch);
+      setBranchFetchState("done");
+    } catch (e: any) {
+      setBranchFetchState("error");
+      setBranchFetchError(String(e?.message ?? e));
+    }
+  }
 
   async function testCFToken() {
     setError(null);
@@ -72,32 +117,23 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
 
   async function testGitHubPAT() {
     setError(null);
-    if (!owner || !repo) {
-      setStep("repo");
-      return;
-    }
-    setBusy(true);
-    try {
-      await TestGitHubPAT(githubPAT.trim(), owner, repo);
-      setPATVerified(true);
-      setStep("repo");
-    } catch (e: any) {
-      setError(String(e?.message ?? e));
-    } finally {
-      setBusy(false);
-    }
+    setStep("repo");
   }
 
   async function testPATWithRepo() {
-    if (!owner || !repo) {
-      setError("Owner and repo are required.");
+    const parsed = parseRepoURL(repoURL);
+    if (!parsed) {
+      setError("Enter a valid GitHub repository URL first.");
+      return;
+    }
+    if (!wsID) {
+      setError("Workspace ID is required.");
       return;
     }
     setBusy(true);
     setError(null);
     try {
-      await TestGitHubPAT(githubPAT.trim(), owner, repo);
-      setPATVerified(true);
+      await TestGitHubPAT(githubPAT.trim(), parsed.owner, parsed.repo);
       setStep("deploy");
     } catch (e: any) {
       setError(String(e?.message ?? e));
@@ -285,38 +321,51 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
       {step === "repo" && (
         <div className="space-y-3">
           <div className="text-xs text-slate-400">
-            Identify the GitHub repository this workspace will work on.
-          </div>
-          <div className="grid grid-cols-2 gap-2">
-            <label className="block">
-              <FieldLabel
-                label="Owner"
-                tip={<p>The GitHub user or organization that owns the repository, e.g. <code className="bg-slate-700 px-0.5 rounded">octocat</code>.</p>}
-              />
-              <input
-                {...noAutoCorrect}
-                value={owner}
-                onChange={(e) => setOwner(e.target.value)}
-                placeholder="octocat"
-                className="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-200"
-              />
-            </label>
-            <label className="block">
-              <FieldLabel
-                label="Repository"
-                tip={<p>The repository name (without the owner prefix), e.g. <code className="bg-slate-700 px-0.5 rounded">my-repo</code>. Your PAT must have Contents and Pull requests access to this repo.</p>}
-              />
-              <input
-                {...noAutoCorrect}
-                value={repo}
-                onChange={(e) => setRepo(e.target.value)}
-                placeholder="my-repo"
-                className="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-200"
-              />
-            </label>
+            Paste the GitHub repository URL — owner, repo, and default branch will be filled in automatically.
           </div>
           <label className="block">
-            <div className="text-xs text-slate-500 mb-1">Default branch</div>
+            <FieldLabel
+              label="Repository URL"
+              tip={
+                <div className="space-y-1">
+                  <p>Paste any GitHub URL form:</p>
+                  <ul className="space-y-0.5 font-mono text-[11px]">
+                    <li>https://github.com/owner/repo</li>
+                    <li>https://github.com/owner/repo.git</li>
+                    <li>git@github.com:owner/repo.git</li>
+                  </ul>
+                </div>
+              }
+            />
+            <input
+              {...noAutoCorrect}
+              value={repoURL}
+              onChange={(e) => handleRepoURLChange(e.target.value)}
+              placeholder="https://github.com/owner/repo"
+              className={
+                "w-full bg-slate-800 border rounded px-2 py-1.5 text-slate-200 font-mono text-xs " +
+                (urlError ? "border-red-500" : "border-slate-700")
+              }
+            />
+            {urlError && <div className="text-red-400 text-xs mt-1">{urlError}</div>}
+          </label>
+
+          {owner && repo && (
+            <div className="text-xs text-slate-500 font-mono">
+              {owner} / {repo}
+            </div>
+          )}
+
+          <label className="block">
+            <div className="flex items-center gap-1 text-xs text-slate-500 mb-1">
+              Default branch
+              {branchFetchState === "loading" && (
+                <span className="text-slate-500 animate-pulse">fetching…</span>
+              )}
+              {branchFetchState === "done" && (
+                <span className="text-emerald-400">✓ fetched</span>
+              )}
+            </div>
             <input
               {...noAutoCorrect}
               value={defaultBranch}
@@ -324,18 +373,24 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
               placeholder="main"
               className="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-200"
             />
+            {branchFetchState === "error" && branchFetchError && (
+              <div className="text-amber-400 text-xs mt-1">
+                Could not fetch default branch — {branchFetchError}. Enter it manually.
+              </div>
+            )}
           </label>
+
           <div className="grid grid-cols-2 gap-2">
             <label className="block">
               <FieldLabel
                 label="Workspace ID"
-                tip={<p>A unique slug for this workspace, e.g. <code className="bg-slate-700 px-0.5 rounded">my-repo-remote</code>. Used as part of the CF Worker name — lowercase letters, numbers, and hyphens only.</p>}
+                tip={<p>A unique slug for this workspace, e.g. <code className="bg-slate-700 px-0.5 rounded">my-repo</code>. Used as part of the CF Worker name — lowercase letters, numbers, and hyphens only.</p>}
               />
               <input
                 {...noAutoCorrect}
                 value={wsID}
                 onChange={(e) => setWsID(e.target.value)}
-                placeholder="my-repo-remote"
+                placeholder="my-repo"
                 className="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-200"
               />
             </label>
@@ -345,11 +400,12 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
                 {...noAutoCorrect}
                 value={displayName}
                 onChange={(e) => setDisplayName(e.target.value)}
-                placeholder="My Repo (Remote)"
+                placeholder="owner/repo"
                 className="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-200"
               />
             </label>
           </div>
+
           <div>
             <div className="text-xs text-slate-500 mb-1">Card color</div>
             <div className="flex gap-1">
@@ -363,6 +419,7 @@ export function RemoteWorkspaceSetup({ onDone }: { onDone: () => void }) {
               ))}
             </div>
           </div>
+
           {error && <div className="text-red-400 text-xs">{error}</div>}
           <div className="flex justify-between pt-1">
             <button onClick={() => setStep("github-pat")} className="text-xs text-slate-500 hover:text-slate-300">

--- a/frontend/src/lib/parseRepoURL.test.ts
+++ b/frontend/src/lib/parseRepoURL.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { parseRepoURL, deriveWorkspaceID } from "./parseRepoURL";
+
+describe("parseRepoURL", () => {
+  it("parses HTTPS URL", () => {
+    expect(parseRepoURL("https://github.com/octocat/hello-world")).toEqual({
+      owner: "octocat",
+      repo: "hello-world",
+    });
+  });
+
+  it("parses HTTPS URL with .git suffix", () => {
+    expect(parseRepoURL("https://github.com/octocat/hello-world.git")).toEqual({
+      owner: "octocat",
+      repo: "hello-world",
+    });
+  });
+
+  it("parses HTTPS URL with trailing slash", () => {
+    expect(parseRepoURL("https://github.com/octocat/hello-world/")).toEqual({
+      owner: "octocat",
+      repo: "hello-world",
+    });
+  });
+
+  it("parses SSH URL", () => {
+    expect(parseRepoURL("git@github.com:octocat/hello-world")).toEqual({
+      owner: "octocat",
+      repo: "hello-world",
+    });
+  });
+
+  it("parses SSH URL with .git suffix", () => {
+    expect(parseRepoURL("git@github.com:octocat/hello-world.git")).toEqual({
+      owner: "octocat",
+      repo: "hello-world",
+    });
+  });
+
+  it("handles org/repo with hyphens and dots", () => {
+    expect(parseRepoURL("https://github.com/my-org/my.repo")).toEqual({
+      owner: "my-org",
+      repo: "my.repo",
+    });
+  });
+
+  it("returns null for non-GitHub URLs", () => {
+    expect(parseRepoURL("https://gitlab.com/octocat/hello-world")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseRepoURL("")).toBeNull();
+  });
+
+  it("returns null for whitespace", () => {
+    expect(parseRepoURL("   ")).toBeNull();
+  });
+
+  it("returns null for URL missing repo part", () => {
+    expect(parseRepoURL("https://github.com/octocat")).toBeNull();
+  });
+
+  it("returns null for bare owner/repo without URL prefix", () => {
+    expect(parseRepoURL("octocat/hello-world")).toBeNull();
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parseRepoURL("  https://github.com/octocat/hello-world  ")).toEqual({
+      owner: "octocat",
+      repo: "hello-world",
+    });
+  });
+});
+
+describe("deriveWorkspaceID", () => {
+  it("uses repo slug when not taken", () => {
+    expect(deriveWorkspaceID("octocat", "hello-world", [])).toBe("hello-world");
+  });
+
+  it("falls back to owner-repo when repo slug is taken", () => {
+    expect(deriveWorkspaceID("octocat", "hello-world", ["hello-world"])).toBe("octocat-hello-world");
+  });
+
+  it("sanitizes uppercase to lowercase", () => {
+    expect(deriveWorkspaceID("MyOrg", "MyRepo", [])).toBe("myrepo");
+  });
+
+  it("sanitizes special characters to hyphens", () => {
+    expect(deriveWorkspaceID("my.org", "my_repo", [])).toBe("my-repo");
+  });
+});

--- a/frontend/src/lib/parseRepoURL.ts
+++ b/frontend/src/lib/parseRepoURL.ts
@@ -1,0 +1,69 @@
+export interface ParsedRepo {
+  owner: string;
+  repo: string;
+}
+
+/**
+ * Parses a GitHub repository URL (HTTPS or SSH) into owner/repo components.
+ *
+ * Accepted forms:
+ *   https://github.com/owner/repo
+ *   https://github.com/owner/repo.git
+ *   git@github.com:owner/repo
+ *   git@github.com:owner/repo.git
+ *
+ * Returns null for any other input.
+ */
+export function parseRepoURL(raw: string): ParsedRepo | null {
+  const s = raw.trim();
+  if (!s) return null;
+
+  let path: string | null = null;
+
+  // HTTPS form: https://github.com/owner/repo[.git]
+  const httpsMatch = s.match(/^https?:\/\/github\.com\/([^/]+\/[^/]+?)(?:\.git)?\/?$/);
+  if (httpsMatch) {
+    path = httpsMatch[1];
+  }
+
+  // SSH form: git@github.com:owner/repo[.git]
+  if (!path) {
+    const sshMatch = s.match(/^git@github\.com:([^/]+\/[^/]+?)(?:\.git)?$/);
+    if (sshMatch) {
+      path = sshMatch[1];
+    }
+  }
+
+  if (!path) return null;
+
+  const slash = path.indexOf("/");
+  if (slash <= 0 || slash === path.length - 1) return null;
+
+  const owner = path.slice(0, slash).trim();
+  const repo = path.slice(slash + 1).trim();
+
+  if (!owner || !repo) return null;
+
+  return { owner, repo };
+}
+
+/**
+ * Derives a workspace ID slug from owner and repo.
+ *
+ * Uses just {repo} when no existing workspace already uses that ID;
+ * otherwise falls back to {owner}-{repo}. Both are sanitized to
+ * lowercase letters, numbers, and hyphens.
+ */
+export function deriveWorkspaceID(owner: string, repo: string, existingIDs: string[]): string {
+  const sanitize = (s: string) =>
+    s
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+
+  const repoSlug = sanitize(repo);
+  if (!existingIDs.includes(repoSlug)) return repoSlug;
+
+  const combined = sanitize(`${owner}-${repo}`);
+  return combined;
+}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -69,6 +69,8 @@ export function GetPollInterval():Promise<number>;
 
 export function GetPoolUsage():Promise<Array<types.PoolUsage>>;
 
+export function GetRepoDefaultBranch(arg1:string,arg2:string,arg3:string):Promise<string>;
+
 export function GitHubAuthStatus():Promise<githubauth.User>;
 
 export function GitHubListRepos():Promise<Array<github.Repository>>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -118,6 +118,10 @@ export function GetPoolUsage() {
   return window['go']['main']['App']['GetPoolUsage']();
 }
 
+export function GetRepoDefaultBranch(arg1, arg2, arg3) {
+  return window['go']['main']['App']['GetRepoDefaultBranch'](arg1, arg2, arg3);
+}
+
 export function GitHubAuthStatus() {
   return window['go']['main']['App']['GitHubAuthStatus']();
 }

--- a/internal/remoteworker/get_repo.go
+++ b/internal/remoteworker/get_repo.go
@@ -1,0 +1,49 @@
+package remoteworker
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// GetRepoDefaultBranch returns the default branch of owner/repo using the
+// supplied GitHub PAT for authentication. Returns an error if the repo is
+// not found (HTTP 404) or the PAT lacks Metadata read access (HTTP 401/403).
+func GetRepoDefaultBranch(pat, owner, repo string) (string, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s", ghAPIBase, owner, repo)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+pat)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("GitHub API request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return "", fmt.Errorf("repository %s/%s not found (check URL and PAT access)", owner, repo)
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return "", fmt.Errorf("GitHub PAT does not have Metadata access to %s/%s", owner, repo)
+	case http.StatusOK:
+		// handled below
+	default:
+		return "", fmt.Errorf("GitHub API returned HTTP %d for %s/%s", resp.StatusCode, owner, repo)
+	}
+
+	var result struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("parse GitHub API response: %w", err)
+	}
+	if result.DefaultBranch == "" {
+		return "", fmt.Errorf("GitHub API returned empty default_branch for %s/%s", owner, repo)
+	}
+	return result.DefaultBranch, nil
+}

--- a/internal/remoteworker/get_repo_test.go
+++ b/internal/remoteworker/get_repo_test.go
@@ -1,0 +1,98 @@
+package remoteworker
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGetRepoDefaultBranch_success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/octocat/hello-world" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"full_name":      "octocat/hello-world",
+			"default_branch": "main",
+		})
+	}))
+	defer srv.Close()
+	replaceHTTPClient(t, &http.Client{Transport: &rewriteGHTransport{base: srv.URL}})
+
+	branch, err := GetRepoDefaultBranch("ghp_fake", "octocat", "hello-world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if branch != "main" {
+		t.Errorf("branch = %q, want %q", branch, "main")
+	}
+}
+
+func TestGetRepoDefaultBranch_masterBranch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"default_branch": "master"})
+	}))
+	defer srv.Close()
+	replaceHTTPClient(t, &http.Client{Transport: &rewriteGHTransport{base: srv.URL}})
+
+	branch, err := GetRepoDefaultBranch("ghp_fake", "org", "repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if branch != "master" {
+		t.Errorf("branch = %q, want master", branch)
+	}
+}
+
+func TestGetRepoDefaultBranch_notFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Not Found"})
+	}))
+	defer srv.Close()
+	replaceHTTPClient(t, &http.Client{Transport: &rewriteGHTransport{base: srv.URL}})
+
+	_, err := GetRepoDefaultBranch("ghp_fake", "owner", "missing")
+	if err == nil {
+		t.Fatal("expected error for 404, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error %q should mention 'not found'", err.Error())
+	}
+}
+
+func TestGetRepoDefaultBranch_unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Bad credentials"})
+	}))
+	defer srv.Close()
+	replaceHTTPClient(t, &http.Client{Transport: &rewriteGHTransport{base: srv.URL}})
+
+	_, err := GetRepoDefaultBranch("bad_pat", "owner", "repo")
+	if err == nil {
+		t.Fatal("expected error for 401, got nil")
+	}
+	if !strings.Contains(err.Error(), "PAT") {
+		t.Errorf("error %q should mention 'PAT'", err.Error())
+	}
+}
+
+func TestGetRepoDefaultBranch_forbidden(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Forbidden"})
+	}))
+	defer srv.Close()
+	replaceHTTPClient(t, &http.Client{Transport: &rewriteGHTransport{base: srv.URL}})
+
+	_, err := GetRepoDefaultBranch("ghp_fake", "owner", "private")
+	if err == nil {
+		t.Fatal("expected error for 403, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Replaces five manual repo fields (owner, repo, default branch, workspace ID, display name) with a single **Repository URL** input that accepts any GitHub HTTPS or SSH form
- On paste, the URL is parsed client-side, owner/repo are derived, and `GetRepoDefaultBranch` is called to pre-fill the default branch; inline error shown if the fetch fails so the user can enter it manually
- Workspace ID auto-suggested as `{repo}` (falls back to `{owner}-{repo}` on collision); display name auto-suggested as `{owner}/{repo}`; both remain editable

## Files modified

- `app.go` — added `GetRepoDefaultBranch` bound method delegating to `remoteworker.GetRepoDefaultBranch`
- `frontend/src/components/RemoteWorkspaceSetup.tsx` — replaced step 3 fields with URL input + derived/editable fields
- `frontend/src/lib/parseRepoURL.ts` — `parseRepoURL` + `deriveWorkspaceID` utilities
- `frontend/src/lib/parseRepoURL.test.ts` — 16 unit tests covering HTTPS/SSH/edge cases
- `frontend/wailsjs/go/main/App.d.ts` / `App.js` — manually added `GetRepoDefaultBranch` binding (wails generate module blocked by missing frontend/dist in worktree)
- `internal/remoteworker/get_repo.go` — `GetRepoDefaultBranch(pat, owner, repo string) (string, error)` hitting GitHub `/repos` API
- `internal/remoteworker/get_repo_test.go` — 5 httptest-based tests (success, master branch, 404, 401, 403)

## Verification

| Check | Command | Result |
|-------|---------|--------|
| Go vet | `go vet prismconductor/internal/remoteworker` | pass |
| TypeScript | `tsc --noEmit` | pass |
| Go tests | `go test prismconductor/internal/remoteworker` | 15/15 pass |
| Frontend tests | `vitest run parseRepoURL.test.ts` | 16/16 pass |
| Build | `wails build` | pass |
| Smoke test | `playwright test startup.spec.ts` | 1/1 pass |

Commit tier: **Tier 1** (GitHub API signed commit `cccea83`)

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-189

Closes #189