### PR TITLE
fix(issueview): keep planning cards in PLAN column (regression from #30)

### DIFF
--- a/internal/issueview/assembler.go
+++ b/internal/issueview/assembler.go
@@ -611,10 +611,11 @@ func selectSessions(iss types.Issue, sessions []types.Session) (active, paused, 
 //
 // Precedence (mirrors plan §98 DerivedColumn rules):
 //  1. PR open/merged → trust the persisted column (already "review" or "done")
-//  2. Active session running → "in_progress"
-//  3. Failed execute session (unacknowledged) → "blocked" (#194)
-//  4. Plan ready (not yet approved) → "plan"
-//  5. Fall back to Issue.Column or "todo"
+//  2. Active plan-mode session → "plan"
+//  3. Active execute-mode session → "in_progress"
+//  4. Failed execute session (unacknowledged) → "blocked" (#194)
+//  5. Plan ready (not yet approved) → "plan"
+//  6. Fall back to Issue.Column or "todo"
 func derivedColumn(iss types.Issue, plan *types.Plan, active *types.Session, lastFail *types.Session) types.BoardColumn {
 	if iss.PRNumber != nil {
 		if iss.Column == "" {
@@ -623,6 +624,12 @@ func derivedColumn(iss types.Issue, plan *types.Plan, active *types.Session, las
 		return iss.Column
 	}
 	if active != nil {
+		// Plan-mode sessions belong in the PLAN column. Bug fix: prior to
+		// this change all active sessions routed to IN_PROGRESS, which
+		// stranded planning cards in the wrong column with the right glow.
+		if active.Mode == types.ModePlan {
+			return types.ColPlan
+		}
 		return types.ColInProgress
 	}
 	// Move cards to the BLOCKED repair column when a failed execute session

--- a/internal/issueview/assembler_test.go
+++ b/internal/issueview/assembler_test.go
@@ -199,11 +199,38 @@ func TestDerivedColumn_PRNumber_TrustsDone(t *testing.T) {
 	}
 }
 
-func TestDerivedColumn_ActiveSession_InProgress(t *testing.T) {
+func TestDerivedColumn_ActiveExecuteSession_InProgress(t *testing.T) {
 	iss := types.Issue{Column: types.ColTodo}
 	sess := makeSession(types.StateRunning, t1, "", false)
+	sess.Mode = types.ModeExecute
 	if col := derivedColumn(iss, nil, &sess, nil); col != types.ColInProgress {
 		t.Errorf("got %v want in_progress", col)
+	}
+}
+
+// Regression: an active plan-mode session must keep the card in the PLAN
+// column, not promote it to IN_PROGRESS. Prior to the fix `derivedColumn`
+// returned ColInProgress for any active session regardless of mode, which
+// stranded planning cards under the wrong column header while the inner
+// card_state correctly resolved to "planning".
+func TestDerivedColumn_ActivePlanSession_StaysInPlan(t *testing.T) {
+	iss := types.Issue{Column: types.ColPlan}
+	sess := makeSession(types.StateRunning, t1, "", false)
+	sess.Mode = types.ModePlan
+	if col := derivedColumn(iss, nil, &sess, nil); col != types.ColPlan {
+		t.Errorf("got %v want plan", col)
+	}
+}
+
+// And: a plan-mode session running on a card that was auto-pulled from TODO
+// (stored column still "todo") should also derive to PLAN, mirroring the
+// orchestrator's intent when it kicked the planner off.
+func TestDerivedColumn_ActivePlanSession_FromTodo_DerivesPlan(t *testing.T) {
+	iss := types.Issue{Column: types.ColTodo}
+	sess := makeSession(types.StateRunning, t1, "", false)
+	sess.Mode = types.ModePlan
+	if col := derivedColumn(iss, nil, &sess, nil); col != types.ColPlan {
+		t.Errorf("got %v want plan", col)
 	}
 }
 


### PR DESCRIPTION
## Summary

Regression from #30's `derivedColumn` consolidation: any active session was being routed to `ColInProgress` regardless of mode, so cards with an active **plan-mode** session got stranded in IN_PROGRESS with a blue "planning" glow. Visually contradictory and confusing.

Root cause in `internal/issueview/assembler.go`:

```go
if active != nil {
    return types.ColInProgress   // no mode check
}
```

Fix: branch on `active.Mode` before falling through. Plan-mode → `ColPlan`. Execute-mode → `ColInProgress`. Other rules unchanged.

## Test plan

- [x] `go test ./internal/issueview/ -run TestDerivedColumn -v` — all 9 cases pass including the two new ones
- [x] `go test ./...` — full suite green
- [ ] Manual: drag a TODO card to PLAN, confirm it stays in PLAN throughout the planner's run
- [ ] Manual: confirm execute-mode cards still land in IN_PROGRESS as before

## Reproduction (from screenshot)

Issue #192's planning session: card stored as `column_name=plan`, planner running, `card_state=planning` (blue glow), but rendered under IN_PROGRESS column header. Frontend correctly prefers `view.derived_column` (so BLOCKED routing for #194 works) — the bug is purely backend.

## Tests added / changed

- Renamed `TestDerivedColumn_ActiveSession_InProgress` → `..._ActiveExecuteSession_InProgress`, set `Mode=ModeExecute` explicitly so the test pins the execute case rather than relying on zero-value mode.
- New `TestDerivedColumn_ActivePlanSession_StaysInPlan` — stored col=plan + plan session = derives plan.
- New `TestDerivedColumn_ActivePlanSession_FromTodo_DerivesPlan` — covers auto-pull-from-TODO (stored col=todo, planner running, no manual move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
