### PR TITLE
chore(ui): remove dev scaffolding buttons from header (#214)

### DIFF
--- a/app.go
+++ b/app.go
@@ -3828,14 +3828,6 @@ func (a *App) SetGoalStatus(id, status string) error {
 	return nil
 }
 
-// SpawnDemo runs `claude --version` in the cwd and streams output to the frontend.
-// Day-1 deliverable per §18.
-func (a *App) SpawnDemo() (*types.Session, error) {
-	cwd, _ := os.Getwd()
-	ws := types.Workspace{ID: "demo", RepoPath: cwd}
-	return a.mgr.SpawnRaw(ws, "claude", []string{"--version"})
-}
-
 // acquirePlanPool reserves a slot on a role=plan pool and returns the
 // resolved row. Callers MUST poolReg.ReleaseByPool(pool.ID) on spawn failure.
 // Strict role=plan — never falls back to role=work (issue #39 rev2).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,8 +7,6 @@ import {
   ListSessions,
   RefreshIssuesNow,
   SetAutoPullPaused,
-  SpawnDemo,
-  SpawnPlanForIssue,
 } from "../wailsjs/go/main/App";
 import { types } from "../wailsjs/go/models";
 import { useSessionStore, SessionActivity } from "./stores/sessionStore";
@@ -62,10 +60,8 @@ function App() {
       ) ?? null
     );
   }, [issues, planTarget]);
-  const [busy, setBusy] = useState(false);
   const toggleAgentDrawer = useAgentTerminalStore((s) => s.toggleDrawer);
   const agentDrawerOpen = useAgentTerminalStore((s) => s.drawerOpen);
-  const [issueInput, setIssueInput] = useState("");
   const [archivedOpen, setArchivedOpen] = useState(false);
   const [archivedCount, setArchivedCount] = useState(0);
   const refreshArchived = useArchivedStore((s) => s.refresh);
@@ -300,83 +296,12 @@ function App() {
     };
   }, [appendLine, setMeta, refreshWorkspaces, refreshGoals, refreshIssues, markPlanReady, clearPlanReady, selectedWorkspace, refreshArchived, refreshArchivedCount]);
 
-  async function spawnDemo() {
-    setBusy(true);
-    try {
-      const sess = await SpawnDemo();
-      if (sess?.id) {
-        setMeta(sess);
-        setActive(sess.id);
-      }
-      setDrawerOpen(true);
-    } catch (e) {
-      appendLine("error", String(e));
-      setActive("error");
-      setDrawerOpen(true);
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function spawnIssue() {
-    const workspaces = useWorkspaceStore.getState().workspaces;
-    const target = selectedWorkspace ?? workspaces[0]?.id;
-    if (!target) {
-      alert("Add a workspace in Settings first.");
-      return;
-    }
-    const num = parseInt(issueInput, 10);
-    if (!num) return;
-    setBusy(true);
-    try {
-      const sess = await SpawnPlanForIssue(target, num);
-      if (sess?.id) {
-        setMeta(sess);
-        setActive(sess.id);
-      }
-      setDrawerOpen(true);
-      setIssueInput("");
-    } catch (e: any) {
-      alert(String(e?.message ?? e));
-    } finally {
-      setBusy(false);
-    }
-  }
-
   return (
     <div className="h-screen flex flex-col bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-200">
       <header className="flex items-center justify-between px-4 py-2 border-b border-slate-200 dark:border-slate-800">
         <div className="font-semibold text-slate-900 dark:text-slate-200">PrismConductor</div>
         <TitleSearch />
         <div className="flex items-center gap-2">
-          {selectedWorkspace && (
-            <>
-              <input
-                type="number"
-                min={1}
-                value={issueInput}
-                onChange={(e) => setIssueInput(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && spawnIssue()}
-                placeholder="issue #"
-                className="w-20 bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded px-2 py-1 text-xs"
-              />
-              <button
-                onClick={spawnIssue}
-                disabled={busy || !issueInput}
-                className="text-xs bg-sky-700 hover:bg-sky-600 disabled:opacity-40 px-2 py-1 rounded"
-                title={issueInput ? "" : "type an issue number first"}
-              >
-                Plan issue
-              </button>
-            </>
-          )}
-          <button
-            onClick={spawnDemo}
-            disabled={busy}
-            className="text-xs bg-emerald-700 hover:bg-emerald-600 disabled:opacity-50 px-2 py-1 rounded"
-          >
-            {busy ? "…" : "Spawn `claude --version`"}
-          </button>
           <button
             onClick={() => RefreshIssuesNow().catch((e) => alert(String(e?.message ?? e)))}
             className="text-xs border border-slate-300 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 px-2 py-1 rounded"

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -219,8 +219,6 @@ export function SetNotifyPrefs(arg1:main.NotifyPrefs):Promise<void>;
 
 export function SetPollInterval(arg1:number):Promise<void>;
 
-export function SpawnDemo():Promise<types.Session>;
-
 export function SpawnPlanForIssue(arg1:string,arg2:number):Promise<types.Session>;
 
 export function StartAgentSession(arg1:string,arg2:string,arg3:Array<string>,arg4:number,arg5:number):Promise<types.AgentTermSession>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -418,10 +418,6 @@ export function SetPollInterval(arg1) {
   return window['go']['main']['App']['SetPollInterval'](arg1);
 }
 
-export function SpawnDemo() {
-  return window['go']['main']['App']['SpawnDemo']();
-}
-
 export function SpawnPlanForIssue(arg1, arg2) {
   return window['go']['main']['App']['SpawnPlanForIssue'](arg1, arg2);
 }


### PR DESCRIPTION
## Summary

- Removed the issue-number input / "Plan issue" button and "Spawn `claude --version`" button from the app header — both were Phase-1 dev scaffolding, superseded by drag-to-PLAN and per-card Plan Now menu actions.
- Pruned all orphaned state (`busy`, `issueInput`), handlers (`spawnDemo`, `spawnIssue`), and frontend imports (`SpawnDemo`, `SpawnPlanForIssue`) from `App.tsx`.
- Deleted `SpawnDemo` from `app.go`; `SpawnPlanForIssue` remains (still used by `Card.tsx`).
- Regenerated Wails bindings via `wails build` — `SpawnDemo` no longer exported from `App.d.ts` / `App.js`.

## Files modified

- `frontend/src/App.tsx`
- `app.go`
- `frontend/wailsjs/go/main/App.d.ts` (auto-generated)
- `frontend/wailsjs/go/main/App.js` (auto-generated)

## Verification

| Check | Command | Result |
|---|---|---|
| TypeScript | `npx tsc --noEmit` | pass |
| Build | `wails build` | pass (9.3s) |
| Smoke test | `npx playwright test tests/e2e/startup.spec.ts` | pass — `✓ app boots, React mounts, no console errors (5.8s)` |
| Go tests | `go test ./...` | pass — all packages |

Commit tier: **Tier 2b** (unsigned — GPG unavailable, branch protection confirmed off).

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-214

Closes #214