### PR TITLE
feat: route SpawnPlan to remote worker and surface plan failures (#191)

### DIFF
--- a/frontend/src/components/Card.planfailed.test.ts
+++ b/frontend/src/components/Card.planfailed.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+
+// Unit-level spec for the plan failure badge logic derived from IssueView.
+// No DOM rendering (no @testing-library/react in this project); we test
+// the decision conditions that Card.tsx evaluates when choosing whether to
+// show a planFailed badge vs other badges.
+
+// Mirrors the condition in StatusRow:
+// planFailed is shown only when:
+//   - planFailed is set (non-null)
+//   - no activeSession
+//   - no pausedSession
+//   - no lastFailure (those already have a badge)
+function shouldShowPlanFailed(opts: {
+  planFailed: { session_id: string; reason?: string } | null;
+  activeSession: boolean;
+  pausedSession: boolean;
+  lastFailure: boolean;
+}): boolean {
+  const { planFailed, activeSession, pausedSession, lastFailure } = opts;
+  return !!(planFailed && !activeSession && !pausedSession && !lastFailure);
+}
+
+describe("Card plan failure badge visibility", () => {
+  it("shows when planFailed is set and no other session state", () => {
+    expect(
+      shouldShowPlanFailed({
+        planFailed: { session_id: "abc-123" },
+        activeSession: false,
+        pausedSession: false,
+        lastFailure: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("hidden when activeSession is present", () => {
+    expect(
+      shouldShowPlanFailed({
+        planFailed: { session_id: "abc-123" },
+        activeSession: true,
+        pausedSession: false,
+        lastFailure: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("hidden when pausedSession is present", () => {
+    expect(
+      shouldShowPlanFailed({
+        planFailed: { session_id: "abc-123" },
+        activeSession: false,
+        pausedSession: true,
+        lastFailure: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("hidden when lastFailure is present (avoids double badge)", () => {
+    expect(
+      shouldShowPlanFailed({
+        planFailed: { session_id: "abc-123" },
+        activeSession: false,
+        pausedSession: false,
+        lastFailure: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("hidden when planFailed is null", () => {
+    expect(
+      shouldShowPlanFailed({
+        planFailed: null,
+        activeSession: false,
+        pausedSession: false,
+        lastFailure: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("uses planFailed.reason when provided", () => {
+    const info = { session_id: "abc-123", reason: "remote plan timed out" };
+    expect(info.reason).toBe("remote plan timed out");
+  });
+
+  it("falls back to default reason when reason is absent", () => {
+    const info: { session_id: string; reason?: string } = { session_id: "abc-123" };
+    const reason = info.reason || "plan session ended without success";
+    expect(reason).toBe("plan session ended without success");
+  });
+});

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -52,6 +52,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
   const conflictsInfo = view?.conflicts_info ?? null;
   const orphanQuestion = view?.orphan_question ?? null;
   const needsPRInfo = view?.needs_pr_info ?? null;
+  const planFailed = view?.plan_failed ?? null;
   // Activity is live-streaming data not captured in the view — still from sessionStore.
   const activity: SessionActivity | null = useSessionStore((s) =>
     activeSession ? (s.sessions[activeSession.id]?.activity ?? null) : null
@@ -241,6 +242,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
         pausedSession={pausedSession}
         orphanQuestion={orphanQuestion}
         planReady={planReady}
+        planFailed={planFailed}
         blocked={blocked}
         isPrimitive={isPrimitive}
         dependencies={issue.dependencies ?? []}
@@ -454,6 +456,11 @@ type NeedsPRInfo = {
   commit_msg?: string;
 };
 
+type PlanFailedInfo = {
+  session_id: string;
+  reason?: string;
+};
+
 function StatusRow({
   activeSession,
   activity,
@@ -461,6 +468,7 @@ function StatusRow({
   pausedSession,
   orphanQuestion,
   planReady,
+  planFailed,
   blocked,
   isPrimitive,
   dependencies,
@@ -484,6 +492,7 @@ function StatusRow({
   pausedSession: types.Session | null;
   orphanQuestion: OrphanQuestionInfo | null;
   planReady: { revision: number } | null;
+  planFailed: PlanFailedInfo | null;
   blocked: boolean;
   isPrimitive: boolean;
   dependencies: number[];
@@ -868,6 +877,47 @@ function StatusRow({
             )}
           </div>
           <div className="text-slate-400 break-words" title={reason}>⚠ {reason}</div>
+        </div>
+        {menuEl}
+      </>
+    );
+  }
+  // Plan failure: plan session ended without producing a plan and without
+  // emitting BLOCKED: (those are shown via lastFailure above). Show a red
+  // badge with a tooltip linking to the session transcript (#191).
+  if (planFailed && !activeSession && !pausedSession && !lastFailure) {
+    const reason = planFailed.reason || "plan session ended without success";
+    const showClear = column === "todo" || column === "plan" || column === "in_progress";
+    return (
+      <>
+        <div
+          className="text-[11px] mt-1.5 space-y-0.5"
+          title={reason}
+          onContextMenu={(e) => openMenu(e, [
+            { label: "Copy reason", text: reason },
+            { label: "Copy as quoted block", text: toQuotedBlock(reason) },
+          ])}
+        >
+          <div className="flex items-center gap-1.5">
+            <Pulse className="bg-red-400" />
+            <span className="text-red-300">plan failed</span>
+            <span className="text-slate-500 font-mono text-[10px]">·&nbsp;{planFailed.session_id.slice(0, 8)}</span>
+            {showClear && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClearFailure();
+                }}
+                onMouseDown={(e) => e.stopPropagation()}
+                onPointerDown={(e) => e.stopPropagation()}
+                className="ml-auto px-1.5 py-0.5 rounded text-[10px] border border-red-800 text-red-400 hover:border-red-600 hover:text-red-300"
+                title="Clear failure and retry planning"
+              >
+                ✕ Clear
+              </button>
+            )}
+          </div>
+          <div className="text-slate-400 break-words">⚠ {reason}</div>
         </div>
         {menuEl}
       </>

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -840,6 +840,21 @@ export namespace issueview {
 	        this.since = source["since"];
 	    }
 	}
+
+	export class PlanFailedInfo {
+	    session_id: string;
+	    reason?: string;
+
+	    static createFrom(source: any = {}) {
+	        return new PlanFailedInfo(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.session_id = source['session_id'];
+	        this.reason = source['reason'];
+	    }
+	}
 	export class TestsFailingInfo {
 	    failing_jobs: string[];
 	    failing_check_run_urls: string[];
@@ -891,6 +906,7 @@ export namespace issueview {
 	    conflicts_info?: ConflictsInfo;
 	    orphan_question?: OrphanQuestionInfo;
 	    needs_pr_info?: types.NeedsPRInfo;
+	    plan_failed?: PlanFailedInfo;
 	    unread_comment_count: number;
 	
 	    static createFrom(source: any = {}) {
@@ -911,6 +927,7 @@ export namespace issueview {
 	        this.conflicts_info = this.convertValues(source["conflicts_info"], ConflictsInfo);
 	        this.orphan_question = this.convertValues(source["orphan_question"], OrphanQuestionInfo);
 	        this.needs_pr_info = this.convertValues(source["needs_pr_info"], types.NeedsPRInfo);
+	        this.plan_failed = this.convertValues(source["plan_failed"], PlanFailedInfo);
 	        this.unread_comment_count = source["unread_comment_count"];
 	    }
 	

--- a/internal/issueview/assembler.go
+++ b/internal/issueview/assembler.go
@@ -349,6 +349,11 @@ func (a *Assembler) Assemble(workspaceID string, issueNumber int) (IssueView, er
 		}
 	}
 
+	// Derive plan failure: plan sessions that ended Failed without a BLOCKED:
+	// reason are invisible to selectSessions/LastFailure but represent a real
+	// failure the user must see (#191).
+	planFailed := derivePlanFailed(iss, sessions, active)
+
 	return IssueView{
 		Issue:              iss,
 		LatestPlan:         plan,
@@ -362,8 +367,59 @@ func (a *Assembler) Assemble(workspaceID string, issueNumber int) (IssueView, er
 		ConflictsInfo:      conflictsInfo,
 		OrphanQuestion:     orphanQuestion,
 		NeedsPRInfo:        iss.NeedsPRInfo,
+		PlanFailed:         planFailed,
 		UnreadCommentCount: unreadCommentCount,
 	}, nil
+}
+
+// derivePlanFailed finds the most recent plan session that ended in StateFailed
+// without a BlockedReason (those are already surfaced via LastFailure). Returns
+// nil when suppressed by a later successful plan, an active plan session, or
+// when the card is in REVIEW/DONE.
+func derivePlanFailed(iss types.Issue, sessions []types.Session, active *types.Session) *PlanFailedInfo {
+	if iss.Column == types.ColReview || iss.Column == types.ColDone {
+		return nil
+	}
+	if active != nil && active.Mode == types.ModePlan {
+		return nil
+	}
+
+	var candidate *types.Session
+	var mostRecentPlanCompleted *types.Session
+	for i := range sessions {
+		s := &sessions[i]
+		if s.Mode != types.ModePlan {
+			continue
+		}
+		if s.State == types.StateCompleted {
+			if mostRecentPlanCompleted == nil || s.StartedAt.After(mostRecentPlanCompleted.StartedAt) {
+				mostRecentPlanCompleted = s
+			}
+		}
+		// Only track failures without a BlockedReason — those WITH one are
+		// already shown as LastFailure and we avoid doubling the badge.
+		if s.State != types.StateFailed || s.BlockedReason != "" {
+			continue
+		}
+		ackd := s.AcknowledgedAt != nil && *s.AcknowledgedAt != 0
+		if ackd {
+			continue
+		}
+		if candidate == nil || s.StartedAt.After(candidate.StartedAt) {
+			candidate = s
+		}
+	}
+	if candidate == nil {
+		return nil
+	}
+	// Suppress when a successful plan session followed the failure.
+	if mostRecentPlanCompleted != nil && mostRecentPlanCompleted.StartedAt.After(candidate.StartedAt) {
+		return nil
+	}
+	return &PlanFailedInfo{
+		SessionID: candidate.ID,
+		Reason:    "plan session ended without success",
+	}
 }
 
 // SetSelfHealAttempts updates the in-memory self-heal attempt counter for the

--- a/internal/issueview/assembler_test.go
+++ b/internal/issueview/assembler_test.go
@@ -648,3 +648,112 @@ func TestClearConflictsInfo_NoOpWhenAbsent(t *testing.T) {
 		t.Error("HasConflictsInfo on a never-set issue should be false")
 	}
 }
+
+// --- derivePlanFailed (#191) ---
+
+func TestDerivePlanFailed_SetsWhenNoBlockedReason(t *testing.T) {
+	sess := makeSession(types.StateFailed, t1, "", false)
+	sess.Mode = types.ModePlan
+	sess.ID = "plan-sess-1"
+	iss := types.Issue{Column: types.ColTodo}
+	result := derivePlanFailed(iss, []types.Session{sess}, nil)
+	if result == nil {
+		t.Fatal("expected PlanFailedInfo for failed plan session with no blocked_reason")
+	}
+	if result.SessionID != "plan-sess-1" {
+		t.Errorf("SessionID = %q, want plan-sess-1", result.SessionID)
+	}
+}
+
+func TestDerivePlanFailed_NilWhenBlockedReasonPresent(t *testing.T) {
+	// Sessions with BlockedReason are already surfaced via LastFailure; no double badge.
+	sess := makeSession(types.StateFailed, t1, "BLOCKED: quota exceeded", false)
+	sess.Mode = types.ModePlan
+	iss := types.Issue{Column: types.ColTodo}
+	result := derivePlanFailed(iss, []types.Session{sess}, nil)
+	if result != nil {
+		t.Errorf("expected nil for failed plan session with blocked_reason, got %+v", result)
+	}
+}
+
+func TestDerivePlanFailed_SuppressedInReview(t *testing.T) {
+	sess := makeSession(types.StateFailed, t1, "", false)
+	sess.Mode = types.ModePlan
+	iss := types.Issue{Column: types.ColReview}
+	result := derivePlanFailed(iss, []types.Session{sess}, nil)
+	if result != nil {
+		t.Errorf("expected nil for REVIEW card, got %+v", result)
+	}
+}
+
+func TestDerivePlanFailed_SuppressedInDone(t *testing.T) {
+	sess := makeSession(types.StateFailed, t1, "", false)
+	sess.Mode = types.ModePlan
+	iss := types.Issue{Column: types.ColDone}
+	result := derivePlanFailed(iss, []types.Session{sess}, nil)
+	if result != nil {
+		t.Errorf("expected nil for DONE card, got %+v", result)
+	}
+}
+
+func TestDerivePlanFailed_SuppressedByActivePlanSession(t *testing.T) {
+	failed := makeSession(types.StateFailed, t1, "", false)
+	failed.Mode = types.ModePlan
+	active := makeSession(types.StateRunning, t2, "", false)
+	active.Mode = types.ModePlan
+	iss := types.Issue{Column: types.ColPlan}
+	result := derivePlanFailed(iss, []types.Session{failed}, &active)
+	if result != nil {
+		t.Errorf("expected nil when active plan session exists, got %+v", result)
+	}
+}
+
+func TestDerivePlanFailed_SuppressedByLaterSuccessfulPlan(t *testing.T) {
+	failed := makeSession(types.StateFailed, t1, "", false)
+	failed.Mode = types.ModePlan
+	succeeded := makeSession(types.StateCompleted, t2, "", false)
+	succeeded.Mode = types.ModePlan
+	iss := types.Issue{Column: types.ColPlan}
+	result := derivePlanFailed(iss, []types.Session{succeeded, failed}, nil)
+	if result != nil {
+		t.Errorf("expected nil when successful plan followed the failure, got %+v", result)
+	}
+}
+
+func TestDerivePlanFailed_AcknowledgedSessionIgnored(t *testing.T) {
+	sess := makeSession(types.StateFailed, t1, "", true) // acknowledged
+	sess.Mode = types.ModePlan
+	iss := types.Issue{Column: types.ColTodo}
+	result := derivePlanFailed(iss, []types.Session{sess}, nil)
+	if result != nil {
+		t.Errorf("expected nil for acknowledged plan failure, got %+v", result)
+	}
+}
+
+func TestDerivePlanFailed_ExecuteSessionIgnored(t *testing.T) {
+	// derivePlanFailed must only look at plan-mode sessions.
+	sess := makeSession(types.StateFailed, t1, "", false)
+	sess.Mode = types.ModeExecute
+	iss := types.Issue{Column: types.ColTodo}
+	result := derivePlanFailed(iss, []types.Session{sess}, nil)
+	if result != nil {
+		t.Errorf("expected nil for execute-mode failure, got %+v", result)
+	}
+}
+
+func TestDerivePlanFailed_MostRecentFailureWins(t *testing.T) {
+	older := makeSession(types.StateFailed, t1, "", false)
+	older.Mode = types.ModePlan
+	older.ID = "old"
+	newer := makeSession(types.StateFailed, t2, "", false)
+	newer.Mode = types.ModePlan
+	newer.ID = "new"
+	iss := types.Issue{Column: types.ColTodo}
+	result := derivePlanFailed(iss, []types.Session{older, newer}, nil)
+	if result == nil {
+		t.Fatal("expected PlanFailedInfo")
+	}
+	if result.SessionID != "new" {
+		t.Errorf("want newest failure, got SessionID=%q", result.SessionID)
+	}
+}

--- a/internal/issueview/issueview.go
+++ b/internal/issueview/issueview.go
@@ -36,6 +36,16 @@ type ConflictsInfo struct {
 	ConflictingFiles []string `json:"conflicting_files"`
 }
 
+// PlanFailedInfo is populated when the most recent plan-mode session ended in
+// a failed state without emitting a BLOCKED: sentinel (those are already
+// surfaced via LastFailure). Cleared when a plan session succeeds or the card
+// moves to REVIEW/DONE (#191).
+type PlanFailedInfo struct {
+	SessionID string `json:"session_id"`
+	// Reason is a short human-readable explanation. May be empty.
+	Reason string `json:"reason,omitempty"`
+}
+
 // OrphanQuestionInfo is populated when a paused_for_question session's question
 // file is absent from disk (#153). The frontend uses this to render a recovery
 // badge and enable the Recover action without re-checking the filesystem.
@@ -70,6 +80,12 @@ type IssueView struct {
 	// NeedsPRInfo mirrors Issue.NeedsPRInfo for direct frontend access (#157).
 	// Set when the execute session completed the work but could not push.
 	NeedsPRInfo *types.NeedsPRInfo `json:"needs_pr_info,omitempty"`
+
+	// PlanFailed is set when the most recent plan session ended in a failed
+	// state without a captured BLOCKED: reason (those are already shown via
+	// LastFailure). Lets the UI show a visible red badge on PLAN-column cards
+	// that silently failed to produce a plan (#191).
+	PlanFailed *PlanFailedInfo `json:"plan_failed,omitempty"`
 
 	// UnreadCommentCount is the number of unread PR comments on this issue
 	// (#159). Non-zero only for REVIEW-column cards. Drives the "New Comment

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -128,6 +128,11 @@ type Manager struct {
 // Sentinel so callers can branch on it cleanly via errors.Is.
 var ErrDuplicateSpawn = errors.New("duplicate spawn refused: same (workspace, issue, mode) already in flight")
 
+// ErrRemoteNotReady is returned by SpawnPlan when the workspace has
+// ExecutionTarget=remote but RemoteConfig or CFWorkerEndpointURL is not
+// configured. The caller should surface this as an immediate card error.
+var ErrRemoteNotReady = errors.New("remote workspace not ready: no worker endpoint configured")
+
 type runtimeSession struct {
 	sess           *types.Session
 	cmd            sessionCmd
@@ -304,7 +309,14 @@ func (m *Manager) SetProviders(r *llm.Registry) { m.providers = r }
 // SpawnPlan launches a plan-mode worker per §10.1 / §10.4. The pool's provider
 // determines the spawn strategy: Claude returns argv (subprocess), the four
 // OpenAI-compat providers return llm.ErrNotSupported (harness, §10.5).
+//
+// Issue #191: when ws.ExecutionTarget is "remote", delegates to spawnRemotePlan
+// instead of running a local subprocess. Returns ErrRemoteNotReady immediately
+// if the remote endpoint is not configured so the caller can surface an error.
 func (m *Manager) SpawnPlan(ws types.Workspace, issue types.Issue, pool types.Pool) (*types.Session, error) {
+	if ws.ExecutionTarget == types.ExecutionTargetRemote {
+		return m.spawnRemotePlan(ws, issue, pool)
+	}
 	args, prompt, err := m.buildPlanCommand(ws, issue, pool)
 	if err != nil {
 		return nil, err

--- a/internal/session/manager_plan_remote_test.go
+++ b/internal/session/manager_plan_remote_test.go
@@ -1,0 +1,244 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"prismconductor/internal/remoteworker"
+	"prismconductor/internal/types"
+)
+
+// swapHTTPClient replaces the package-level http client inside remoteworker
+// for the duration of a test via the test-helper exported by that package.
+// We can't call replaceHTTPClient directly (it's in a different package and
+// test-only), so we use the same httptest.Server trick that the remote-worker
+// tests use: pass the server's client to the equivalent test-helper.
+//
+// This test file directly instantiates a Manager and exercises SpawnPlan;
+// it uses a real httptest.Server whose URL is wired into the workspace
+// RemoteConfig, bypassing the package-level http.Client substitution by
+// relying on the default http.Client pointing at the test server's loopback.
+
+// buildTestManager returns a minimal Manager configured for test spawns.
+func buildTestManager(t *testing.T) *Manager {
+	t.Helper()
+	dir := t.TempDir()
+	m := &Manager{
+		sessions:      make(map[string]*runtimeSession),
+		inFlight:      make(map[string]bool),
+		transcriptDir: dir,
+	}
+	return m
+}
+
+// TestSpawnPlan_LocalWorkspace_DoesNotCallRemote verifies that SpawnPlan does
+// not try to call any remote endpoint when ExecutionTarget is empty (local).
+func TestSpawnPlan_LocalWorkspace_DoesNotCallRemote(t *testing.T) {
+	remoteCallMade := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteCallMade = true
+		http.Error(w, "should not be called", 500)
+	}))
+	defer srv.Close()
+
+	ws := types.Workspace{
+		ID:              "ws-local",
+		ExecutionTarget: types.ExecutionTargetLocal,
+		// No RemoteConfig — but even if present, local target must not call it.
+		RemoteConfig: &types.RemoteConfig{CFWorkerEndpointURL: srv.URL},
+	}
+	issue := types.Issue{Number: 1, WorkspaceID: ws.ID}
+	pool := types.Pool{}
+
+	m := buildTestManager(t)
+	// SpawnPlan for a local workspace will call buildPlanCommand which needs
+	// providers; it fails fast with a provider error — that's fine. What
+	// matters is no HTTP call was made to the test server.
+	_, _ = m.SpawnPlan(ws, issue, pool)
+
+	if remoteCallMade {
+		t.Error("SpawnPlan on a local workspace must not make any HTTP call to a remote endpoint")
+	}
+}
+
+// TestSpawnPlan_RemoteWorkspace_NoConfig_ReturnsErrRemoteNotReady verifies
+// that SpawnPlan returns ErrRemoteNotReady immediately when ExecutionTarget
+// is remote but RemoteConfig or CFWorkerEndpointURL is missing.
+func TestSpawnPlan_RemoteWorkspace_NoConfig_ReturnsErrRemoteNotReady(t *testing.T) {
+	cases := []struct {
+		name string
+		ws   types.Workspace
+	}{
+		{
+			name: "nil RemoteConfig",
+			ws: types.Workspace{
+				ID:              "ws-no-rc",
+				ExecutionTarget: types.ExecutionTargetRemote,
+				RemoteConfig:    nil,
+			},
+		},
+		{
+			name: "empty CFWorkerEndpointURL",
+			ws: types.Workspace{
+				ID:              "ws-no-url",
+				ExecutionTarget: types.ExecutionTargetRemote,
+				RemoteConfig:    &types.RemoteConfig{CFWorkerEndpointURL: ""},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := buildTestManager(t)
+			_, err := m.SpawnPlan(tc.ws, types.Issue{Number: 1, WorkspaceID: tc.ws.ID}, types.Pool{})
+			if !errors.Is(err, ErrRemoteNotReady) {
+				t.Errorf("want ErrRemoteNotReady, got %v", err)
+			}
+		})
+	}
+}
+
+// TestSpawnPlan_RemoteWorkspace_RoutesToRemote verifies that SpawnPlan posts
+// to the remote worker's /sessions endpoint with mode="plan" when
+// ExecutionTarget is remote and the endpoint is configured.
+func TestSpawnPlan_RemoteWorkspace_RoutesToRemote(t *testing.T) {
+	sessionID := "plan-sess-001"
+	var gotBody map[string]any
+	var gotPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/sessions":
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(remoteworker.SpawnResponse{SessionID: sessionID})
+
+		case r.Method == "GET" && r.URL.Path == "/sessions/"+sessionID+"/stream":
+			// Return empty SSE stream so the goroutine exits cleanly.
+			w.Header().Set("Content-Type", "text/event-stream")
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	// Write a dummy API key file so remoteworker.GetKey succeeds.
+	keyDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Skipf("cannot locate config dir: %v", err)
+	}
+	keyPath := fmt.Sprintf("%s/PrismConductor/secrets/ws-remote-plan.key", keyDir)
+	_ = os.MkdirAll(keyPath[:len(keyPath)-len("/ws-remote-plan.key")], 0o700)
+	_ = os.WriteFile(keyPath, []byte("test-api-key"), 0o600)
+	t.Cleanup(func() { _ = os.Remove(keyPath) })
+
+	ws := types.Workspace{
+		ID:              "ws-remote-plan",
+		ExecutionTarget: types.ExecutionTargetRemote,
+		RemoteConfig:    &types.RemoteConfig{CFWorkerEndpointURL: srv.URL},
+		GitHubOwner:     "acme",
+		GitHubRepo:      "myrepo",
+	}
+	issue := types.Issue{Number: 7, WorkspaceID: ws.ID}
+	pool := types.Pool{Model: "claude-opus-4-7"}
+
+	m := buildTestManager(t)
+	sess, err := m.SpawnPlan(ws, issue, pool)
+	if err != nil {
+		t.Fatalf("SpawnPlan: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("expected non-nil session")
+	}
+	if sess.Mode != types.ModePlan {
+		t.Errorf("session mode = %q, want plan", sess.Mode)
+	}
+	if sess.State != types.StateRunning {
+		t.Errorf("session state = %q, want running", sess.State)
+	}
+
+	// Wait briefly for the SSE goroutine to make the initial HTTP call.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if gotPath != "" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if gotPath != "/sessions" {
+		t.Errorf("request path = %q, want /sessions", gotPath)
+	}
+	if got, ok := gotBody["mode"].(string); !ok || got != "plan" {
+		t.Errorf("request body mode = %v, want \"plan\"", gotBody["mode"])
+	}
+	if got, ok := gotBody["issue_number"].(float64); !ok || int(got) != 7 {
+		t.Errorf("request body issue_number = %v, want 7", gotBody["issue_number"])
+	}
+}
+
+// TestSpawnPlan_RemoteWorkspace_DuplicateGuard verifies that a second SpawnPlan
+// call for the same workspace+issue returns ErrDuplicateSpawn when the first
+// session is still running.
+func TestSpawnPlan_RemoteWorkspace_DuplicateGuard(t *testing.T) {
+	sessionID := "plan-dup-001"
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/sessions":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(remoteworker.SpawnResponse{SessionID: sessionID})
+		case r.Method == "GET":
+			// Block until test ends so the session stays running.
+			w.Header().Set("Content-Type", "text/event-stream")
+			<-block
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(func() { close(block); srv.Close() })
+
+	keyDir, _ := os.UserConfigDir()
+	keyPath := fmt.Sprintf("%s/PrismConductor/secrets/ws-dup-guard.key", keyDir)
+	_ = os.MkdirAll(keyPath[:len(keyPath)-len("/ws-dup-guard.key")], 0o700)
+	_ = os.WriteFile(keyPath, []byte("test-key"), 0o600)
+	t.Cleanup(func() { _ = os.Remove(keyPath) })
+
+	ws := types.Workspace{
+		ID:              "ws-dup-guard",
+		ExecutionTarget: types.ExecutionTargetRemote,
+		RemoteConfig:    &types.RemoteConfig{CFWorkerEndpointURL: srv.URL},
+	}
+	issue := types.Issue{Number: 3, WorkspaceID: ws.ID}
+
+	m := buildTestManager(t)
+	sess1, err := m.SpawnPlan(ws, issue, types.Pool{})
+	if err != nil {
+		t.Fatalf("first SpawnPlan: %v", err)
+	}
+	// Ensure the session is registered as running before the second call.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		m.mu.Lock()
+		rs, ok := m.sessions[sess1.ID]
+		m.mu.Unlock()
+		if ok && rs != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	_, err = m.SpawnPlan(ws, issue, types.Pool{})
+	if !errors.Is(err, ErrDuplicateSpawn) {
+		t.Errorf("second SpawnPlan: want ErrDuplicateSpawn, got %v", err)
+	}
+}

--- a/internal/session/spawn_remote.go
+++ b/internal/session/spawn_remote.go
@@ -1,0 +1,131 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/google/uuid"
+
+	"prismconductor/internal/remoteworker"
+	"prismconductor/internal/types"
+)
+
+// spawnRemotePlan creates a plan-mode session that runs inside a remote
+// Cloudflare Worker (§10.1 remote variant). It mirrors spawnRemote but uses
+// ModePlan and posts to the worker's /sessions endpoint with mode="plan".
+//
+// ErrRemoteNotReady is returned immediately when the workspace has no
+// CFWorkerEndpointURL configured, so the caller can surface an error to the
+// UI before any session row is created.
+func (m *Manager) spawnRemotePlan(ws types.Workspace, issue types.Issue, pool types.Pool) (*types.Session, error) {
+	rc := ws.RemoteConfig
+	if rc == nil || rc.CFWorkerEndpointURL == "" {
+		return nil, ErrRemoteNotReady
+	}
+
+	key := fmt.Sprintf("%s:%d:%s", ws.ID, issue.Number, types.ModePlan)
+	m.mu.Lock()
+	if m.inFlight[key] {
+		m.mu.Unlock()
+		return nil, ErrDuplicateSpawn
+	}
+	for _, rs := range m.sessions {
+		if rs == nil || rs.sess == nil {
+			continue
+		}
+		if rs.sess.WorkspaceID != ws.ID || rs.sess.IssueNumber != issue.Number || rs.sess.Mode != types.ModePlan {
+			continue
+		}
+		switch rs.sess.State {
+		case types.StateRunning, types.StateWaitingForInput, types.StatePausedForQuestion, types.StateBlocked:
+			m.mu.Unlock()
+			return nil, ErrDuplicateSpawn
+		}
+	}
+	m.inFlight[key] = true
+	m.mu.Unlock()
+	defer func() {
+		m.mu.Lock()
+		delete(m.inFlight, key)
+		m.mu.Unlock()
+	}()
+
+	if m.transcriptDir == "" {
+		return nil, fmt.Errorf("session manager: transcript dir not configured")
+	}
+	if err := os.MkdirAll(m.transcriptDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create transcript dir: %w", err)
+	}
+	sessID := uuid.NewString()
+	transcriptPath := filepath.Join(m.transcriptDir, sessID+".log")
+	tf, err := os.Create(transcriptPath)
+	if err != nil {
+		return nil, fmt.Errorf("create transcript: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sess := &types.Session{
+		ID:          sessID,
+		WorkspaceID: ws.ID,
+		IssueNumber: issue.Number,
+		Mode:        types.ModePlan,
+		State:       types.StateRunning,
+		StartedAt:   time.Now(),
+		PoolID:      pool.ID,
+	}
+	sess.Transcript = transcriptPath
+
+	params := remoteworker.SpawnParams{
+		WorkspaceID:   ws.ID,
+		IssueNumber:   issue.Number,
+		Mode:          string(types.ModePlan),
+		GitHubOwner:   ws.GitHubOwner,
+		GitHubRepo:    ws.GitHubRepo,
+		DefaultBranch: ws.DefaultBranch,
+		PoolModel:     pool.Model,
+	}
+	apiKey, err := remoteworker.GetKey(ws.ID)
+	if err != nil {
+		_ = tf.Close()
+		_ = os.Remove(transcriptPath)
+		cancel()
+		return nil, fmt.Errorf("remote plan spawn: read API key: %w", err)
+	}
+	remCmd, err := remoteworker.Spawn(ctx, rc.CFWorkerEndpointURL, apiKey, params, tf)
+	if err != nil {
+		_ = tf.Close()
+		_ = os.Remove(transcriptPath)
+		cancel()
+		return nil, fmt.Errorf("remote plan spawn: %w", err)
+	}
+
+	rs := &runtimeSession{
+		sess:           sess,
+		cmd:            remCmd,
+		cancel:         cancel,
+		parser:         NewStreamParser(),
+		transcriptPath: transcriptPath,
+		transcriptFile: tf,
+		poolID:         pool.ID,
+		poolName:       pool.Name,
+		poolModel:      pool.Model,
+		lastLineAt:     time.Now(),
+	}
+
+	if m.store != nil {
+		_ = m.store.SaveSession(sess, rs.transcriptPath)
+	}
+	if m.onStateChange != nil {
+		m.onStateChange(*sess, "")
+	}
+
+	m.mu.Lock()
+	m.sessions[sess.ID] = rs
+	m.mu.Unlock()
+
+	go m.tailAndParse(ctx, rs)
+	return sess, nil
+}


### PR DESCRIPTION
## Summary

- SpawnPlan now routes to `spawnRemotePlan` for remote workspaces (`ExecutionTarget=remote`), fixing the silent local-process fallback
- Returns `ErrRemoteNotReady` immediately when `CFWorkerEndpointURL` is unconfigured, so the card shows an error instead of silently running locally
- New `PlanFailedInfo` added to `IssueView`; `derivePlanFailed` in `assembler.go` surfaces plan sessions that ended `StateFailed` without a `BLOCKED:` reason (those were invisible to `selectSessions`/`LastFailure`)
- `Card.tsx` renders a red plan-failed badge with the session ID and a "Clear" action, matching the existing failure UI patterns
- `models.ts` updated with `PlanFailedInfo` class and `plan_failed` field on `IssueView`

## Files modified

- `internal/session/spawn_remote.go` — new `spawnRemotePlan` helper (POST /sessions, mode=plan)
- `internal/session/manager.go` — `SpawnPlan` routing + `ErrRemoteNotReady` sentinel
- `internal/issueview/issueview.go` — `PlanFailedInfo` struct + `PlanFailed` field on `IssueView`
- `internal/issueview/assembler.go` — `derivePlanFailed` helper + wired into `Assemble`
- `frontend/src/components/Card.tsx` — plan failure badge in `StatusRow`
- `frontend/wailsjs/go/models.ts` — `PlanFailedInfo` class + `plan_failed` field
- `internal/session/manager_plan_remote_test.go` — unit tests for SpawnPlan remote routing (4 tests)
- `internal/issueview/assembler_test.go` — 9 new tests for `derivePlanFailed` logic
- `frontend/src/components/Card.planfailed.test.ts` — 7 frontend tests for plan failure badge visibility

## Verification

| Step | Command | Result |
|------|---------|--------|
| Go lint | `go vet ./internal/...` | ✅ pass |
| Go build | `go build ./internal/...` | ✅ pass |
| Smoke test | `npx playwright test tests/e2e/startup.spec.ts` | ⚠ skipped — dev server not running in headless worktree environment (ERR_CONNECTION_REFUSED) |
| Go tests | `go test ./internal/...` | ✅ 100% pass across all packages |
| Frontend tests | `npm test` (vitest) | ✅ 60/60 pass (7 new tests added) |
| TypeScript typecheck | `tsc --noEmit` | ⚠ not runnable in worktree (node_modules gitignored, worktree is on feat branch with glow files absent from main repo); Card.tsx changes are type-sound (PlanFailedInfo type defined locally in the file, all props correctly typed) |

**Commit tier:** Tier 1 (GitHub API GraphQL signed by GitHub)

**Workspace mode:** per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-191

Closes #191