### PR TITLE
fix(card): lift conditional useState out of render branches (kills #310 on cards with NEEDS_PR / orphan-PR state)

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -582,6 +582,18 @@ function StatusRow({
   onPlanNow: () => void;
 }) {
   const [menu, setMenu] = useState<{ x: number; y: number; actions: CopyAction[] } | null>(null);
+  // Hooks for the conditional render branches below MUST be declared at the
+  // component top (rules-of-hooks). Previously these lived inside
+  // `if (showNeedsPR ...)` and `if (orphanPRInfo ...)` blocks, which produced
+  // a different hook count on each render whenever the card transitioned
+  // across those state boundaries — and React minified error #310 fired
+  // ("rendered more/fewer hooks than during the previous render"). Card #204,
+  // which has needs_pr_info populated from a NEEDS_PR sentinel, lived right
+  // at one of those boundaries and reproducibly threw the error.
+  const [attachOpen, setAttachOpen] = useState(false);
+  const [prURLInput, setPRURLInput] = useState("");
+  const [msgExpanded, setMsgExpanded] = useState(false);
+  const [orphanPROpening, setOrphanPROpening] = useState(false);
 
   function openMenu(e: React.MouseEvent, actions: CopyAction[]) {
     e.preventDefault();
@@ -705,9 +717,6 @@ function StatusRow({
   if (showNeedsPR && needsPRInfo) {
     const info = needsPRInfo; // capture for closures — TypeScript can't narrow through async boundaries
     const isCommitSigning = info.kind === "commit_signing";
-    const [attachOpen, setAttachOpen] = useState(false);
-    const [prURLInput, setPRURLInput] = useState("");
-    const [msgExpanded, setMsgExpanded] = useState(false);
 
     function copyPushCmd(e: React.MouseEvent) {
       e.stopPropagation();
@@ -812,7 +821,8 @@ function StatusRow({
 
   // Orphan PR recovery: execute session pushed a branch but died before opening a PR (#194).
   if (orphanPRInfo && !activeSession && !pausedSession && !needsPRInfo) {
-    const [opening, setOpening] = useState(false);
+    const opening = orphanPROpening;
+    const setOpening = setOrphanPROpening;
     return (
       <>
         <div className="text-[11px] mt-1.5 space-y-0.5">


### PR DESCRIPTION
## Summary

`StatusRow` in `Card.tsx` had **four `useState` calls inside conditional render branches**:

- 3 inside `if (showNeedsPR && needsPRInfo)` — `attachOpen`, `prURLInput`, `msgExpanded`
- 1 inside `if (orphanPRInfo && !activeSession && !pausedSession && !needsPRInfo)` — `opening`

Both violated React's rules-of-hooks. When a card transitioned across those state boundaries (e.g., a NEEDS_PR sentinel fires on an otherwise-clean card, or orphan-PR detection toggles), the hook count changed between renders and React threw minified error #310: *"rendered more/fewer hooks than during the previous render."*

**Card #204 reproducibly threw this in the wild** — its `needs_pr_info` field was populated by yesterday's NEEDS_PR sentinel, so it lived right at the hook-count boundary.

This is the same hook-ordering bug class that the top-level ErrorBoundary in #201 was added to contain. The boundary still saves the rest of the app from white-screening, but the affected card now renders cleanly instead of falling back to the "Render error" tile.

## Fix

Lifted all four `useState` calls to the top of `StatusRow`, alongside the existing `menu` state. Inner branches reference the lifted state through aliased local names (`opening` / `setOpening` for the orphan-PR branch) so the rest of the JSX is unchanged. Hook count is now constant per render regardless of card state.

Cost: 4 always-allocated `useState` slots (3 booleans + 1 string). Trivial.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Reload the conductor on a board with card #204 (NEEDS_PR badge active) — should render the push-needed badge cleanly, no error tile.
- [ ] Drag a card REVIEW → PLAN that previously triggered #310 — should not throw.
- [ ] On any card with `orphanPRInfo` set, click "Open PR for pushed branch" — `Opening…` state and the eventual return to button text both work (state is now lifted but the UX is unchanged).

## Severity

Closes the reproducible render error for any card with NEEDS_PR or orphan-PR state set. The top-level ErrorBoundary (#201) prevented the whole-app blank in the meantime, so this is the substantive fix.

## Out of scope

The two other early-return branches in `StatusRow` (paused-session, planFailed) don't add new hooks, so they don't need lifting. Future maintainers: any new `useState` in this function MUST go at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
