### PR TITLE
feat: BLOCKED column + orphan-PR recovery for failed execute sessions (#194)

### DIFF
--- a/app.go
+++ b/app.go
@@ -456,6 +456,19 @@ func (a *App) handleSessionStateChange(sess types.Session, prev types.SessionSta
 		return
 	}
 
+	// When an execute session fails, persist the failure reason on the issue
+	// and move the card to the BLOCKED column so it appears in a dedicated
+	// repair column instead of staying silently in IN_PROGRESS (#194).
+	if sess.Mode == types.ModeExecute &&
+		(sess.State == types.StateBlocked || sess.State == types.StateFailed) &&
+		a.store != nil {
+		reason := sess.BlockedReason
+		if reason == "" {
+			reason = "execute session ended without success"
+		}
+		_ = a.store.SetIssueFailureReason(sess.WorkspaceID, sess.IssueNumber, reason)
+	}
+
 	// When an execute session COMPLETES on a card that had merge conflicts
 	// recorded, optimistically clear the conflict info so the card doesn't
 	// stay glowing red after the resolver demonstrably finished. The
@@ -1447,6 +1460,16 @@ func (a *App) ClearIssueFailure(workspaceID string, issueNumber int) error {
 	if err != nil {
 		return err
 	}
+	// Clear the persisted failure_reason so the card no longer shows the
+	// blocked tooltip after the user acknowledges the failure (#194).
+	_ = a.store.SetIssueFailureReason(workspaceID, issueNumber, "")
+	// Emit orphan PR cleared so the assembler removes the recovery button.
+	if a.bus != nil {
+		a.bus.Publish(eventbus.EvtOrphanPRCleared, eventbus.OrphanPRCleared{
+			WorkspaceID: workspaceID,
+			IssueNumber: issueNumber,
+		})
+	}
 	if sess != nil {
 		wruntime.EventsEmit(a.ctx, "session.state", *sess)
 		// Publish to the in-process bus too so the IssueView assembler
@@ -1470,6 +1493,57 @@ func (a *App) ClearIssueFailure(workspaceID string, issueNumber int) error {
 		// at least makes the UI converge with backend truth.
 		a.assembler.Reassemble(workspaceID, issueNumber)
 	}
+	return nil
+}
+
+// OpenOrphanPR creates a draft PR for a pushed branch from a failed execute
+// session that never opened a PR. Transitions the card to REVIEW on success
+// (#194). Returns an error if no orphan session exists or the API call fails.
+func (a *App) OpenOrphanPR(workspaceID string, issueNumber int) error {
+	if a.store == nil {
+		return fmt.Errorf("store unavailable")
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return fmt.Errorf("unknown workspace %q", workspaceID)
+	}
+	sess, err := a.store.MostRecentFailedExecuteSession(workspaceID, issueNumber)
+	if err != nil {
+		return fmt.Errorf("lookup failed execute session: %w", err)
+	}
+	if sess == nil || sess.Branch == "" {
+		return fmt.Errorf("no failed execute session with a pushed branch for issue #%d", issueNumber)
+	}
+	if a.gh == nil {
+		return fmt.Errorf("github client not configured")
+	}
+	iss, err := a.store.LoadIssue(workspaceID, issueNumber)
+	if err != nil {
+		return fmt.Errorf("load issue: %w", err)
+	}
+	prNum, prURL, err := a.gh.CreateDraftPR(a.ctx, ws, sess.Branch, iss.Title, issueNumber)
+	if err != nil {
+		return fmt.Errorf("create draft PR: %w", err)
+	}
+	if err := a.store.MarkPROpened(workspaceID, issueNumber, prNum, prURL); err != nil {
+		return fmt.Errorf("mark PR opened: %w", err)
+	}
+	// Clear orphan state and emit PR-opened so the assembler moves the card.
+	_ = a.store.SetIssueFailureReason(workspaceID, issueNumber, "")
+	if a.bus != nil {
+		a.bus.Publish(eventbus.EvtPROpened, map[string]any{
+			"workspace_id": workspaceID,
+			"issue_number": issueNumber,
+			"pr_number":    prNum,
+			"pr_url":       prURL,
+		})
+	}
+	wruntime.EventsEmit(a.ctx, "pr.opened", map[string]any{
+		"workspace_id": workspaceID,
+		"issue_number": issueNumber,
+		"pr_number":    prNum,
+		"pr_url":       prURL,
+	})
 	return nil
 }
 

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -31,6 +31,7 @@ const COLUMNS: { id: ColumnID; title: string }[] = [
   { id: "in_progress", title: "IN_PROGRESS" },
   { id: "review", title: "REVIEW" },
   { id: "done", title: "DONE" },
+  { id: "blocked", title: "BLOCKED" },
 ];
 
 const cardID = (i: types.Issue) => `${i.workspace_id}#${i.number}`;
@@ -60,6 +61,7 @@ const fromCardID = (id: string) => {
 export function Board({ onCardClick }: { onCardClick?: (issue: types.Issue) => void }) {
   const { issues, refresh, applyLocalMove, applyLocalReorder, moveColumn, reorder, searchQuery } = useIssueStore();
   const loadIssueViews = useIssueViewStore((s) => s.loadForWorkspace);
+  const getView = useIssueViewStore((s) => s.get);
   const { workspaces, selectedID } = useWorkspaceStore();
   const { selected: labelSelected, mode: labelMode } = useLabelFilterStore();
   const [filteredTodoNums, setFilteredTodoNums] = useState<Set<string> | null>(null);
@@ -107,6 +109,8 @@ export function Board({ onCardClick }: { onCardClick?: (issue: types.Issue) => v
 
   // Group issues by column. For TODO, drop anything excluded by the active goal,
   // and order by orchestrator priority desc when no manual reorder has happened.
+  // BLOCKED is derived: cards route to BLOCKED when their IssueView.derived_column
+  // is "blocked", regardless of the stored issue.column value (#194).
   const grouped = useMemo(() => {
     const out: Record<ColumnID, types.Issue[]> = {
       todo: [],
@@ -114,10 +118,13 @@ export function Board({ onCardClick }: { onCardClick?: (issue: types.Issue) => v
       in_progress: [],
       review: [],
       done: [],
+      blocked: [],
     };
     const labelSet = labelSelected.length > 0 ? new Set(labelSelected) : null;
     for (const i of issues) {
-      const col = (i.column || "todo") as ColumnID;
+      const view = getView(i.workspace_id, i.number);
+      const derivedCol = (view?.derived_column || i.column || "todo") as ColumnID;
+      const col = derivedCol;
       if (col === "todo" && filteredTodoNums && !filteredTodoNums.has(cardID(i))) continue;
       if (!matchesQuery(i.title, searchQuery)) continue;
       if (labelSet) {
@@ -134,7 +141,7 @@ export function Board({ onCardClick }: { onCardClick?: (issue: types.Issue) => v
     // every item shares manual_order=0 (no human reorder yet), use priority.
     out.todo = sortTodoByPriority(out.todo);
     return out;
-  }, [issues, filteredTodoNums, searchQuery, labelSelected, labelMode]);
+  }, [issues, filteredTodoNums, searchQuery, labelSelected, labelMode, getView]);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
 

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { BrowserOpenURL } from "../../wailsjs/runtime/runtime";
-import { Replan, ReplanForce, ClearIssueFailure, SelfHeal, CancelSession, SpawnPlanForIssue, ResolveConflicts, AttachManualPR, PrepareManualPushCommand } from "../../wailsjs/go/main/App";
+import { Replan, ReplanForce, ClearIssueFailure, SelfHeal, CancelSession, SpawnPlanForIssue, ResolveConflicts, AttachManualPR, PrepareManualPushCommand, OpenOrphanPR } from "../../wailsjs/go/main/App";
 import { ClipboardSetText } from "../../wailsjs/runtime/runtime";
 import { RecoverButton } from "./RecoverButton";
 import { types } from "../../wailsjs/go/models";
@@ -53,6 +53,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
   const orphanQuestion = view?.orphan_question ?? null;
   const needsPRInfo = view?.needs_pr_info ?? null;
   const planFailed = view?.plan_failed ?? null;
+  const orphanPRInfo = view?.orphan_pr_info ?? null;
   // Activity is live-streaming data not captured in the view — still from sessionStore.
   const activity: SessionActivity | null = useSessionStore((s) =>
     activeSession ? (s.sessions[activeSession.id]?.activity ?? null) : null
@@ -243,6 +244,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, onClick }: CardPro
         orphanQuestion={orphanQuestion}
         planReady={planReady}
         planFailed={planFailed}
+        orphanPRInfo={orphanPRInfo}
         blocked={blocked}
         isPrimitive={isPrimitive}
         dependencies={issue.dependencies ?? []}
@@ -461,6 +463,10 @@ type PlanFailedInfo = {
   reason?: string;
 };
 
+type OrphanPRInfo = {
+  branch: string;
+};
+
 function StatusRow({
   activeSession,
   activity,
@@ -469,6 +475,7 @@ function StatusRow({
   orphanQuestion,
   planReady,
   planFailed,
+  orphanPRInfo,
   blocked,
   isPrimitive,
   dependencies,
@@ -493,6 +500,7 @@ function StatusRow({
   orphanQuestion: OrphanQuestionInfo | null;
   planReady: { revision: number } | null;
   planFailed: PlanFailedInfo | null;
+  orphanPRInfo: OrphanPRInfo | null;
   blocked: boolean;
   isPrimitive: boolean;
   dependencies: number[];
@@ -733,6 +741,52 @@ function StatusRow({
               </button>
             </div>
           )}
+        </div>
+        {menuEl}
+      </>
+    );
+  }
+
+  // Orphan PR recovery: execute session pushed a branch but died before opening a PR (#194).
+  if (orphanPRInfo && !activeSession && !pausedSession && !needsPRInfo) {
+    const [opening, setOpening] = useState(false);
+    return (
+      <>
+        <div className="text-[11px] mt-1.5 space-y-0.5">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <Pulse className="bg-red-400" />
+            <span className="text-red-300 font-medium">BLOCKED — branch pushed, no PR</span>
+          </div>
+          <div className="text-slate-400 text-[10px] truncate pl-3.5" title={orphanPRInfo.branch}>
+            {orphanPRInfo.branch}
+          </div>
+          <div className="flex gap-1.5 pl-3.5">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setOpening(true);
+                OpenOrphanPR(workspaceID, issueNumber)
+                  .catch((err: any) => alert(String(err?.message ?? err)))
+                  .finally(() => setOpening(false));
+              }}
+              onMouseDown={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
+              disabled={opening}
+              className="px-1.5 py-0.5 rounded text-[10px] border border-emerald-700 text-emerald-300 hover:border-emerald-500 hover:text-emerald-200 disabled:opacity-50"
+              title={`Open a draft PR for branch ${orphanPRInfo.branch}`}
+            >
+              {opening ? "Opening…" : "↗ Open PR for pushed branch"}
+            </button>
+            <button
+              onClick={(e) => { e.stopPropagation(); onClearFailure(); }}
+              onMouseDown={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
+              className="px-1.5 py-0.5 rounded text-[10px] border border-slate-700 text-slate-400 hover:border-slate-500 hover:text-slate-200"
+              title="Dismiss this recovery prompt"
+            >
+              ✕ Dismiss
+            </button>
+          </div>
         </div>
         {menuEl}
       </>

--- a/frontend/src/stores/issueStore.ts
+++ b/frontend/src/stores/issueStore.ts
@@ -10,7 +10,7 @@ import {
 } from "../../wailsjs/go/main/App";
 import { types } from "../../wailsjs/go/models";
 
-export type Column = "todo" | "plan" | "in_progress" | "review" | "done";
+export type Column = "todo" | "plan" | "in_progress" | "review" | "done" | "blocked";
 
 type State = {
   issues: types.Issue[];

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -234,3 +234,5 @@ export function WorkspaceSpendToday(arg1:string):Promise<number>;
 export function WriteAgentInput(arg1:string,arg2:string):Promise<void>;
 
 export function WriteAnswersOnly(arg1:main.AnswerSubmission):Promise<void>;
+
+export function OpenOrphanPR(arg1:string,arg2:number):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -449,3 +449,7 @@ export function WriteAgentInput(arg1, arg2) {
 export function WriteAnswersOnly(arg1) {
   return window['go']['main']['App']['WriteAnswersOnly'](arg1);
 }
+
+export function OpenOrphanPR(arg1, arg2) {
+  return window['go']['main']['App']['OpenOrphanPR'](arg1, arg2);
+}

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -841,6 +841,19 @@ export namespace issueview {
 	    }
 	}
 
+	export class OrphanPRInfo {
+	    branch: string;
+
+	    static createFrom(source: any = {}) {
+	        return new OrphanPRInfo(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.branch = source["branch"];
+	    }
+	}
+
 	export class PlanFailedInfo {
 	    session_id: string;
 	    reason?: string;
@@ -907,6 +920,7 @@ export namespace issueview {
 	    orphan_question?: OrphanQuestionInfo;
 	    needs_pr_info?: types.NeedsPRInfo;
 	    plan_failed?: PlanFailedInfo;
+	    orphan_pr_info?: OrphanPRInfo;
 	    unread_comment_count: number;
 	
 	    static createFrom(source: any = {}) {
@@ -928,6 +942,7 @@ export namespace issueview {
 	        this.orphan_question = this.convertValues(source["orphan_question"], OrphanQuestionInfo);
 	        this.needs_pr_info = this.convertValues(source["needs_pr_info"], types.NeedsPRInfo);
 	        this.plan_failed = this.convertValues(source["plan_failed"], PlanFailedInfo);
+	        this.orphan_pr_info = this.convertValues(source["orphan_pr_info"], OrphanPRInfo);
 	        this.unread_comment_count = source["unread_comment_count"];
 	    }
 	

--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -54,6 +54,10 @@ const (
 	// Issue #159: PR comment surface — inbound badge and outbound post.
 	EvtPRCommentReceived EventType = "pr_comment_received"
 	EvtPRCommentPosted   EventType = "pr_comment_posted"
+
+	// Issue #194: orphan-branch detection and recovery.
+	EvtOrphanPRDetected EventType = "orphan_pr_detected"
+	EvtOrphanPRCleared  EventType = "orphan_pr_cleared"
 )
 
 type Event struct {
@@ -160,6 +164,19 @@ type PRCommentReceived struct {
 	PRNumber    int    `json:"pr_number"`
 	CommentID   int64  `json:"comment_id"`
 	Author      string `json:"author"`
+}
+
+// OrphanPRDetected is the payload for EvtOrphanPRDetected (#194).
+type OrphanPRDetected struct {
+	WorkspaceID string `json:"workspace_id"`
+	IssueNumber int    `json:"issue_number"`
+	Branch      string `json:"branch"`
+}
+
+// OrphanPRCleared is the payload for EvtOrphanPRCleared (#194).
+type OrphanPRCleared struct {
+	WorkspaceID string `json:"workspace_id"`
+	IssueNumber int    `json:"issue_number"`
 }
 
 type Handler func(Event)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -409,3 +409,34 @@ func (c *Client) SetIssueLabels(ctx context.Context, ws types.Workspace, issueNu
 	_, _, err := c.api.Issues.ReplaceLabelsForIssue(ctx, ws.GitHubOwner, ws.GitHubRepo, issueNumber, names)
 	return err
 }
+
+// CreateDraftPR opens a draft pull request for the given branch, targeting the
+// repository's default branch. Returns the PR number and HTML URL (#194).
+func (c *Client) CreateDraftPR(ctx context.Context, ws types.Workspace, branch, issueTitle string, issueNumber int) (int, string, error) {
+	if ws.GitHubOwner == "" || ws.GitHubRepo == "" {
+		return 0, "", fmt.Errorf("workspace %q missing github_owner / github_repo", ws.ID)
+	}
+	// Resolve the repo's default branch to use as the base.
+	repo, _, err := c.api.Repositories.Get(ctx, ws.GitHubOwner, ws.GitHubRepo)
+	if err != nil {
+		return 0, "", fmt.Errorf("get repo: %w", err)
+	}
+	base := repo.GetDefaultBranch()
+	if base == "" {
+		base = "main"
+	}
+	draft := true
+	title := fmt.Sprintf("%s (#%d)", issueTitle, issueNumber)
+	body := fmt.Sprintf("Closes #%d\n\n_PR created via PrismConductor orphan-branch recovery._", issueNumber)
+	pr, _, err := c.api.PullRequests.Create(ctx, ws.GitHubOwner, ws.GitHubRepo, &gh.NewPullRequest{
+		Title: &title,
+		Head:  &branch,
+		Base:  &base,
+		Body:  &body,
+		Draft: &draft,
+	})
+	if err != nil {
+		return 0, "", err
+	}
+	return pr.GetNumber(), pr.GetHTMLURL(), nil
+}

--- a/internal/github/poll.go
+++ b/internal/github/poll.go
@@ -24,6 +24,7 @@ type Store interface {
 	MarkPRClosedUnmerged(workspaceID string, number int) error
 	SaveLabels(workspaceID string, labels []types.Label) error
 	UpsertPRComment(c types.PRComment) (bool, error)
+	MostRecentFailedExecuteSession(workspaceID string, issueNumber int) (*types.Session, error)
 }
 
 // WorkspaceSource lets the poller pick up newly-added workspaces between ticks.
@@ -361,6 +362,44 @@ func (p *Poller) pollOne(ctx context.Context, ws types.Workspace) error {
 			continue
 		}
 		p.publishPR(eventbus.EvtPROpened, ws, iss)
+	}
+
+	// Orphan-branch detection (#194): for issues with a failed execute session
+	// that have a branch but no open PR, check GitHub for a PR targeting that
+	// branch. Bounded by issues with failed execute sessions (typically 0–2).
+	for _, iss := range prev {
+		if iss.PRNumber != nil {
+			continue // PR already attached
+		}
+		if iss.NeedsPRInfo != nil {
+			continue // already handled by NEEDS_PR path
+		}
+		sess, err := p.Store.MostRecentFailedExecuteSession(ws.ID, iss.Number)
+		if err != nil || sess == nil || sess.Branch == "" {
+			continue
+		}
+		prNum, prURL, err := p.Client.FetchOpenPRsForBranch(ctx, ws, sess.Branch)
+		if err != nil {
+			log.Printf("orphan-pr poll %s#%d: %v", ws.ID, iss.Number, err)
+			continue
+		}
+		if prNum != 0 {
+			// PR was opened manually; auto-attach it.
+			if err := p.Store.MarkPROpened(ws.ID, iss.Number, prNum, prURL); err != nil {
+				log.Printf("orphan-pr: mark pr opened %s#%d: %v", ws.ID, iss.Number, err)
+				continue
+			}
+			p.publishPR(eventbus.EvtPROpened, ws, iss)
+		} else {
+			// Branch pushed but no PR yet — surface recovery button.
+			if p.Bus != nil {
+				p.Bus.Publish(eventbus.EvtOrphanPRDetected, eventbus.OrphanPRDetected{
+					WorkspaceID: ws.ID,
+					IssueNumber: iss.Number,
+					Branch:      sess.Branch,
+				})
+			}
+		}
 	}
 
 	// Piggy-back label fetch on the same tick. Failures are logged and don't

--- a/internal/issueview/assembler.go
+++ b/internal/issueview/assembler.go
@@ -51,6 +51,7 @@ type Assembler struct {
 	cache         map[string]string           // "wsID#num" → last-emitted JSON
 	checkFails    map[string]*checkFailEntry  // "wsID#num" → latest check failure
 	conflictFails map[string]*conflictEntry   // "wsID#num" → latest conflict state
+	orphanPRs     map[string]string           // "wsID#num" → branch name (#194)
 
 	// repoPathFn resolves a workspace ID to its local repo path. When set,
 	// Assemble probes the questions directory to detect orphan question files
@@ -66,6 +67,7 @@ func New(bus *eventbus.Bus, st issueStore) *Assembler {
 		cache:         make(map[string]string),
 		checkFails:    make(map[string]*checkFailEntry),
 		conflictFails: make(map[string]*conflictEntry),
+		orphanPRs:     make(map[string]string),
 	}
 	bus.Subscribe(a.handleEvent)
 	return a
@@ -93,6 +95,8 @@ var issueRelevantEvents = map[eventbus.EventType]bool{
 	eventbus.EvtPRConflictsResolved: true,
 	eventbus.EvtNeedsPR:           true,
 	eventbus.EvtPRCommentReceived: true,
+	eventbus.EvtOrphanPRDetected:  true,
+	eventbus.EvtOrphanPRCleared:   true,
 }
 
 func (a *Assembler) handleEvent(e eventbus.Event) {
@@ -141,6 +145,20 @@ func (a *Assembler) handleEvent(e eventbus.Event) {
 			delete(a.conflictFails, key)
 			a.mu.Unlock()
 		}
+	case eventbus.EvtOrphanPRDetected:
+		if p, ok := e.Payload.(eventbus.OrphanPRDetected); ok {
+			key := p.WorkspaceID + "#" + strconv.Itoa(p.IssueNumber)
+			a.mu.Lock()
+			a.orphanPRs[key] = p.Branch
+			a.mu.Unlock()
+		}
+	case eventbus.EvtOrphanPRCleared, eventbus.EvtPROpened:
+		if wsID != "" && issueNum != 0 {
+			key := wsID + "#" + strconv.Itoa(issueNum)
+			a.mu.Lock()
+			delete(a.orphanPRs, key)
+			a.mu.Unlock()
+		}
 	}
 	// Session-state changes are LOAD-BEARING for the frontend's glow ladder
 	// (running execute → purple, blocked → red, etc). The cache-diff gate
@@ -159,7 +177,9 @@ func (a *Assembler) handleEvent(e eventbus.Event) {
 		eventbus.EvtPRConflictsResolved,
 		eventbus.EvtPROpened,
 		eventbus.EvtPRMerged,
-		eventbus.EvtPRClosedUnmerged:
+		eventbus.EvtPRClosedUnmerged,
+		eventbus.EvtOrphanPRDetected,
+		eventbus.EvtOrphanPRCleared:
 		a.reassembleAndForceEmit(wsID, issueNum)
 		return
 	}
@@ -354,6 +374,16 @@ func (a *Assembler) Assemble(workspaceID string, issueNumber int) (IssueView, er
 	// failure the user must see (#191).
 	planFailed := derivePlanFailed(iss, sessions, active)
 
+	// Orphan PR: branch pushed by a failed execute session with no open PR (#194).
+	issKey := workspaceID + "#" + strconv.Itoa(issueNumber)
+	a.mu.Lock()
+	orphanBranch := a.orphanPRs[issKey]
+	a.mu.Unlock()
+	var orphanPRInfo *OrphanPRInfo
+	if orphanBranch != "" {
+		orphanPRInfo = &OrphanPRInfo{Branch: orphanBranch}
+	}
+
 	return IssueView{
 		Issue:              iss,
 		LatestPlan:         plan,
@@ -362,12 +392,13 @@ func (a *Assembler) Assemble(workspaceID string, issueNumber int) (IssueView, er
 		LastFailure:        lastFail,
 		LastSession:        lastSession,
 		PoolBadge:          poolBadge,
-		DerivedColumn:      derivedColumn(iss, plan, active),
+		DerivedColumn:      derivedColumn(iss, plan, active, lastFail),
 		TestsFailingInfo:   testsFailingInfo,
 		ConflictsInfo:      conflictsInfo,
 		OrphanQuestion:     orphanQuestion,
 		NeedsPRInfo:        iss.NeedsPRInfo,
 		PlanFailed:         planFailed,
+		OrphanPRInfo:       orphanPRInfo,
 		UnreadCommentCount: unreadCommentCount,
 	}, nil
 }
@@ -556,9 +587,10 @@ func selectSessions(iss types.Issue, sessions []types.Session) (active, paused, 
 // Precedence (mirrors plan §98 DerivedColumn rules):
 //  1. PR open/merged → trust the persisted column (already "review" or "done")
 //  2. Active session running → "in_progress"
-//  3. Plan ready (not yet approved) → "plan"
-//  4. Fall back to Issue.Column or "todo"
-func derivedColumn(iss types.Issue, plan *types.Plan, active *types.Session) types.BoardColumn {
+//  3. Failed execute session (unacknowledged) → "blocked" (#194)
+//  4. Plan ready (not yet approved) → "plan"
+//  5. Fall back to Issue.Column or "todo"
+func derivedColumn(iss types.Issue, plan *types.Plan, active *types.Session, lastFail *types.Session) types.BoardColumn {
 	if iss.PRNumber != nil {
 		if iss.Column == "" {
 			return types.ColReview
@@ -567,6 +599,14 @@ func derivedColumn(iss types.Issue, plan *types.Plan, active *types.Session) typ
 	}
 	if active != nil {
 		return types.ColInProgress
+	}
+	// Move cards to the BLOCKED repair column when a failed execute session
+	// exists and the user hasn't acknowledged it yet.
+	if lastFail != nil && lastFail.Mode == types.ModeExecute {
+		ackd := lastFail.AcknowledgedAt != nil && *lastFail.AcknowledgedAt != 0
+		if !ackd {
+			return types.ColBlocked
+		}
 	}
 	if plan != nil && plan.ReadyToExecute && plan.ApprovedAt == nil {
 		return types.ColPlan

--- a/internal/issueview/assembler_test.go
+++ b/internal/issueview/assembler_test.go
@@ -187,14 +187,14 @@ func TestSelectSessions_NoReason_NotTrackedAsFailure(t *testing.T) {
 
 func TestDerivedColumn_PRNumber_TrustsReview(t *testing.T) {
 	iss := types.Issue{Column: types.ColReview, PRNumber: prNumber(42)}
-	if col := derivedColumn(iss, nil, nil); col != types.ColReview {
+	if col := derivedColumn(iss, nil, nil, nil); col != types.ColReview {
 		t.Errorf("got %v want review", col)
 	}
 }
 
 func TestDerivedColumn_PRNumber_TrustsDone(t *testing.T) {
 	iss := types.Issue{Column: types.ColDone, PRNumber: prNumber(42)}
-	if col := derivedColumn(iss, nil, nil); col != types.ColDone {
+	if col := derivedColumn(iss, nil, nil, nil); col != types.ColDone {
 		t.Errorf("got %v want done", col)
 	}
 }
@@ -202,34 +202,34 @@ func TestDerivedColumn_PRNumber_TrustsDone(t *testing.T) {
 func TestDerivedColumn_ActiveSession_InProgress(t *testing.T) {
 	iss := types.Issue{Column: types.ColTodo}
 	sess := makeSession(types.StateRunning, t1, "", false)
-	if col := derivedColumn(iss, nil, &sess); col != types.ColInProgress {
+	if col := derivedColumn(iss, nil, &sess, nil); col != types.ColInProgress {
 		t.Errorf("got %v want in_progress", col)
 	}
 }
 
 func TestDerivedColumn_PlanReady(t *testing.T) {
 	iss := types.Issue{Column: types.ColTodo}
-	if col := derivedColumn(iss, planPtr(true, false), nil); col != types.ColPlan {
+	if col := derivedColumn(iss, planPtr(true, false), nil, nil); col != types.ColPlan {
 		t.Errorf("got %v want plan", col)
 	}
 }
 
 func TestDerivedColumn_PlanApproved_NoOverride(t *testing.T) {
 	iss := types.Issue{Column: types.ColTodo}
-	if col := derivedColumn(iss, planPtr(true, true), nil); col != types.ColTodo {
+	if col := derivedColumn(iss, planPtr(true, true), nil, nil); col != types.ColTodo {
 		t.Errorf("got %v want todo (approved plan should not force plan column)", col)
 	}
 }
 
 func TestDerivedColumn_Fallback_EmptyColumn(t *testing.T) {
-	if col := derivedColumn(types.Issue{}, nil, nil); col != types.ColTodo {
+	if col := derivedColumn(types.Issue{}, nil, nil, nil); col != types.ColTodo {
 		t.Errorf("got %v want todo", col)
 	}
 }
 
 func TestDerivedColumn_Fallback_StoredColumn(t *testing.T) {
 	iss := types.Issue{Column: types.ColInProgress}
-	if col := derivedColumn(iss, nil, nil); col != types.ColInProgress {
+	if col := derivedColumn(iss, nil, nil, nil); col != types.ColInProgress {
 		t.Errorf("got %v want in_progress", col)
 	}
 }

--- a/internal/issueview/issueview.go
+++ b/internal/issueview/issueview.go
@@ -87,8 +87,19 @@ type IssueView struct {
 	// that silently failed to produce a plan (#191).
 	PlanFailed *PlanFailedInfo `json:"plan_failed,omitempty"`
 
+	// OrphanPRInfo is set when the poller detects a feat/issue-N-* branch
+	// pushed by a failed execute session but no open PR targeting it (#194).
+	// The frontend renders an "Open PR" recovery button on the card.
+	OrphanPRInfo *OrphanPRInfo `json:"orphan_pr_info,omitempty"`
+
 	// UnreadCommentCount is the number of unread PR comments on this issue
 	// (#159). Non-zero only for REVIEW-column cards. Drives the "New Comment
 	// (N)" badge.
 	UnreadCommentCount int `json:"unread_comment_count"`
+}
+
+// OrphanPRInfo is surfaced when an execute session pushed a branch but failed
+// before opening a PR (#194). Enables the "Open PR" recovery button.
+type OrphanPRInfo struct {
+	Branch string `json:"branch"`
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -66,6 +66,9 @@ type Persister interface {
 	// UpdateSessionUsage persists per-session token counts and estimated cost
 	// to the dedicated columns and JSON blob (issue #101).
 	UpdateSessionUsage(sess *types.Session, transcriptPath string) error
+	// UpdateSessionDiagnostics persists exit diagnostics captured after the
+	// subprocess exits (#194).
+	UpdateSessionDiagnostics(id string, exitCode *int, signal string, waitMs int64, lastStderr string) error
 }
 
 // StateChangeHandler is fired on every state transition. Used by the App layer
@@ -202,6 +205,10 @@ type runtimeSession struct {
 	// so the worktree is preserved on the normal Completed cleanup path.
 	// Protected by actMu.
 	autoKilledForPROpen bool
+
+	// lastOutputBuf is a rolling buffer of the last ~200 bytes of transcript
+	// output for failure diagnostics (#194). Protected by actMu.
+	lastOutputBuf []byte
 }
 
 // sessionCmd is the §10.5 abstraction over both spawn strategies. The
@@ -670,6 +677,7 @@ func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types
 		State:       types.StateRunning,
 		StartedAt:   time.Now(),
 		PoolID:      pool.ID,
+		Branch:      branch,
 	}
 	sess.Transcript = transcriptPath
 
@@ -953,6 +961,12 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 			if len(line) > 0 {
 				rs.actMu.Lock()
 				rs.lastLineAt = time.Now()
+				const maxOutputBuf = 200
+				combined := append(rs.lastOutputBuf, []byte(line)...)
+				if len(combined) > maxOutputBuf {
+					combined = combined[len(combined)-maxOutputBuf:]
+				}
+				rs.lastOutputBuf = combined
 				rs.actMu.Unlock()
 				m.feedLine(rs, strings.TrimRight(line, "\r\n"))
 				rs.transcriptOffset += int64(len(line))
@@ -973,6 +987,12 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 						if len(line) > 0 {
 							rs.actMu.Lock()
 							rs.lastLineAt = time.Now()
+							const maxOutputBuf = 200
+							combined := append(rs.lastOutputBuf, []byte(line)...)
+							if len(combined) > maxOutputBuf {
+								combined = combined[len(combined)-maxOutputBuf:]
+							}
+							rs.lastOutputBuf = combined
 							rs.actMu.Unlock()
 							m.feedLine(rs, strings.TrimRight(line, "\r\n"))
 							rs.transcriptOffset += int64(len(line))
@@ -1001,12 +1021,28 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 		_ = m.store.UpdateSessionTranscriptOffset(rs.sess.ID, rs.transcriptOffset)
 	}
 	prev := rs.sess.State
+	waitStart := time.Now()
 	if !waited {
 		// We broke out without observing Wait — typically because ctx was
 		// cancelled. Wait now to reap the child and capture its exit code.
 		waitErr = <-done
 	}
+	rs.sess.CmdWaitTimeMs = time.Since(waitStart).Milliseconds()
 	rs.sess.State = mapTerminalState(rs.sess.State, waitErr)
+
+	// Capture subprocess exit diagnostics for failed execute sessions (#194).
+	if waitErr != nil {
+		if exitErr, ok := waitErr.(*exec.ExitError); ok {
+			code := exitErr.ExitCode()
+			rs.sess.ExitCode = &code
+			if !exitErr.ProcessState.Exited() {
+				rs.sess.Signal = exitErr.ProcessState.String()
+			}
+		}
+	}
+	rs.actMu.Lock()
+	rs.sess.LastStderrChunk = strings.TrimSpace(string(rs.lastOutputBuf))
+	rs.actMu.Unlock()
 	rs.actMu.Lock()
 	autoKilled := rs.autoKilledForPROpen
 	rs.actMu.Unlock()
@@ -1042,6 +1078,17 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 		rs.sess.OutputTokens = outputTok
 		rs.sess.EstimatedCostCents = costCents
 		_ = m.store.UpdateSessionUsage(rs.sess, rs.transcriptPath)
+		// Persist exit diagnostics for failed execute sessions (#194).
+		if rs.sess.Mode == types.ModeExecute &&
+			(rs.sess.State == types.StateFailed || rs.sess.State == types.StateBlocked) {
+			_ = m.store.UpdateSessionDiagnostics(
+				rs.sess.ID,
+				rs.sess.ExitCode,
+				rs.sess.Signal,
+				rs.sess.CmdWaitTimeMs,
+				rs.sess.LastStderrChunk,
+			)
+		}
 		// Accumulate LLM cost from Claude stream-json result event (issue #47).
 		// Only Claude subprocess sessions emit this; harness sessions don't.
 		cd := rs.parser.LastCost()

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -142,6 +142,9 @@ func (p *fakePersister) AccumulateIssueWork(_ string, _ int, _ types.SessionMode
 }
 func (p *fakePersister) AccumulateIssueCost(_ string, _ int, _ float64) error { return nil }
 func (p *fakePersister) UpdateSessionUsage(_ *types.Session, _ string) error  { return nil }
+func (p *fakePersister) UpdateSessionDiagnostics(_ string, _ *int, _ string, _ int64, _ string) error {
+	return nil
+}
 
 func TestMatchPatternsQuestionPending(t *testing.T) {
 	const qid = "11111111-2222-3333-4444-555555555555"

--- a/internal/store/issues.go
+++ b/internal/store/issues.go
@@ -104,6 +104,11 @@ func (s *Store) SaveIssue(iss types.Issue) (bool, error) {
 			if prev.NeedsPRInfo != nil {
 				iss.NeedsPRInfo = prev.NeedsPRInfo
 			}
+			// Preserve FailureReason: set by the conductor on execute failure;
+			// the GitHub poll has no opinion on it (#194).
+			if prev.FailureReason != "" {
+				iss.FailureReason = prev.FailureReason
+			}
 		}
 	}
 	iss.Column = col
@@ -884,4 +889,16 @@ WHERE column_name = 'done'
 		return 0, err
 	}
 	return int(n), nil
+}
+
+// SetIssueFailureReason writes the failure_reason into the issue JSON blob.
+// Used when an execute session fails; cleared on ClearIssueFailure (#194).
+func (s *Store) SetIssueFailureReason(workspaceID string, issueNumber int, reason string) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	_, err := s.DB.Exec(
+		`UPDATE issues SET json = json_set(json, '$.failure_reason', ?) WHERE workspace_id = ? AND number = ?`,
+		reason, workspaceID, issueNumber)
+	return err
 }

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -452,6 +452,58 @@ func (s *Store) WorkspaceSpendCents(workspaceID string, since time.Time) (float6
 	return total, err
 }
 
+// UpdateSessionDiagnostics persists subprocess exit diagnostics for failed
+// execute sessions (#194). Written only after session teardown.
+func (s *Store) UpdateSessionDiagnostics(id string, exitCode *int, signal string, waitMs int64, lastStderr string) error {
+	if s == nil || s.DB == nil {
+		return nil
+	}
+	var codeVal any
+	if exitCode != nil {
+		codeVal = *exitCode
+	}
+	_, err := s.DB.Exec(
+		`UPDATE sessions SET
+			exit_code = ?,
+			signal = ?,
+			cmd_wait_time_ms = ?,
+			last_stderr_chunk = ?
+		 WHERE id = ?`,
+		codeVal, nullableString(signal), waitMs, nullableString(lastStderr), id)
+	return err
+}
+
+// MostRecentFailedExecuteSession returns the most recent unacknowledged failed
+// or blocked execute session with a branch name for (workspaceID, issueNumber).
+// Used by the orphan-PR poller to find pushed branches with no open PR (#194).
+func (s *Store) MostRecentFailedExecuteSession(workspaceID string, issueNumber int) (*types.Session, error) {
+	if s == nil || s.DB == nil {
+		return nil, nil
+	}
+	var raw string
+	err := s.DB.QueryRow(`
+		SELECT json FROM sessions
+		WHERE workspace_id = ? AND issue_number = ?
+		  AND state IN ('failed','blocked')
+		  AND json_extract(json, '$.mode') = 'execute'
+		  AND json_extract(json, '$.branch') IS NOT NULL
+		  AND json_extract(json, '$.branch') <> ''
+		  AND (acknowledged_at IS NULL OR acknowledged_at = 0)
+		ORDER BY json_extract(json, '$.started_at') DESC
+		LIMIT 1`, workspaceID, issueNumber).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var sess types.Session
+	if _, err := jsonutil.Load([]byte(raw), &sess); err != nil {
+		return nil, err
+	}
+	return &sess, nil
+}
+
 // SessionTranscriptPath returns the spool path for a session id.
 func (s *Store) SessionTranscriptPath(id string) (string, error) {
 	if s == nil || s.DB == nil {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -371,6 +371,11 @@ type Issue struct {
 	// opened against NeedsPRInfo.Branch and auto-attaches it (#157).
 	// Cleared by MarkPROpened.
 	NeedsPRInfo *NeedsPRInfo `json:"needs_pr_info,omitempty"`
+
+	// FailureReason is a concise human-readable explanation of why the most
+	// recent execute session failed. Set when an execute session reaches
+	// StateBlocked or StateFailed; cleared on ClearIssueFailure (#194).
+	FailureReason string `json:"failure_reason,omitempty"`
 }
 
 // NeedsPRInfo holds the context needed to display the NEEDS_PR badge and poll
@@ -397,8 +402,12 @@ const (
 	ColTodo       BoardColumn = "todo"
 	ColPlan       BoardColumn = "plan"
 	ColInProgress BoardColumn = "in_progress"
-	ColReview     BoardColumn = "review"
-	ColDone       BoardColumn = "done"
+	// ColBlocked is the repair column for issues whose execute session died
+	// mid-flow without opening a PR. Cards sit here until the user acknowledges
+	// the failure or opens the orphan PR (#194).
+	ColBlocked BoardColumn = "blocked"
+	ColReview  BoardColumn = "review"
+	ColDone    BoardColumn = "done"
 )
 
 // --- Plan (§6.4) ---
@@ -496,6 +505,15 @@ type Session struct {
 	InputTokens        int64   `json:"input_tokens,omitempty"`
 	OutputTokens       int64   `json:"output_tokens,omitempty"`
 	EstimatedCostCents float64 `json:"estimated_cost_cents,omitempty"`
+
+	// Issue #194: diagnostics captured at subprocess exit for failed execute sessions.
+	ExitCode        *int   `json:"exit_code,omitempty"`
+	Signal          string `json:"signal,omitempty"`
+	CmdWaitTimeMs   int64  `json:"cmd_wait_time_ms,omitempty"`
+	LastStderrChunk string `json:"last_stderr_chunk,omitempty"`
+
+	// Branch is the git branch this execute session ran on (#194).
+	Branch string `json:"branch,omitempty"`
 }
 
 // MidRunAnswer is the §6.4-shaped answer payload for a mid-run question

--- a/migrations/20260505_add_session_failure_fields.sql
+++ b/migrations/20260505_add_session_failure_fields.sql
@@ -1,0 +1,5 @@
+-- Issue #194: persist subprocess exit diagnostics on failed execute sessions.
+ALTER TABLE sessions ADD COLUMN exit_code INTEGER DEFAULT NULL;
+ALTER TABLE sessions ADD COLUMN signal TEXT DEFAULT NULL;
+ALTER TABLE sessions ADD COLUMN cmd_wait_time_ms INTEGER DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN last_stderr_chunk TEXT DEFAULT NULL;


### PR DESCRIPTION
## Summary

- When an execute-mode worker dies after pushing a branch but before opening a PR, the card now moves to a dedicated **BLOCKED** column
- A rolling 200-byte stderr buffer and exit diagnostics (exit code, signal, wait time) are captured and persisted
- The GitHub poller detects orphan branches (pushed but no open PR) and surfaces an **"Open PR for pushed branch"** recovery button on the card

## Files modified

| File | Change |
|------|--------|
| `migrations/20260505_add_session_failure_fields.sql` | Add exit_code, signal, cmd_wait_time_ms, last_stderr_chunk columns |
| `internal/types/types.go` | Add `ColBlocked`, `Session.Branch/ExitCode/Signal/CmdWaitTimeMs/LastStderrChunk`, `Issue.FailureReason` |
| `internal/eventbus/bus.go` | Add `EvtOrphanPRDetected` / `EvtOrphanPRCleared` events |
| `internal/session/manager.go` | Rolling 200-byte output buffer; persist exit diagnostics after Wait() |
| `internal/store/sessions.go` | `UpdateSessionDiagnostics`, `MostRecentFailedExecuteSession` |
| `internal/store/issues.go` | Preserve `FailureReason` on GitHub-poll re-saves; `SetIssueFailureReason` |
| `internal/issueview/issueview.go` | Add `OrphanPRInfo` type and field to `IssueView` |
| `internal/issueview/assembler.go` | Route `ColBlocked` from `lastFail` session; handle orphan-PR events; add `orphanPRs` map |
| `internal/issueview/assembler_test.go` | Update `derivedColumn` calls to 4-arg signature |
| `internal/github/poll.go` | Detect orphan branches from failed execute sessions |
| `internal/github/client.go` | Add `CreateDraftPR` for orphan-PR recovery |
| `app.go` | Add `OpenOrphanPR` Wails binding; call `SetIssueFailureReason` on execute failure |
| `frontend/src/stores/issueStore.ts` | Add `"blocked"` to `Column` type |
| `frontend/src/components/Board.tsx` | Add BLOCKED column; group cards by `derived_column` from IssueView |
| `frontend/src/components/Card.tsx` | Add `OrphanPRInfo` type; wire orphan-PR recovery button in `StatusRow` |
| `frontend/wailsjs/go/main/App.{js,d.ts}` | Add `OpenOrphanPR` binding |
| `frontend/wailsjs/go/models.ts` | Add `OrphanPRInfo` class and `orphan_pr_info` field to `IssueView` |

## Verification

| Gate | Command | Result |
|------|---------|--------|
| Go lint/vet | `go vet ./internal/...` | ✅ pass |
| TypeScript | `tsc --noEmit` (worktree frontend with symlinked node_modules) | ✅ pass |
| Smoke test | `playwright test tests/e2e/startup.spec.ts` | ⚠ skipped — dev server not running in worktree |
| Go tests | `go test ./internal/...` | ✅ 28 packages pass |

- Commit tier: Tier 2 (unsigned local commit — gpg not available on this machine)
- Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-194

Closes #194