### PR TITLE
fix(frontend): top-level ErrorBoundary + AppearancePanel build-break fix

### DIFF
--- a/frontend/src/components/AppearancePanel.tsx
+++ b/frontend/src/components/AppearancePanel.tsx
@@ -128,7 +128,7 @@ function GlowRow({
             <div className="bg-slate-800 border border-slate-600 rounded-lg p-3 shadow-2xl">
               <HexColorPicker
                 color={entry.color}
-                onChange={(color) => onChange({ color })}
+                onChange={(color: string) => onChange({ color })}
               />
               <div className="mt-2 flex items-center gap-2">
                 <input

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,13 +4,50 @@ import './style.css'
 import './stores/useThemeStore'   // side-effect: applies saved theme class to <html> before first paint
 import './stores/useGlowColorsStore' // side-effect: injects glow keyframes before first render
 import App from './App'
+import { ErrorBoundary } from './components/ErrorBoundary'
 
 const container = document.getElementById('root')
 
 const root = createRoot(container!)
 
+// Top-level boundary: any descendant render exception (hook-order changes,
+// thrown null deref, etc.) renders a recoverable fallback instead of blanking
+// the whole app. Per-card boundaries inside <Board /> still catch finer-grained
+// crashes; this is the last-resort net.
+function RootFallback({ error, onReload }: { error: Error; onReload: () => void }) {
+    return (
+        <div className="min-h-screen bg-slate-900 text-slate-100 flex items-center justify-center p-8">
+            <div className="max-w-2xl w-full rounded-lg border border-red-700 bg-red-950/40 p-6 space-y-4">
+                <div>
+                    <div className="text-lg font-semibold text-red-200">App render error</div>
+                    <div className="text-xs text-red-300 mt-1">
+                        The UI hit an unrecoverable render exception. Your conductor backend is unaffected — workers, sessions, and the database are still running. Reload the window to recover.
+                    </div>
+                </div>
+                <pre className="text-[11px] text-red-200/80 bg-black/30 rounded p-3 overflow-auto max-h-64 whitespace-pre-wrap break-all">
+{error.name}: {error.message}
+{error.stack ? '\n\n' + error.stack : ''}
+                </pre>
+                <div className="flex items-center gap-2">
+                    <button
+                        onClick={onReload}
+                        className="text-xs px-3 py-1.5 rounded bg-red-700 hover:bg-red-600 text-white"
+                    >
+                        Reload window
+                    </button>
+                    <span className="text-[11px] text-red-400/70">
+                        Error details are also logged to the Wails DevTools console (Cmd+Opt+I in debug builds).
+                    </span>
+                </div>
+            </div>
+        </div>
+    )
+}
+
 root.render(
     <React.StrictMode>
-        <App/>
+        <ErrorBoundary fallback={(err) => <RootFallback error={err} onReload={() => window.location.reload()} />}>
+            <App/>
+        </ErrorBoundary>
     </React.StrictMode>
 )


### PR DESCRIPTION
## Summary

Two unrelated frontend fixes that surfaced during dogfooding of #200:

- **Top-level ErrorBoundary** (`main.tsx`): moving a card from REVIEW to PLAN threw a React #310 hook-order error inside the Card subtree. Card.tsx already sits in a per-card boundary inside `Board.tsx`, but the cascade flickered the entire root subtree blank for one render before the inner boundary stabilized — net effect to the user, the app appeared to vanish. The new top-level boundary catches anything the per-card boundaries miss and shows a recoverable panel with the error message, stack, and a Reload button. Backend (Wails Go process, sessions, DB) is unaffected and called out in the fallback copy.

- **AppearancePanel.tsx implicit-`any` fix**: `wails build` was failing on a clean checkout with `Parameter 'color' implicitly has an 'any' type` from `react-colorful`'s `onChange` prop. One-line fix: `(color: string) => onChange({ color })`. Also coincidentally surfaced because `react-colorful` was in `package.json` but absent from `node_modules` until a fresh `npm install` synced the lockfile.

## Test plan

- [ ] `cd frontend && npx tsc --noEmit` — passes (verified locally)
- [ ] `wails build` — produces a clean app bundle
- [ ] `wails dev` — top-level boundary doesn't fire on healthy navigation
- [ ] Deliberately move a card REVIEW → PLAN — should not blank the entire app even if a child throws

## Out of scope

The underlying hook-order bug in the Card subtree (the actual cause of the React #310) is **not fixed** by this PR. It needs DevTools capture of the unminified stack to identify which child component diverges its hook count between renders. The boundary makes that diagnostic loop tolerable instead of crash-and-relaunch.

## Related

- Surfaced during work on #30 (card-state consolidation, PR #200)
- The hook-order bug deserves its own ticket once the stack trace is captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
