### PR TITLE
fix(conductor-execute): Tier 1 pre-push + Tier 2b unsigned fallback (#205)

### DIFF
--- a/internal/skills/bundle/skills/conductor-execute.md
+++ b/internal/skills/bundle/skills/conductor-execute.md
@@ -84,6 +84,15 @@ straight away, `auto` (default/empty) = Tier 1 → Tier 2 → Tier 3.
 
 12a. Draft the commit message (subject + body with `Closes #<num>` +
      `Co-Authored-By: PrismConductor worker <noreply@anthropic.com>`).
+12a-pre. **Ensure the remote branch exists before calling `createCommitOnBranch`.**
+     Run `git ls-remote --heads origin <current-branch>`. If the output is
+     empty (branch not yet on origin), push it first:
+     ```
+     git push -u origin HEAD
+     ```
+     This is idempotent — if the branch already exists the ls-remote check is a
+     no-op and no push is needed. Skipping this step causes the GraphQL mutation
+     to fail with a "Reference does not exist" error.
 12b. Call the GitHub GraphQL mutation `createCommitOnBranch` using the
      workspace PAT (`gh api graphql`). The mutation requires:
      - `repositoryNameWithOwner`: `<owner>/<repo>`
@@ -122,8 +131,39 @@ straight away, `auto` (default/empty) = Tier 1 → Tier 2 → Tier 3.
      content; truncate only the GraphQL payload, never the file).
 12e. `git commit -S -F .prismconductor/commit-msg/<issue>.txt` with a 30 s
      timeout. Do NOT attempt to supply a passphrase. If the process blocks on
-     TTY or times out, fall through to Tier 3.
+     TTY, times out, exits non-zero, or stderr contains `cannot run gpg` / key
+     unavailable messages, fall through to **Tier 2b** (do NOT skip to Tier 3
+     directly — an unsigned commit may still be possible).
 12f. `git push -u origin HEAD`.
+
+**Tier 2b — unsigned commit fallback (GPG unavailable)**
+
+When Tier 2a (signed commit) fails due to a missing or unusable GPG key:
+
+12e-i. **Probe branch protection** to determine whether signed commits are
+     required for `<BASE>`:
+     ```
+     gh api repos/{owner}/{repo}/branches/{BASE}/protection \
+       --jq '.required_signatures.enabled' 2>/dev/null || echo "false"
+     ```
+     Cache this boolean for the duration of this worker run. A 404 or any
+     error from this probe means no branch-protection rule is configured —
+     treat as `false` (unsigned commits are permitted).
+
+12e-ii. **Decision:**
+     - If the probe returns `true`: signed commits are **required**. Fall
+       through to Tier 3 (NEEDS_PR). Do NOT attempt an unsigned commit.
+     - If the probe returns `false`, empty, or errors: proceed with an
+       unsigned commit.
+
+12e-iii. **Unsigned commit + push:**
+     ```
+     git commit -F .prismconductor/commit-msg/<issue>.txt
+     git push -u origin HEAD
+     ```
+     On success: proceed to PR creation exactly as after a Tier 1 / Tier 2a
+     success. Note in the PR body that Tier 2b (unsigned) was used.
+     On failure: fall through to Tier 3.
 
 **Tier 3 — preserved worktree + manual command (NEEDS_PR)**
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -85,6 +85,28 @@ tag = "v1"
 new_classes = ["SessionDO"]
 ```
 
+## Commit-and-push tier strategy
+
+The `conductor-execute` skill uses a four-tier fallback to commit and push work.
+Tiers are attempted in order; the first success stops the chain.
+
+| Tier | Name | Mechanism | Falls back when |
+|------|------|-----------|-----------------|
+| 1 | GitHub API | `createCommitOnBranch` GraphQL mutation (GitHub-signed) | payload > 8 MB, > 200 files, or API error |
+| 2a | Local signed | `git commit -S` + `git push` | GPG unavailable / key blocked / TTY timeout |
+| 2b | Local unsigned | `git commit` + `git push` after probing `required_signatures` | `required_signatures: true` on target branch |
+| 3 | NEEDS_PR | Staged worktree preserved; user pushes manually | all above fail or signing required |
+
+**Tier 1 pre-flight:** before calling `createCommitOnBranch`, the worker checks
+`git ls-remote --heads origin <branch>` and pushes the branch if it is not yet
+on origin. This avoids a "Reference does not exist" GraphQL rejection on fresh
+branches (issue #205).
+
+**Tier 2b probe:** before attempting an unsigned commit the worker calls
+`gh api repos/{owner}/{repo}/branches/{BASE}/protection --jq '.required_signatures.enabled'`.
+A 404 / error is treated as `false` (no enforcement). The result is cached for
+the duration of the worker run.
+
 ## Feature flag
 
 Remote workspaces are gated behind `execution_target: "remote"` on the


### PR DESCRIPTION
Fixes two bugs in the conductor-execute commit-and-push ladder that caused workers on machines without GPG to always end up in NEEDS_PR state even when the repo does not enforce signed commits.

## Changes

- `internal/skills/bundle/skills/conductor-execute.md` — Tier 1: add `git ls-remote` pre-flight check + push before calling `createCommitOnBranch`, so the GraphQL mutation never fails with "Reference does not exist" on fresh branches. Tier 2: rename to Tier 2a (signed) and add new Tier 2b (unsigned fallback) that probes `required_signatures` via the GH API before attempting `git commit` without `-S`; only falls through to Tier 3/NEEDS_PR when signed commits are actually required by branch protection.
- `worker/README.md` — document the four-tier commit strategy (1, 2a, 2b, 3) including the Tier 1 pre-flight and Tier 2b probe behaviour.

## Note on plan's commit_flow.go

The approved plan referenced `internal/skills/bundle/worker/commit_flow.go` as a file to create. This path does not exist in the repo — the commit logic IS the skill markdown itself (instructions Claude follows). The fix is correctly applied to `conductor-execute.md`; no Go file was created.

## Verification

| Gate | Command | Result |
|------|---------|--------|
| Lint (internal packages) | `go vet ./internal/...` | pass |
| Tests | `go test ./internal/...` | pass (28/28 packages) |
| Build | `go build ./...` requires built `frontend/dist` — pre-existing env constraint, not introduced by this PR | skipped |
| Smoke test | `npx --prefix tests playwright test tests/e2e/startup.spec.ts` | exit 0 (playwright not installed in dev env, pre-existing) |

Commit tier: **Tier 1** (GitHub API `createCommitOnBranch`, SHA `1ae9ab26`)

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-205

Closes #205
