### PR TITLE
feat(approve): failure_reason + RetryExecute RPC + card retry button (#218)

### DIFF
--- a/app.go
+++ b/app.go
@@ -3349,19 +3349,7 @@ func (a *App) ApprovePlan(workspaceID string, issueNumber, revision int) error {
 		return nil
 	}
 	if _, err := a.mgr.SpawnExecute(ws, issue, plan, pool); err != nil {
-		a.poolReg.ReleaseByPool(pool.ID)
-		// Roll back the column move so the card doesn't sit silently in
-		// IN_PROGRESS with no execute session attached (issue #218). The
-		// approved_at stamp on the plan is intentionally retained — a retry
-		// click should re-spawn against the same approved plan, not force a
-		// re-plan. Surface the failure as a toast since the inline error in
-		// PlanModal is easy to miss when the user is watching the board.
-		if rerr := a.store.MoveIssueColumn(workspaceID, issueNumber, types.ColPlan); rerr != nil {
-			log.Printf("ApprovePlan: rollback column to plan for #%d failed: %v", issueNumber, rerr)
-		}
-		a.emitToast("error", toastWorkspaceName(a.wsReg, workspaceID),
-			fmt.Sprintf("#%d execute could not start — %v", issueNumber, err),
-			map[string]any{"workspace_id": workspaceID, "issue_number": issueNumber, "action": "focus_card"})
+		a.handleSpawnExecuteFailure(workspaceID, issueNumber, pool, err)
 		return err
 	}
 	// Issue #101 Q3: pre-flight estimate toast so the user sees expected spend
@@ -3382,6 +3370,87 @@ func (a *App) ApprovePlan(workspaceID string, issueNumber, revision int) error {
 		"workspace_id": workspaceID,
 		"issue_number": issueNumber,
 		"revision":     revision,
+	})
+	return nil
+}
+
+// handleSpawnExecuteFailure undoes the IN_PROGRESS column move, sets a
+// failure_reason on the issue so the card shows a retry affordance, releases
+// the pool slot, and emits a top-level toast. Shared by ApprovePlan and
+// RetryExecuteForApprovedPlan.
+func (a *App) handleSpawnExecuteFailure(workspaceID string, issueNumber int, pool types.Pool, spawnErr error) {
+	a.poolReg.ReleaseByPool(pool.ID)
+	if rerr := a.store.MoveIssueColumn(workspaceID, issueNumber, types.ColPlan); rerr != nil {
+		log.Printf("handleSpawnExecuteFailure: rollback column for #%d: %v", issueNumber, rerr)
+	}
+	if rerr := a.store.SetIssueFailureReason(workspaceID, issueNumber,
+		fmt.Sprintf("execute spawn failed: %v", spawnErr)); rerr != nil {
+		log.Printf("handleSpawnExecuteFailure: set failure_reason for #%d: %v", issueNumber, rerr)
+	}
+	a.emitToast("error", toastWorkspaceName(a.wsReg, workspaceID),
+		fmt.Sprintf("#%d execute could not start — %v", issueNumber, spawnErr),
+		map[string]any{"workspace_id": workspaceID, "issue_number": issueNumber, "action": "focus_card"})
+}
+
+// RetryExecuteForApprovedPlan re-attempts SpawnExecute against the existing
+// approved plan for an issue that was rolled back to PLAN after a prior spawn
+// failure. Clears failure_reason on success.
+func (a *App) RetryExecuteForApprovedPlan(workspaceID string, issueNumber int) error {
+	if a.wsReg == nil || a.store == nil {
+		return fmt.Errorf("registry/store unavailable")
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return fmt.Errorf("unknown workspace %q", workspaceID)
+	}
+	plan, err := a.store.LatestPlan(workspaceID, issueNumber)
+	if err != nil {
+		return err
+	}
+	if plan == nil || plan.ApprovedAt == nil {
+		return fmt.Errorf("no approved plan found for issue #%d", issueNumber)
+	}
+	issue, err := a.store.LoadIssue(workspaceID, issueNumber)
+	if err != nil {
+		log.Printf("RetryExecuteForApprovedPlan: load issue #%d failed (%v); spawning with empty title", issueNumber, err)
+		issue = types.Issue{Number: issueNumber, WorkspaceID: workspaceID}
+	}
+	pool, ok := a.acquireWorkPool(ws)
+	if !ok {
+		_ = a.store.EnqueuePendingPool(workspaceID, issueNumber, types.RoleWork, "retry_execute")
+		_ = a.store.SetIssueWaitingForPool(workspaceID, issueNumber, true)
+		a.bus.Publish(eventbus.EvtPendingPoolEnqueued, eventbus.PendingPoolChange{
+			WorkspaceID: workspaceID,
+			IssueNumber: issueNumber,
+			Role:        string(types.RoleWork),
+		})
+		return nil
+	}
+	if err := a.store.MoveIssueColumn(workspaceID, issueNumber, types.ColInProgress); err != nil {
+		a.poolReg.ReleaseByPool(pool.ID)
+		return err
+	}
+	if _, err := a.mgr.SpawnExecute(ws, issue, *plan, pool); err != nil {
+		a.handleSpawnExecuteFailure(workspaceID, issueNumber, pool, err)
+		return err
+	}
+	_ = a.store.SetIssueFailureReason(workspaceID, issueNumber, "")
+	est := a.EstimateSpawnCost(workspaceID, issueNumber, pool.ID)
+	if est.Tokens > 0 {
+		var costStr string
+		if est.CostCents > 0 {
+			costStr = fmt.Sprintf(", est. $%.2f", est.CostCents/100)
+		}
+		a.emitToast("info", toastWorkspaceName(a.wsReg, workspaceID),
+			fmt.Sprintf("#%d execute spawned on %s (~%s tok%s)",
+				issueNumber, pool.Model,
+				formatTokenCount(est.Tokens), costStr),
+			map[string]any{"workspace_id": workspaceID, "issue_number": issueNumber, "action": "focus_card"})
+	}
+	a.bus.Publish(eventbus.EvtPlanApproved, map[string]any{
+		"workspace_id": workspaceID,
+		"issue_number": issueNumber,
+		"revision":     plan.Revision,
 	})
 	return nil
 }

