### PR TITLE
fix(approve): roll back column + toast on SpawnExecute failure (#218)

### DIFF
--- a/app.go
+++ b/app.go
@@ -3350,6 +3350,18 @@ func (a *App) ApprovePlan(workspaceID string, issueNumber, revision int) error {
 	}
 	if _, err := a.mgr.SpawnExecute(ws, issue, plan, pool); err != nil {
 		a.poolReg.ReleaseByPool(pool.ID)
+		// Roll back the column move so the card doesn't sit silently in
+		// IN_PROGRESS with no execute session attached (issue #218). The
+		// approved_at stamp on the plan is intentionally retained — a retry
+		// click should re-spawn against the same approved plan, not force a
+		// re-plan. Surface the failure as a toast since the inline error in
+		// PlanModal is easy to miss when the user is watching the board.
+		if rerr := a.store.MoveIssueColumn(workspaceID, issueNumber, types.ColPlan); rerr != nil {
+			log.Printf("ApprovePlan: rollback column to plan for #%d failed: %v", issueNumber, rerr)
+		}
+		a.emitToast("error", toastWorkspaceName(a.wsReg, workspaceID),
+			fmt.Sprintf("#%d execute could not start — %v", issueNumber, err),
+			map[string]any{"workspace_id": workspaceID, "issue_number": issueNumber, "action": "focus_card"})
 		return err
 	}
 	// Issue #101 Q3: pre-flight estimate toast so the user sees expected spend


### PR DESCRIPTION
## Summary

Fixes #218. `ApprovePlan` was committing the column move to IN_PROGRESS **before** the `SpawnExecute` attempt. When SpawnExecute failed (witnessed in the wild on a remote machine — likely an invalid worktree path on the work-role pool), the card was stranded in IN_PROGRESS with:

- No execute session row
- No event of any kind emitted
- Only an inline error in `PlanModal` that's easy to miss when the user is watching the board
- No recovery affordance besides drag-back-to-PLAN, which spawns a fresh plan worker (paying for re-plan twice)

The user's `badconductor2.db` showed two approved plan revisions for `sre_skills#1`, zero execute sessions, and no `plan_approved` / `pending_pool_enqueued` events — proving SpawnExecute failed silently both times.

## Fix

Two-line behavioral addition to the SpawnExecute-error branch:

```go
if _, err := a.mgr.SpawnExecute(ws, issue, plan, pool); err != nil {
    a.poolReg.ReleaseByPool(pool.ID)
    // Roll back the column move so the card doesn't sit silently in
    // IN_PROGRESS with no execute session attached (issue #218).
    if rerr := a.store.MoveIssueColumn(workspaceID, issueNumber, types.ColPlan); rerr != nil {
        log.Printf("ApprovePlan: rollback column to plan for #%d failed: %v", issueNumber, rerr)
    }
    a.emitToast("error", toastWorkspaceName(a.wsReg, workspaceID),
        fmt.Sprintf("#%d execute could not start — %v", issueNumber, err),
        map[string]any{"workspace_id": workspaceID, "issue_number": issueNumber, "action": "focus_card"})
    return err
}
```

The plan's `approved_at` stamp is intentionally retained — a retry click re-spawns against the same approved plan, no need to re-plan. The drain-from-queue path at `app.go:271-279` already had this rollback; this brings `ApprovePlan` into alignment.

## Test plan

- [x] `go build ./...` clean
- [ ] Manual: configure a workspace with a deliberately broken `RepoPath`, drag a card to PLAN, plan completes, click Approve. Card returns to PLAN with the approved stamp intact, error toast appears at top of screen with the failure reason.
- [ ] Manual: fix the workspace `RepoPath`, click Approve again on the same card. Execute spawns. No re-plan.

## Out of scope

- A card-level "▶ Retry execute" badge (described in #218's "Better" section). Would land in a follow-up.
- Validating workspace `RepoPath` at workspace-save time (separate ticket — orthogonal to this fix).
- Auto-retry on transient SpawnExecute failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
