### PR TITLE
feat(isolation): add PRISMCONDUCTOR_DATA_DIR env override for test sandbox isolation (#225)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: enforce test isolation (no prod data dir in tests)
+        if: matrix.name == 'linux'
+        run: |
+          bad=$(grep -RnE 'os\.UserConfigDir|UserHomeDir|Library/Application Support/(prism|Prism)[Cc]onductor|\.config/prismconductor' \
+                    --include='*_test.go' tests/ . 2>/dev/null || true)
+          if [ -n "$bad" ]; then
+            echo "::error::test code references the user's real data dir; use t.TempDir() / PRISMCONDUCTOR_DATA_DIR instead"
+            echo "$bad"
+            exit 1
+          fi
+
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -101,6 +112,8 @@ jobs:
         # always 0) and a real test failure silently passes CI.
         run: |
           set -m
+          export PRISMCONDUCTOR_DATA_DIR="$RUNNER_TEMP/prismconductor-smoke"
+          mkdir -p "$PRISMCONDUCTOR_DATA_DIR"
           xvfb-run --auto-servernum --server-args='-screen 0 1280x800x24' \
             wails dev -loglevel error > /tmp/wails-dev.log 2>&1 &
           WAILS_PID=$!

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -15,6 +15,15 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+      - name: enforce test isolation (no prod data dir in tests)
+        run: |
+          bad=$(grep -RnE 'os\.UserConfigDir|UserHomeDir|Library/Application Support/(prism|Prism)[Cc]onductor|\.config/prismconductor' \
+                    --include='*_test.go' tests/ . 2>/dev/null || true)
+          if [ -n "$bad" ]; then
+            echo "::error::test code references the user's real data dir; use t.TempDir() / PRISMCONDUCTOR_DATA_DIR instead"
+            echo "$bad"
+            exit 1
+          fi
       - uses: actions/setup-go@v6
         with: { go-version: "1.25" }
       - uses: actions/setup-node@v6
@@ -76,6 +85,8 @@ jobs:
         # job hangs until the 15-minute job timeout fires.
         run: |
           set -m
+          export PRISMCONDUCTOR_DATA_DIR="$RUNNER_TEMP/prismconductor-smoke"
+          mkdir -p "$PRISMCONDUCTOR_DATA_DIR"
           xvfb-run --auto-servernum --server-args='-screen 0 1280x800x24' \
             wails dev -loglevel error > /tmp/wails-dev.log 2>&1 &
           echo "WAILS_PID=$!" >> "$GITHUB_ENV"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,3 +22,4 @@ The product spec lives in `PRISMCONDUCTOR_PLAN.md`. Treat it as the source of tr
 - `go build ./...` — Go compile check.
 - `cd frontend && npx tsc --noEmit` — frontend typecheck.
 - `wails build` — full app bundle (~40s).
+- `PRISMCONDUCTOR_DATA_DIR=<path>` — overrides the conductor's data directory. Tests, smoke harnesses, and worker verification gates MUST set this to a temp dir; otherwise they can corrupt the user's real `~/Library/Application Support/PrismConductor/conductor.db`. CI enforces that no test code touches the prod path (see `.github/workflows/smoke.yml` and `.github/workflows/build.yml`).

--- a/app.go
+++ b/app.go
@@ -4064,6 +4064,9 @@ func (a *App) GitHubListRepos() ([]*gh.Repository, error) {
 }
 
 func configDir() (string, error) {
+	if d := os.Getenv("PRISMCONDUCTOR_DATA_DIR"); d != "" {
+		return d, nil
+	}
 	switch runtime.GOOS {
 	case "darwin":
 		home, err := os.UserHomeDir()

--- a/app_configdir_test.go
+++ b/app_configdir_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfigDir_RespectsEnvOverride(t *testing.T) {
+	want := t.TempDir()
+	t.Setenv("PRISMCONDUCTOR_DATA_DIR", want)
+	got, err := configDir()
+	if err != nil {
+		t.Fatalf("configDir: %v", err)
+	}
+	if got != want {
+		t.Errorf("configDir() = %q, want %q", got, want)
+	}
+}
+
+func TestConfigDir_FallbackUnchanged(t *testing.T) {
+	t.Setenv("PRISMCONDUCTOR_DATA_DIR", "")
+	got, err := configDir()
+	if err != nil {
+		t.Fatalf("configDir: %v", err)
+	}
+	lower := strings.ToLower(got)
+	if !strings.Contains(lower, "prismconductor") {
+		t.Errorf("configDir() = %q, expected it to contain 'prismconductor'", got)
+	}
+}

--- a/internal/remoteworker/keychain.go
+++ b/internal/remoteworker/keychain.go
@@ -8,14 +8,31 @@ import (
 
 const keychainServiceName = "PrismConductor"
 
+// testKeychainDir, when non-empty, redirects all key-file operations to the
+// given directory instead of os.UserConfigDir(). Set via OverrideKeychainDir.
+var testKeychainDir string
+
+// OverrideKeychainDir redirects key-file I/O to dir for the duration of a
+// test. Call it only from test code; the returned function restores the
+// previous value and must be deferred or passed to t.Cleanup.
+func OverrideKeychainDir(dir string) func() {
+	prev := testKeychainDir
+	testKeychainDir = dir
+	return func() { testKeychainDir = prev }
+}
+
 // keyFilePath returns the path to the per-workspace key file in the user
 // config directory, e.g. ~/Library/Application Support/PrismConductor/secrets/<wsID>.key
 func keyFilePath(workspaceID string) (string, error) {
-	dir, err := os.UserConfigDir()
-	if err != nil {
-		return "", fmt.Errorf("user config dir: %w", err)
+	base := testKeychainDir
+	if base == "" {
+		dir, err := os.UserConfigDir()
+		if err != nil {
+			return "", fmt.Errorf("user config dir: %w", err)
+		}
+		base = filepath.Join(dir, keychainServiceName)
 	}
-	return filepath.Join(dir, keychainServiceName, "secrets", workspaceID+".key"), nil
+	return filepath.Join(base, "secrets", workspaceID+".key"), nil
 }
 
 // GetKey retrieves the conductor API key for workspaceID from the local key

--- a/internal/session/manager_plan_remote_test.go
+++ b/internal/session/manager_plan_remote_test.go
@@ -3,10 +3,10 @@ package session
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -130,15 +130,12 @@ func TestSpawnPlan_RemoteWorkspace_RoutesToRemote(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Write a dummy API key file so remoteworker.GetKey succeeds.
-	keyDir, err := os.UserConfigDir()
-	if err != nil {
-		t.Skipf("cannot locate config dir: %v", err)
-	}
-	keyPath := fmt.Sprintf("%s/PrismConductor/secrets/ws-remote-plan.key", keyDir)
-	_ = os.MkdirAll(keyPath[:len(keyPath)-len("/ws-remote-plan.key")], 0o700)
+	// Redirect key-file I/O to a temp dir; write a dummy key so Spawn accepts it.
+	keychainDir := t.TempDir()
+	t.Cleanup(remoteworker.OverrideKeychainDir(keychainDir))
+	keyPath := filepath.Join(keychainDir, "secrets", "ws-remote-plan.key")
+	_ = os.MkdirAll(filepath.Dir(keyPath), 0o700)
 	_ = os.WriteFile(keyPath, []byte("test-api-key"), 0o600)
-	t.Cleanup(func() { _ = os.Remove(keyPath) })
 
 	ws := types.Workspace{
 		ID:              "ws-remote-plan",
@@ -207,11 +204,12 @@ func TestSpawnPlan_RemoteWorkspace_DuplicateGuard(t *testing.T) {
 	}))
 	t.Cleanup(func() { close(block); srv.Close() })
 
-	keyDir, _ := os.UserConfigDir()
-	keyPath := fmt.Sprintf("%s/PrismConductor/secrets/ws-dup-guard.key", keyDir)
-	_ = os.MkdirAll(keyPath[:len(keyPath)-len("/ws-dup-guard.key")], 0o700)
+	// Redirect key-file I/O to a temp dir; write a dummy key so Spawn accepts it.
+	keychainDir := t.TempDir()
+	t.Cleanup(remoteworker.OverrideKeychainDir(keychainDir))
+	keyPath := filepath.Join(keychainDir, "secrets", "ws-dup-guard.key")
+	_ = os.MkdirAll(filepath.Dir(keyPath), 0o700)
 	_ = os.WriteFile(keyPath, []byte("test-key"), 0o600)
-	t.Cleanup(func() { _ = os.Remove(keyPath) })
 
 	ws := types.Workspace{
 		ID:              "ws-dup-guard",

--- a/internal/skills/bundle/skills/conductor-execute.md
+++ b/internal/skills/bundle/skills/conductor-execute.md
@@ -61,6 +61,19 @@ If you hit a question the plan didn't cover, invoke `/conductor-question` (write
 
 These run before commit. Failures here are **stop-the-world** events: print `BLOCKED:` and exit, leaving the branch in place for the user to inspect. Do **not** commit broken work. Do **not** swallow failures into the PR body.
 
+9-prep. **Test isolation (NON-NEGOTIABLE).** Set up a sandboxed data dir before any verification command runs. Workers run in a worktree but share the user's process-level data directory; a worker that tests a DB migration can corrupt the user's prod DB (issue #225).
+
+```bash
+export PRISMCONDUCTOR_DATA_DIR="$(mktemp -d -t prismconductor-verify-XXXXXX)"
+if [ -z "$PRISMCONDUCTOR_DATA_DIR" ]; then
+  echo "BLOCKED: cannot create temp data dir for verification — mktemp failed on this system"
+  exit 1
+fi
+trap 'rm -rf "$PRISMCONDUCTOR_DATA_DIR"' EXIT
+```
+
+If `wails dev` or the built binary is launched as part of verification (smoke spec), `PRISMCONDUCTOR_DATA_DIR` MUST be present in its environment. Do NOT run `wails dev` against the user's real data dir during verification — if the var is unset for any reason, abort with `BLOCKED: refusing to run wails dev against unsandboxed data dir`.
+
 9. **Lint / typecheck** every changed surface:
    - Go files touched → `go vet ./...` (or the project's `PRISMCONDUCTOR_LINT_CMD` if set).
    - TypeScript files touched → `npx tsc --noEmit` from the relevant frontend dir.

--- a/internal/store/open_test.go
+++ b/internal/store/open_test.go
@@ -1,0 +1,26 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestOpen_PlacesDBInDir verifies that Open creates conductor.db inside the
+// given directory — the contract that PRISMCONDUCTOR_DATA_DIR relies on.
+func TestOpen_PlacesDBInDir(t *testing.T) {
+	dir := t.TempDir()
+	st, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { st.DB.Close() })
+
+	want := filepath.Join(dir, "conductor.db")
+	if st.Path != want {
+		t.Errorf("Store.Path = %q, want %q", st.Path, want)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("conductor.db not found at %q: %v", want, err)
+	}
+}

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -1,4 +1,9 @@
 import { defineConfig } from "@playwright/test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const smokeDataDir = mkdtempSync(join(tmpdir(), "prismconductor-smoke-"));
 
 export default defineConfig({
   // testDir is relative to this config (tests/playwright.config.ts), so the
@@ -23,5 +28,6 @@ export default defineConfig({
         cwd: "..",
         stdout: "pipe",
         stderr: "pipe",
+        env: { ...process.env, PRISMCONDUCTOR_DATA_DIR: smokeDataDir },
       },
 });


### PR DESCRIPTION
## Summary

- Introduces `PRISMCONDUCTOR_DATA_DIR` env var that overrides `configDir()` so workers and smoke tests can redirect the conductor DB to a throwaway temp dir, making prod-DB corruption by worker verification structurally impossible (issue #225).
- CI grep guard in `smoke.yml` and `build.yml` fails fast if any `_test.go` or `tests/` file references the user's real config paths.
- conductor-execute skill gains a mandatory `9-prep` isolation step.

## Files modified

- `app.go` — `configDir()` checks `PRISMCONDUCTOR_DATA_DIR` first
- `app_configdir_test.go` (new) — unit tests for env-override and OS fallback
- `internal/remoteworker/keychain.go` — adds `OverrideKeychainDir()` test hook so tests redirect key-file I/O without touching prod config
- `internal/session/manager_plan_remote_test.go` — replaced `os.UserConfigDir()` calls with `OverrideKeychainDir(t.TempDir())`
- `internal/store/open_test.go` (new) — asserts `store.Open(dir)` creates `dir/conductor.db`
- `tests/playwright.config.ts` — `webServer.env` sets `PRISMCONDUCTOR_DATA_DIR` to a per-run temp dir
- `.github/workflows/smoke.yml` — grep guard step + `PRISMCONDUCTOR_DATA_DIR` for `wails dev`
- `.github/workflows/build.yml` — mirror of grep guard + `PRISMCONDUCTOR_DATA_DIR` for smoke test step
- `internal/skills/bundle/skills/conductor-execute.md` — `9-prep` test isolation step (NON-NEGOTIABLE)
- `CLAUDE.md` — documents the env var and CI enforcement

## Verification

| Check | Command | Result |
|-------|---------|--------|
| lint | `go vet ./...` | pass |
| build | `go build ./...` | pass |
| typecheck | `npx tsc --noEmit` | pass |
| smoke | `npx --prefix tests playwright test e2e/startup.spec.ts` | pass (1 passed, wails dev with PRISMCONDUCTOR_DATA_DIR set to temp dir) |
| tests | `go test ./...` | pass (all packages) |
| CI guard | grep for prod paths in test files | pass (no matches) |

Commit tier: Tier 2b (unsigned local commit; branch protection not enabled).

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-225

Closes #225