--- a/app_test.go
+++ b/app_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"prismconductor/internal/eventbus"
 	"prismconductor/internal/store"
 	"prismconductor/internal/types"
+	"prismconductor/internal/workerpool"
 )
 
 func TestPullNumberFromURL(t *testing.T) {
@@ -271,5 +273,70 @@ func TestLabelSetEqual(t *testing.T) {
 		if got := labelSetEqual(c.a, c.b); got != c.want {
 			t.Errorf("labelSetEqual(%v, %v) = %v, want %v", c.a, c.b, got, c.want)
 		}
+	}
+}
+
+// handleSpawnExecuteFailure rolls back the column to PLAN, sets failure_reason,
+// and releases the pool slot (issue #218).
+func TestHandleSpawnExecuteFailure_RollsBackAndSetsReason(t *testing.T) {
+	s, err := store.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	const wsID = "ws1"
+	const issueNum = 42
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID: wsID,
+		Number:      issueNum,
+		Title:       "test issue",
+		State:       "open",
+		Column:      types.ColInProgress,
+	}); err != nil {
+		t.Fatalf("SaveIssue: %v", err)
+	}
+
+	const poolID = "p1"
+	reg := workerpool.NewRegistry(func(types.Provider) bool { return true })
+	reg.Sync([]types.Pool{{ID: poolID, Capacity: 1, Enabled: true, Role: types.RoleWork}})
+	// Simulate one slot already acquired (the one ApprovePlan took before failing).
+	if _, ok := reg.AcquireForWork(types.Workspace{ID: wsID}); !ok {
+		t.Fatal("AcquireForWork failed — pool not set up correctly")
+	}
+	if reg.FreeWorkSlots() != 0 {
+		t.Fatalf("expected 0 free slots after acquire, got %d", reg.FreeWorkSlots())
+	}
+
+	a := &App{store: s, poolReg: reg, bus: eventbus.New()}
+	// Pass a minimal pool stub — only pool.ID is used by handleSpawnExecuteFailure.
+	a.handleSpawnExecuteFailure(wsID, issueNum, types.Pool{ID: poolID}, errors.New("no such binary"))
+
+	// Pool slot must be released.
+	if reg.FreeWorkSlots() != 1 {
+		t.Errorf("expected 1 free slot after failure, got %d", reg.FreeWorkSlots())
+	}
+
+	// Column must be rolled back to PLAN.
+	iss, err := s.LoadIssue(wsID, issueNum)
+	if err != nil {
+		t.Fatalf("LoadIssue: %v", err)
+	}
+	if iss.Column != types.ColPlan {
+		t.Errorf("column = %q, want %q", iss.Column, types.ColPlan)
+	}
+
+	// failure_reason must be set.
+	if iss.FailureReason == "" {
+		t.Error("failure_reason not set after spawn failure")
+	}
+}
+
+// RetryExecuteForApprovedPlan returns an error when store/registry unavailable.
+func TestRetryExecuteForApprovedPlan_RequiresRegistry(t *testing.T) {
+	a := &App{bus: eventbus.New()}
+	err := a.RetryExecuteForApprovedPlan("ws1", 1)
+	if err == nil {
+		t.Fatal("expected error when wsReg and store are nil")
 	}
 }

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { BrowserOpenURL } from "../../wailsjs/runtime/runtime";
-import { Replan, ReplanForce, ClearIssueFailure, SelfHeal, CancelSession, SpawnPlanForIssue, ResolveConflicts, AttachManualPR, PrepareManualPushCommand, OpenOrphanPR } from "../../wailsjs/go/main/App";
+import { Replan, ReplanForce, ClearIssueFailure, SelfHeal, CancelSession, SpawnPlanForIssue, ResolveConflicts, AttachManualPR, PrepareManualPushCommand, OpenOrphanPR, RetryExecuteForApprovedPlan } from "../../wailsjs/go/main/App";
 import { ClipboardSetText } from "../../wailsjs/runtime/runtime";
 import { RecoverButton } from "./RecoverButton";
 import { types, issueview } from "../../wailsjs/go/models";
