### PR TITLE
fix(assembler): surface FailureCause-only sessions as lastFail (regression from #194)

### DIFF
--- a/internal/issueview/assembler.go
+++ b/internal/issueview/assembler.go
@@ -550,8 +550,17 @@ func selectSessions(iss types.Issue, sessions []types.Session) (active, paused, 
 			continue
 		}
 
+		// A failed/blocked session is surfaced as lastFail when it has either:
+		//   - a BlockedReason (worker emitted a `BLOCKED:` sentinel), OR
+		//   - a FailureCause (worker died mid-flow without sentinel — #194)
+		// Pre-fix: the gate required BlockedReason != "" only, so a session
+		// killed by SIGKILL (OOM, watchdog, manual kill) had FailureCause
+		// populated but BlockedReason empty, was dropped here, and the card
+		// rendered as if nothing happened. Witnessed live on issue #221:
+		// 22-min execute SIGKILL'd, card sat glow-less in IN_PROGRESS.
+		hasFailureSignal := m.BlockedReason != "" || m.FailureCause != nil
 		if (m.State == types.StateFailed || m.State == types.StateBlocked) &&
-			m.BlockedReason != "" && notAck {
+			hasFailureSignal && notAck {
 			if lastFail == nil || m.StartedAt.After(lastFail.StartedAt) {
 				lastFail = m
 			}

--- a/internal/issueview/assembler_test.go
+++ b/internal/issueview/assembler_test.go
@@ -175,11 +175,31 @@ func TestSelectSessions_MostRecentFailureWins(t *testing.T) {
 	}
 }
 
-func TestSelectSessions_NoReason_NotTrackedAsFailure(t *testing.T) {
+func TestSelectSessions_NoReasonNoCause_NotTrackedAsFailure(t *testing.T) {
+	// A failed session with neither BlockedReason nor FailureCause is genuinely
+	// uninformative — no signal to render. Skip it.
 	sessions := []types.Session{makeSession(types.StateFailed, t1, "", false)}
 	_, _, lastFail, _ := selectSessions(types.Issue{Column: types.ColTodo}, sessions)
 	if lastFail != nil {
-		t.Error("failed session with no reason should not surface as lastFail")
+		t.Error("failed session with no reason and no cause should not surface as lastFail")
+	}
+}
+
+// Regression: a session killed mid-flow (SIGKILL via OOM, watchdog, etc.)
+// captures FailureCause but no BlockedReason, since the worker never emitted
+// a BLOCKED: sentinel. The assembler must surface it as lastFail so the card
+// renders with a failure indicator instead of going glow-less in IN_PROGRESS.
+// Witnessed live on issue #221: 22-min execute SIGKILL'd, derived
+// card_state="todo" because lastFail=nil filtered it out.
+func TestSelectSessions_FailureCauseOnly_TrackedAsLastFail(t *testing.T) {
+	sess := makeSession(types.StateFailed, t1, "", false)
+	sess.FailureCause = &types.FailureCause{Kind: "exit_code", Reason: "signal: killed"}
+	_, _, lastFail, _ := selectSessions(types.Issue{Column: types.ColTodo}, []types.Session{sess})
+	if lastFail == nil {
+		t.Fatal("failed session with FailureCause must surface as lastFail")
+	}
+	if lastFail.FailureCause == nil || lastFail.FailureCause.Reason != "signal: killed" {
+		t.Errorf("lastFail.FailureCause not preserved: %+v", lastFail.FailureCause)
 	}
 }
 


### PR DESCRIPTION
## Summary

Regression from #194. When a worker subprocess is killed mid-flow (SIGKILL from OOM, watchdog, or manual kill), the session manager captures a `FailureCause` but no `BlockedReason` — the worker had no chance to emit a `BLOCKED:` sentinel before dying. The assembler's `selectSessions` filter at `internal/issueview/assembler.go:553` only accepted `BlockedReason != ""` as a valid failure signal, so these sessions were silently dropped from `lastFail` tracking. Result: `card_state="todo"`, `last_failure=null`, no glow, no badge — a "sad glow-less ticket in the IN_PROGRESS lane."

## Witnessed live on #221

22-minute execute session for the auto-retry-with-backoff feature SIGKILL'd at 14:58:25 EDT. Captured state:

```json
{
  "state": "failed",
  "failure_cause": { "kind": "exit_code", "reason": "signal: killed" },
  "blocked_reason": null,
  "ended_at": "2026-05-06T14:58:25.652583-04:00"
}
```

Live assembler dump for the issue:

```json
{
  "derived_column": "in_progress",
  "card_state": "todo",      ← WRONG
  "last_failure": null,       ← WRONG (failed session is invisible)
  "active_session": null
}
```

Most likely root: OOM kill during heavy code generation (cardstate + retry scheduler + persistence + UI is a substantial change). The conductor correctly captured the failure cause but the assembler refused to surface it.

The irony is sharp: the card was building the very feature that would have auto-retried it.

## Fix

Two-line change in `internal/issueview/assembler.go::selectSessions`:

```go
// Pre-fix:
if (m.State == types.StateFailed || m.State == types.StateBlocked) &&
    m.BlockedReason != "" && notAck { ... }

// Post-fix:
hasFailureSignal := m.BlockedReason != "" || m.FailureCause != nil
if (m.State == types.StateFailed || m.State == types.StateBlocked) &&
    hasFailureSignal && notAck { ... }
```

Both fields are written by the post-#194 session-manager terminal-state writer; either is a valid signal that the session needs surfacing.

## Tests

- Renamed `TestSelectSessions_NoReason_NotTrackedAsFailure` → `..._NoReasonNoCause_...` and clarified: "no signal at all → still skip."
- Added `TestSelectSessions_FailureCauseOnly_TrackedAsLastFail` pinning the new behavior with a comment referencing #221 for forensic trail.
- All existing `TestSelectSessions_*` and `TestDeriveCardState_*` continue to pass.

## Verification

- [x] `go build ./...` clean
- [x] `go test ./internal/issueview/ ./internal/cardstate/` clean
- [ ] Manual: with the running conductor, card #221 should now render `card_state="blocked"` with the failure-cause-derived reason ("signal: killed") visible in the badge tooltip after rebuild.

## Out of scope

- Fixing the OOM root cause (workers shouldn't need 22 min on a single execute — separate scope question, possibly addressed by chunking large features into multiple cards).
- The auto-retry-with-backoff feature itself (#221) — that's the in-flight ticket the worker was building when it died.
- Investigating why the SIGKILL fired specifically. (`signal: killed` is observable; root attribution is harder. Worth a separate ticket if it recurs.)

## Severity

**High.** Affects every session that dies mid-flow without a sentinel — exactly the failure mode #194 was supposed to surface. With this fix, the FailureCause data #194 captured actually becomes user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