@@ -324,6 +324,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, relatedSiblings, o
         onClearFailure={() => ClearIssueFailure(issue.workspace_id, issue.number).catch((err: any) => alert(String(err?.message ?? err)))}
         onCancelSession={activeSession ? () => CancelSession(activeSession.id).catch((err: any) => alert(String(err?.message ?? err))) : null}
         onPlanNow={() => SpawnPlanForIssue(issue.workspace_id, issue.number).catch((err: any) => alert(String(err?.message ?? err)))}
+        spawnFailureReason={issue.failure_reason ?? null}
       />
       {activeSession && activeSession.state === "running" && (
         <AgentActivityStrip
@@ -555,6 +556,7 @@ function StatusRow({
   onClearFailure,
   onCancelSession,
   onPlanNow,
+  spawnFailureReason,
 }: {
   activeSession: types.Session | null;
   activity: SessionActivity | null;
@@ -580,6 +582,7 @@ function StatusRow({
   onClearFailure: () => void;
   onCancelSession: (() => void) | null;
   onPlanNow: () => void;
+  spawnFailureReason: string | null;
 }) {
   const [menu, setMenu] = useState<{ x: number; y: number; actions: CopyAction[] } | null>(null);
   // Hooks for the conditional render branches below MUST be declared at the
@@ -594,6 +597,7 @@ function StatusRow({
   const [prURLInput, setPRURLInput] = useState("");
   const [msgExpanded, setMsgExpanded] = useState(false);
   const [orphanPROpening, setOrphanPROpening] = useState(false);
+  const [retrying, setRetrying] = useState(false);
 
   function openMenu(e: React.MouseEvent, actions: CopyAction[]) {
     e.preventDefault();
@@ -1045,6 +1049,55 @@ function StatusRow({
             )}
           </div>
           <div className="text-slate-400 break-words">⚠ {reason}</div>
+        </div>
+        {menuEl}
+      </>
+    );
+  }
+  // Spawn failure: SpawnExecute failed after plan approval, card rolled back
+  // to PLAN. Show failure_reason with a retry button (issue #218).
+  if (spawnFailureReason && column === "plan" && !activeSession && !lastFailure && !pausedSession) {
+    return (
+      <>
+        <div
+          className="text-[11px] mt-1.5 space-y-0.5"
+          onContextMenu={(e) => openMenu(e, [
+            { label: "Copy reason", text: spawnFailureReason },
+            { label: "Copy as quoted block", text: toQuotedBlock(spawnFailureReason) },
+          ])}
+        >
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <Pulse className="bg-red-400" />
+            <span className="text-red-300">execute failed to start</span>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setRetrying(true);
+                RetryExecuteForApprovedPlan(workspaceID, issueNumber)
+                  .catch((err: any) => alert(String(err?.message ?? err)))
+                  .finally(() => setRetrying(false));
+              }}
+              onMouseDown={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
+              disabled={retrying}
+              className="ml-auto px-1.5 py-0.5 rounded text-[10px] border border-emerald-700 text-emerald-300 hover:border-emerald-500 hover:text-emerald-200 disabled:opacity-50"
+              title={spawnFailureReason}
+            >
+              {retrying ? "Retrying…" : "▶ Retry execute"}
+            </button>
+            <button
+              onClick={(e) => { e.stopPropagation(); onClearFailure(); }}
+              onMouseDown={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
+              className="px-1.5 py-0.5 rounded text-[10px] border border-slate-700 text-slate-400 hover:border-slate-500 hover:text-slate-200"
+              title="Clear this error without retrying"
+            >
+              ✕
+            </button>
+          </div>
+          <div className="text-slate-400 break-words pl-3.5" title={spawnFailureReason}>
+            ⚠ {spawnFailureReason}
+          </div>
         </div>
         {menuEl}
       </>

--- a/frontend/src/components/PlanModal.tsx
+++ b/frontend/src/components/PlanModal.tsx
@@ -146,8 +146,14 @@ export function PlanModal({
       await ApprovePlan(issue.workspace_id, issue.number, plan.revision);
       await Promise.all([refreshIssues(selectedWorkspace ?? ""), loadIssueViews(issue.workspace_id)]);
       handleClose();
-    } catch (e: any) {
-      setError(String(e?.message ?? e));
+    } catch {
+      // The backend emits a toast and rolls the card back to PLAN on spawn
+      // failure, so close the modal and let the toast be the primary signal.
+      await Promise.all([
+        refreshIssues(selectedWorkspace ?? ""),
+        loadIssueViews(issue.workspace_id),
+      ]).catch(() => {});
+      handleClose();
     } finally {
       setBusy(false);
     }

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -191,6 +191,8 @@ export function ResizeAgentTerm(arg1:string,arg2:number,arg3:number):Promise<voi
 
 export function ResolveConflicts(arg1:string,arg2:number):Promise<void>;
 
+export function RetryExecuteForApprovedPlan(arg1:string,arg2:number):Promise<void>;
+
 export function RotateRemoteWorkerKey(arg1:string,arg2:string):Promise<void>;
 
 export function RunAutoArchiveNow(arg1:string):Promise<number>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -362,6 +362,10 @@ export function ResolveConflicts(arg1, arg2) {
   return window['go']['main']['App']['ResolveConflicts'](arg1, arg2);
 }
 
+export function RetryExecuteForApprovedPlan(arg1, arg2) {
+  return window['go']['main']['App']['RetryExecuteForApprovedPlan'](arg1, arg2);
+}
+
 export function RotateRemoteWorkerKey(arg1, arg2) {
   return window['go']['main']['App']['RotateRemoteWorkerKey'](arg1, arg2);
 }


### PR DESCRIPTION
## Summary

- `handleSpawnExecuteFailure` helper now sets `failure_reason` on the issue (in addition to rolling back the column and emitting a toast), giving the card a concrete retry affordance
- New `RetryExecuteForApprovedPlan` RPC spawns execute against the already-approved plan, clears `failure_reason` on success, and reuses the same failure handler on error
- `Card.tsx` / `StatusRow`: renders a `▶ Retry execute` button when `column === "plan"`, `failure_reason` is set, and there is no active/failed session
- `PlanModal.tsx`: closes the modal on `ApprovePlan` error (backend toast is the primary signal); refreshes issue list to reflect rollback before close
- Wailsjs bindings updated with `RetryExecuteForApprovedPlan` (regenerated by `wails build`)

## Files modified

- `app.go` — `handleSpawnExecuteFailure`, `RetryExecuteForApprovedPlan`, refactored `ApprovePlan` failure branch
- `app_test.go` — `TestHandleSpawnExecuteFailure_RollsBackAndSetsReason`, `TestRetryExecuteForApprovedPlan_RequiresRegistry`
- `frontend/src/components/Card.tsx` — spawn failure render branch + `RetryExecuteForApprovedPlan` import
- `frontend/src/components/PlanModal.tsx` — close modal on approve error
- `frontend/wailsjs/go/main/App.d.ts` / `App.js` — `RetryExecuteForApprovedPlan` binding

## Verification

| Gate | Command | Result |
|------|---------|--------|
| Lint | `go vet ./...` | pass |
| TypeScript | `tsc --noEmit` | pass |
| Build | `wails build` | pass (13.5s) |
| Tests | `go test . ./internal/...` | all pass (2 new tests) |
| Smoke | `playwright test tests/e2e/startup.spec.ts` | skipped — app not running in worktree context (net::ERR_CONNECTION_REFUSED); no code changes affect boot path |

Commit tier: **Tier 1** (GitHub API signed commit)

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-218

Closes #218
