### PR TITLE
feat(retry): auto-retry with exponential backoff for transient failures (#221)

### DIFF
--- a/app.go
+++ b/app.go
@@ -27,6 +27,7 @@ import (
 	"prismconductor/internal/archiver"
 	"prismconductor/internal/diagnose"
 	"prismconductor/internal/eventbus"
+	"prismconductor/internal/retry"
 	pcgit "prismconductor/internal/git"
 	pcgithub "prismconductor/internal/github"
 	"prismconductor/internal/handlers"
@@ -86,6 +87,9 @@ type App struct {
 
 	// Issue #178: OS-native secret store for CF API tokens.
 	secretStore secretstore.Store
+
+	// Issue #221: auto-retry scheduler for transient execute failures.
+	retryScheduler *retry.Scheduler
 }
 
 type issueDetailEntry struct {
@@ -212,6 +216,9 @@ func (a *App) startup(ctx context.Context) {
 
 	// Issue #161: ephemeral PTY-backed agent terminal panel.
 	a.agentTerm = agentterm.New(a.emitAgentData, a.emitAgentExit)
+
+	// Issue #221: auto-retry scheduler for transient execute failures.
+	a.retryScheduler = retry.NewScheduler(a.bus, a.doAutoRetry)
 
 	a.mgr = session.NewManager(a.bus, a.emitLine)
 	a.mgr.Configure(filepath.Join(cfgDir, "transcripts"), a.store, a.handleSessionStateChange)
@@ -472,6 +479,14 @@ func (a *App) handleSessionStateChange(sess types.Session, prev types.SessionSta
 			reason = "execute session ended without success"
 		}
 		_ = a.store.SetIssueFailureReason(sess.WorkspaceID, sess.IssueNumber, reason)
+
+		// Attempt to schedule an automatic retry for transient failures (#221).
+		// The scheduler decides whether the cause is retryable and enforces caps.
+		if a.retryScheduler != nil && a.wsReg != nil {
+			if ws, ok := a.wsReg.Get(sess.WorkspaceID); ok {
+				a.retryScheduler.Schedule(ws, sess, sess.FailureCause)
+			}
+		}
 	}
 
 	// When an execute session COMPLETES on a card that had merge conflicts
@@ -3453,6 +3468,48 @@ func (a *App) RetryExecuteForApprovedPlan(workspaceID string, issueNumber int) e
 		"revision":     plan.Revision,
 	})
 	return nil
+}
+
+// doAutoRetry is the FireFunc passed to the retry.Scheduler. It re-uses the
+// RetryExecuteForApprovedPlan path; the Scheduler has already enforced caps and
+// policy before calling here. Runs in its own goroutine (scheduler dispatches async).
+func (a *App) doAutoRetry(workspaceID string, issueNumber int, attempt int, _ string) {
+	log.Printf("retry: auto-retry attempt %d for #%d", attempt, issueNumber)
+	if err := a.RetryExecuteForApprovedPlan(workspaceID, issueNumber); err != nil {
+		log.Printf("retry: auto-retry #%d attempt %d failed: %v", issueNumber, attempt, err)
+		// Surface to user as a toast so transient re-spawns that fail are visible.
+		if a.ctx != nil {
+			a.emitToast("error", toastWorkspaceName(a.wsReg, workspaceID),
+				fmt.Sprintf("#%d auto-retry attempt %d failed: %v", issueNumber, attempt, err),
+				map[string]any{"workspace_id": workspaceID, "issue_number": issueNumber, "action": "focus_card"})
+		}
+	}
+}
+
+// CancelRetries cancels the pending auto-retry for an issue. Returns true if
+// a retry was present and cancelled. Safe to call with no pending retry.
+func (a *App) CancelRetries(workspaceID string, issueNumber int) bool {
+	if a.retryScheduler == nil {
+		return false
+	}
+	return a.retryScheduler.Cancel(workspaceID, issueNumber)
+}
+
+// RetryNow fires the pending auto-retry immediately, bypassing the backoff
+// countdown. Returns true if a retry was present and dispatched.
+func (a *App) RetryNow(workspaceID string, issueNumber int) bool {
+	if a.retryScheduler == nil {
+		return false
+	}
+	return a.retryScheduler.FireNow(workspaceID, issueNumber)
+}
+
+// GetRetryQueue returns the list of pending auto-retries for a workspace.
+func (a *App) GetRetryQueue(workspaceID string) []retry.PendingRetry {
+	if a.retryScheduler == nil {
+		return nil
+	}
+	return a.retryScheduler.List(workspaceID)
 }
 
 // formatTokenCount formats a token count as a human-readable string.

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { BrowserOpenURL } from "../../wailsjs/runtime/runtime";
-import { Replan, ReplanForce, ClearIssueFailure, SelfHeal, CancelSession, SpawnPlanForIssue, ResolveConflicts, AttachManualPR, PrepareManualPushCommand, OpenOrphanPR, RetryExecuteForApprovedPlan } from "../../wailsjs/go/main/App";
+import { Replan, ReplanForce, ClearIssueFailure, SelfHeal, CancelSession, SpawnPlanForIssue, ResolveConflicts, AttachManualPR, PrepareManualPushCommand, OpenOrphanPR, RetryExecuteForApprovedPlan, CancelRetries, RetryNow } from "../../wailsjs/go/main/App";
 import { ClipboardSetText } from "../../wailsjs/runtime/runtime";
 import { RecoverButton } from "./RecoverButton";
 import { types, issueview } from "../../wailsjs/go/models";
@@ -39,7 +39,14 @@ type CardStateValue =
   | "tests_failing"
   | "plan_failed"
   | "review"
-  | "done";
+  | "done"
+  | "retry_scheduled";
+
+type PendingRetryInfo = {
+  attempt: number;
+  max_attempts: number;
+  not_before: number; // unix seconds
+};
 
 // Extended view type that includes the new card_state fields not yet in
 // the auto-generated models.ts (wails generate module adds them on next build).
@@ -50,6 +57,7 @@ type IssueViewWithCardState = issueview.IssueView & {
     session_id?: string;
     session_mode?: string;
     blocked_reason?: string;
+    retry_info?: PendingRetryInfo;
   };
 };
 
@@ -86,6 +94,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, relatedSiblings, o
   const needsPRInfo = view?.needs_pr_info ?? null;
   const planFailed = view?.plan_failed ?? null;
   const orphanPRInfo = view?.orphan_pr_info ?? null;
+  const pendingRetryInfo: PendingRetryInfo | null = view?.card_state_details?.retry_info ?? null;
   // Activity is live-streaming data not captured in the view — still from sessionStore.
   const activity: SessionActivity | null = useSessionStore((s) =>
     activeSession ? (s.sessions[activeSession.id]?.activity ?? null) : null
@@ -325,6 +334,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, relatedSiblings, o
         onCancelSession={activeSession ? () => CancelSession(activeSession.id).catch((err: any) => alert(String(err?.message ?? err))) : null}
         onPlanNow={() => SpawnPlanForIssue(issue.workspace_id, issue.number).catch((err: any) => alert(String(err?.message ?? err)))}
         spawnFailureReason={issue.failure_reason ?? null}
+        pendingRetryInfo={pendingRetryInfo}
       />
       {activeSession && activeSession.state === "running" && (
         <AgentActivityStrip
@@ -557,6 +567,7 @@ function StatusRow({
   onCancelSession,
   onPlanNow,
   spawnFailureReason,
+  pendingRetryInfo,
 }: {
   activeSession: types.Session | null;
   activity: SessionActivity | null;
@@ -583,6 +594,7 @@ function StatusRow({
   onCancelSession: (() => void) | null;
   onPlanNow: () => void;
   spawnFailureReason: string | null;
+  pendingRetryInfo: PendingRetryInfo | null;
 }) {
   const [menu, setMenu] = useState<{ x: number; y: number; actions: CopyAction[] } | null>(null);
   // Hooks for the conditional render branches below MUST be declared at the
@@ -598,6 +610,20 @@ function StatusRow({
   const [msgExpanded, setMsgExpanded] = useState(false);
   const [orphanPROpening, setOrphanPROpening] = useState(false);
   const [retrying, setRetrying] = useState(false);
+  const [cancellingRetry, setCancellingRetry] = useState(false);
+  const [secsLeft, setSecsLeft] = useState(() =>
+    pendingRetryInfo
+      ? Math.max(0, Math.ceil((pendingRetryInfo.not_before * 1000 - Date.now()) / 1000))
+      : 0
+  );
+  useEffect(() => {
+    if (!pendingRetryInfo) return;
+    const tick = () =>
+      setSecsLeft(Math.max(0, Math.ceil((pendingRetryInfo.not_before * 1000 - Date.now()) / 1000)));
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [pendingRetryInfo?.not_before]);
 
   function openMenu(e: React.MouseEvent, actions: CopyAction[]) {
     e.preventDefault();
@@ -971,6 +997,62 @@ function StatusRow({
               attempt {testsFailingInfo.self_heal_attempts}/{testsFailingInfo.attempt_cap ?? 3}
             </div>
           )}
+        </div>
+        {menuEl}
+      </>
+    );
+  }
+  // Pending auto-retry: transient failure, scheduler queued a re-spawn (#221).
+  if (pendingRetryInfo && lastFailure) {
+    const reason = lastFailure.blocked_reason || "session ended without success";
+    const countdownLabel = secsLeft > 0 ? `in ${secsLeft}s` : "now";
+    return (
+      <>
+        <div
+          className="text-[11px] mt-1.5 space-y-0.5"
+          onContextMenu={(e) => openMenu(e, [
+            { label: "Copy reason", text: reason },
+            { label: "Copy as quoted block", text: toQuotedBlock(reason) },
+          ])}
+        >
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <Pulse className="bg-amber-400" />
+            <span className="text-amber-300">retry {countdownLabel}</span>
+            <span className="text-slate-500">· {pendingRetryInfo.attempt}/{pendingRetryInfo.max_attempts}</span>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setRetrying(true);
+                RetryNow(workspaceID, issueNumber)
+                  .catch((err: any) => alert(String(err?.message ?? err)))
+                  .finally(() => setRetrying(false));
+              }}
+              onMouseDown={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
+              disabled={retrying}
+              className="px-1.5 py-0.5 rounded text-[10px] border border-emerald-700 text-emerald-300 hover:border-emerald-500 hover:text-emerald-200 disabled:opacity-50"
+              title="Fire the retry immediately"
+            >
+              {retrying ? "…" : "↺ Now"}
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setCancellingRetry(true);
+                CancelRetries(workspaceID, issueNumber)
+                  .catch((err: any) => alert(String(err?.message ?? err)))
+                  .finally(() => setCancellingRetry(false));
+              }}
+              onMouseDown={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
+              disabled={cancellingRetry}
+              className="px-1.5 py-0.5 rounded text-[10px] border border-slate-700 text-slate-400 hover:border-slate-500 hover:text-slate-200 disabled:opacity-50"
+              title="Cancel the pending retry and leave the card in blocked state"
+            >
+              {cancellingRetry ? "…" : "✕ Cancel"}
+            </button>
+          </div>
+          <div className="text-slate-400 break-words" title={reason}>⚠ {reason}</div>
         </div>
         {menuEl}
       </>

--- a/frontend/src/components/WorkspacesPanel.tsx
+++ b/frontend/src/components/WorkspacesPanel.tsx
@@ -123,6 +123,101 @@ function AutoArchiveEditor({ workspace, onSave }: { workspace: types.Workspace; 
   );
 }
 
+// Default retry policy values (mirrors types.DefaultRetryPolicy in Go).
+const DEFAULT_RETRY_MAX_ATTEMPTS = 3;
+const DEFAULT_RETRY_BASE_BACKOFF_S = 10;
+const DEFAULT_RETRY_MAX_BACKOFF_S = 300;
+const DEFAULT_RETRY_JITTER_PCT = 25;
+
+function RetryPolicyEditor({ workspace, onSave }: { workspace: types.Workspace; onSave: () => void }) {
+  const p = (workspace as any).retry_policy;
+  const [maxAttempts, setMaxAttempts] = useState<number>(p?.max_attempts ?? DEFAULT_RETRY_MAX_ATTEMPTS);
+  const [baseBackoffS, setBaseBackoffS] = useState<number>(
+    p?.base_backoff ? Math.round(p.base_backoff / 1_000_000_000) : DEFAULT_RETRY_BASE_BACKOFF_S
+  );
+  const [maxBackoffS, setMaxBackoffS] = useState<number>(
+    p?.max_backoff ? Math.round(p.max_backoff / 1_000_000_000) : DEFAULT_RETRY_MAX_BACKOFF_S
+  );
+  const [jitterPct, setJitterPct] = useState<number>(p?.jitter_pct ?? DEFAULT_RETRY_JITTER_PCT);
+  const [enabled, setEnabled] = useState<boolean>(maxAttempts > 0);
+
+  async function save(nextEnabled: boolean, ma: number, bb: number, mb: number, jp: number) {
+    const policy = nextEnabled
+      ? { max_attempts: ma, base_backoff: bb * 1_000_000_000, max_backoff: mb * 1_000_000_000, jitter_pct: jp }
+      : { max_attempts: 0, base_backoff: 0, max_backoff: 0, jitter_pct: 0 };
+    const updated = types.Workspace.createFrom({ ...workspace, retry_policy: policy });
+    await UpdateWorkspace(updated);
+    onSave();
+  }
+
+  return (
+    <div>
+      <div className="text-xs text-slate-400 mb-2">Auto-retry (transient failures)</div>
+      <div className="flex flex-col gap-2">
+        <label className="flex items-center gap-2 text-xs text-slate-300">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={async (e) => {
+              setEnabled(e.target.checked);
+              await save(e.target.checked, maxAttempts, baseBackoffS, maxBackoffS, jitterPct);
+            }}
+          />
+          Automatically retry rate-limited / crashed sessions
+        </label>
+        {enabled && (
+          <div className="flex flex-col gap-1.5 pl-5 text-xs text-slate-400">
+            <label className="flex items-center gap-2">
+              Max attempts
+              <input
+                {...noAutoCorrect}
+                type="number" min={1} max={10} value={maxAttempts}
+                onChange={(e) => setMaxAttempts(Number(e.target.value))}
+                onBlur={() => save(enabled, maxAttempts, baseBackoffS, maxBackoffS, jitterPct)}
+                className="w-14 bg-slate-800 border border-slate-600 rounded px-1 py-0.5 text-slate-200"
+              />
+              <span className="text-slate-600">(global cap: 10)</span>
+            </label>
+            <label className="flex items-center gap-2">
+              Base backoff
+              <input
+                {...noAutoCorrect}
+                type="number" min={1} max={300} value={baseBackoffS}
+                onChange={(e) => setBaseBackoffS(Number(e.target.value))}
+                onBlur={() => save(enabled, maxAttempts, baseBackoffS, maxBackoffS, jitterPct)}
+                className="w-14 bg-slate-800 border border-slate-600 rounded px-1 py-0.5 text-slate-200"
+              />
+              s
+            </label>
+            <label className="flex items-center gap-2">
+              Max backoff
+              <input
+                {...noAutoCorrect}
+                type="number" min={10} max={3600} value={maxBackoffS}
+                onChange={(e) => setMaxBackoffS(Number(e.target.value))}
+                onBlur={() => save(enabled, maxAttempts, baseBackoffS, maxBackoffS, jitterPct)}
+                className="w-14 bg-slate-800 border border-slate-600 rounded px-1 py-0.5 text-slate-200"
+              />
+              s
+            </label>
+            <label className="flex items-center gap-2">
+              Jitter
+              <input
+                {...noAutoCorrect}
+                type="number" min={0} max={50} value={jitterPct}
+                onChange={(e) => setJitterPct(Number(e.target.value))}
+                onBlur={() => save(enabled, maxAttempts, baseBackoffS, maxBackoffS, jitterPct)}
+                className="w-14 bg-slate-800 border border-slate-600 rounded px-1 py-0.5 text-slate-200"
+              />
+              %
+            </label>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function PoolBindings({ workspaceID }: { workspaceID: string }) {
   const [pools, setPools] = useState<workerpool.PoolStatus[]>([]);
 
@@ -405,6 +500,7 @@ export function WorkspacesPanel() {
                       <PipelineEditor workspace={ws} />
                     </div>
                     <AutoArchiveEditor workspace={ws} onSave={refresh} />
+                    <RetryPolicyEditor workspace={ws} onSave={refresh} />
                     <SigningStrategyEditor workspace={ws} onSave={refresh} />
                     <div>
                       <div className="text-xs text-slate-400 mb-2">Labels</div>

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -4,6 +4,7 @@ import {types} from '../models';
 import {main} from '../models';
 import {diagnose} from '../models';
 import {issueview} from '../models';
+import {retry} from '../models';
 import {githubauth} from '../models';
 import {github} from '../models';
 import {workspace} from '../models';
@@ -26,6 +27,8 @@ export function ApprovePlan(arg1:string,arg2:number,arg3:number):Promise<void>;
 export function ArchiveDone(arg1:string):Promise<number>;
 
 export function AttachManualPR(arg1:string,arg2:number,arg3:string):Promise<void>;
+
+export function CancelRetries(arg1:string,arg2:number):Promise<boolean>;
 
 export function CancelSession(arg1:string):Promise<void>;
 
@@ -78,6 +81,8 @@ export function GetPollInterval():Promise<number>;
 export function GetPoolUsage():Promise<Array<types.PoolUsage>>;
 
 export function GetRepoDefaultBranch(arg1:string,arg2:string,arg3:string):Promise<string>;
+
+export function GetRetryQueue(arg1:string):Promise<Array<retry.PendingRetry>>;
 
 export function GitHubAuthStatus():Promise<githubauth.User>;
 
@@ -192,6 +197,8 @@ export function ResizeAgentTerm(arg1:string,arg2:number,arg3:number):Promise<voi
 export function ResolveConflicts(arg1:string,arg2:number):Promise<void>;
 
 export function RetryExecuteForApprovedPlan(arg1:string,arg2:number):Promise<void>;
+
+export function RetryNow(arg1:string,arg2:number):Promise<boolean>;
 
 export function RotateRemoteWorkerKey(arg1:string,arg2:string):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -34,6 +34,10 @@ export function AttachManualPR(arg1, arg2, arg3) {
   return window['go']['main']['App']['AttachManualPR'](arg1, arg2, arg3);
 }
 
+export function CancelRetries(arg1, arg2) {
+  return window['go']['main']['App']['CancelRetries'](arg1, arg2);
+}
+
 export function CancelSession(arg1) {
   return window['go']['main']['App']['CancelSession'](arg1);
 }
@@ -136,6 +140,10 @@ export function GetPoolUsage() {
 
 export function GetRepoDefaultBranch(arg1, arg2, arg3) {
   return window['go']['main']['App']['GetRepoDefaultBranch'](arg1, arg2, arg3);
+}
+
+export function GetRetryQueue(arg1) {
+  return window['go']['main']['App']['GetRetryQueue'](arg1);
 }
 
 export function GitHubAuthStatus() {
@@ -364,6 +372,10 @@ export function ResolveConflicts(arg1, arg2) {
 
 export function RetryExecuteForApprovedPlan(arg1, arg2) {
   return window['go']['main']['App']['RetryExecuteForApprovedPlan'](arg1, arg2);
+}
+
+export function RetryNow(arg1, arg2) {
+  return window['go']['main']['App']['RetryNow'](arg1, arg2);
 }
 
 export function RotateRemoteWorkerKey(arg1, arg2) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1,23 +1,21 @@
 export namespace cardstate {
 	
-	export class CardStateDetails {
-	    reason?: string;
-	    session_id?: string;
-	    session_mode?: string;
-	    blocked_reason?: string;
-	    failure_cause?: types.FailureCause;
+	export class PendingRetryInfo {
+	    attempt: number;
+	    max_attempts: number;
+	    not_before: number;
+	    last_cause?: types.FailureCause;
 	
 	    static createFrom(source: any = {}) {
-	        return new CardStateDetails(source);
+	        return new PendingRetryInfo(source);
 	    }
 	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.reason = source["reason"];
-	        this.session_id = source["session_id"];
-	        this.session_mode = source["session_mode"];
-	        this.blocked_reason = source["blocked_reason"];
-	        this.failure_cause = this.convertValues(source["failure_cause"], types.FailureCause);
+	        this.attempt = source["attempt"];
+	        this.max_attempts = source["max_attempts"];
+	        this.not_before = source["not_before"];
+	        this.last_cause = this.convertValues(source["last_cause"], types.FailureCause);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -38,6 +36,47 @@ export namespace cardstate {
 		    return a;
 		}
 	}
+	export class CardStateDetails {
+	    reason?: string;
+	    session_id?: string;
+	    session_mode?: string;
+	    blocked_reason?: string;
+	    failure_cause?: types.FailureCause;
+	    retry_info?: PendingRetryInfo;
+	
+	    static createFrom(source: any = {}) {
+	        return new CardStateDetails(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.reason = source["reason"];
+	        this.session_id = source["session_id"];
+	        this.session_mode = source["session_mode"];
+	        this.blocked_reason = source["blocked_reason"];
+	        this.failure_cause = this.convertValues(source["failure_cause"], types.FailureCause);
+	        this.retry_info = this.convertValues(source["retry_info"], PendingRetryInfo);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	
 	export class PlanFailedInfo {
 	    session_id: string;
 	    reason?: string;
@@ -1254,6 +1293,54 @@ export namespace main {
 
 }
 
+export namespace retry {
+	
+	export class PendingRetry {
+	    WorkspaceID: string;
+	    IssueNumber: number;
+	    Attempt: number;
+	    MaxAttempts: number;
+	    // Go type: time
+	    NotBefore: any;
+	    LastCause?: types.FailureCause;
+	    PriorSessionID: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new PendingRetry(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.WorkspaceID = source["WorkspaceID"];
+	        this.IssueNumber = source["IssueNumber"];
+	        this.Attempt = source["Attempt"];
+	        this.MaxAttempts = source["MaxAttempts"];
+	        this.NotBefore = this.convertValues(source["NotBefore"], null);
+	        this.LastCause = this.convertValues(source["LastCause"], types.FailureCause);
+	        this.PriorSessionID = source["PriorSessionID"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+
+}
+
 export namespace store {
 	
 	export class PendingPlan {
@@ -2020,6 +2107,24 @@ export namespace types {
 		}
 	}
 	
+	export class RetryPolicy {
+	    max_attempts: number;
+	    base_backoff: number;
+	    max_backoff: number;
+	    jitter_pct: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new RetryPolicy(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.max_attempts = source["max_attempts"];
+	        this.base_backoff = source["base_backoff"];
+	        this.max_backoff = source["max_backoff"];
+	        this.jitter_pct = source["jitter_pct"];
+	    }
+	}
 	export class Session {
 	    id: string;
 	    workspace_id: string;
@@ -2046,6 +2151,8 @@ export namespace types {
 	    last_stderr_chunk?: string;
 	    branch?: string;
 	    failure_cause?: FailureCause;
+	    retry_attempt?: number;
+	    retry_of_session_id?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new Session(source);
@@ -2076,6 +2183,8 @@ export namespace types {
 	        this.last_stderr_chunk = source["last_stderr_chunk"];
 	        this.branch = source["branch"];
 	        this.failure_cause = this.convertValues(source["failure_cause"], FailureCause);
+	        this.retry_attempt = source["retry_attempt"];
+	        this.retry_of_session_id = source["retry_of_session_id"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -2211,6 +2320,7 @@ export namespace types {
 	    provisioning?: boolean;
 	    // Go type: time
 	    provisioning_at?: any;
+	    retry_policy?: RetryPolicy;
 	
 	    static createFrom(source: any = {}) {
 	        return new Workspace(source);
@@ -2236,6 +2346,7 @@ export namespace types {
 	        this.remote_config = this.convertValues(source["remote_config"], RemoteConfig);
 	        this.provisioning = source["provisioning"];
 	        this.provisioning_at = this.convertValues(source["provisioning_at"], null);
+	        this.retry_policy = this.convertValues(source["retry_policy"], RetryPolicy);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/cardstate/cardstate.go
+++ b/internal/cardstate/cardstate.go
@@ -43,7 +43,19 @@ const (
 	CardStateReview CardState = "review"
 	// CardStateDone — card is in the done column; work has shipped.
 	CardStateDone CardState = "done"
+	// CardStateRetryScheduled — execute failed with a retryable cause; the
+	// scheduler has queued an automatic re-spawn with exponential backoff (#221).
+	CardStateRetryScheduled CardState = "retry_scheduled"
 )
+
+// PendingRetryInfo carries the retry schedule for a card in retry_scheduled
+// state. Populated by the assembler from the in-memory scheduler (#221).
+type PendingRetryInfo struct {
+	Attempt     int                 `json:"attempt"`
+	MaxAttempts int                 `json:"max_attempts"`
+	NotBefore   int64               `json:"not_before"` // unix seconds
+	LastCause   *types.FailureCause `json:"last_cause,omitempty"`
+}
 
 // CardStateDetails carries diagnostic context alongside CardState. Fields are
 // populated only when relevant to the current state; absent fields are nil/zero.
@@ -58,6 +70,8 @@ type CardStateDetails struct {
 	BlockedReason string `json:"blocked_reason,omitempty"`
 	// FailureCause is the structured cause for terminal failed/blocked sessions.
 	FailureCause *types.FailureCause `json:"failure_cause,omitempty"`
+	// RetryInfo is set when the card is in retry_scheduled state (#221).
+	RetryInfo *PendingRetryInfo `json:"retry_info,omitempty"`
 }
 
 // PlanFailedInfo is the minimal representation of a silently-failed plan
@@ -86,6 +100,11 @@ type DeriveParams struct {
 	HasConflicts      bool
 	HasOrphanQuestion bool
 	PlanFailed        *PlanFailedInfo // nil = no silent plan failure
+
+	// PendingRetry is set when the scheduler has queued an auto-retry for this
+	// issue. Non-nil overrides the blocked state so the card shows a countdown
+	// instead of a permanent error badge (#221).
+	PendingRetry *PendingRetryInfo
 }
 
 // DeriveCardState maps DeriveParams to a single CardState + detail blob.
@@ -183,6 +202,16 @@ func DeriveCardState(p DeriveParams) (CardState, CardStateDetails) {
 		return CardStateTestsFailing, CardStateDetails{Reason: "PR check runs are failing"}
 	}
 	if p.LastFailure != nil {
+		// A pending auto-retry overrides the blocked state so the card shows a
+		// countdown instead of a permanent error badge (#221).
+		if p.PendingRetry != nil {
+			return CardStateRetryScheduled, CardStateDetails{
+				SessionID:    p.LastFailure.ID,
+				SessionMode:  string(p.LastFailure.Mode),
+				FailureCause: p.LastFailure.FailureCause,
+				RetryInfo:    p.PendingRetry,
+			}
+		}
 		d := CardStateDetails{
 			SessionID:     p.LastFailure.ID,
 			SessionMode:   string(p.LastFailure.Mode),

--- a/internal/cardstate/retry.go
+++ b/internal/cardstate/retry.go
@@ -1,0 +1,67 @@
+package cardstate
+
+import (
+	"strings"
+
+	"prismconductor/internal/types"
+)
+
+// retryableExitCodes are subprocess exit codes that signal transient termination:
+//
+//	124 = timeout (GNU timeout / ulimit)
+//	130 = SIGINT received by subprocess
+//	137 = SIGKILL (OOM or external kill)
+//	143 = SIGTERM (graceful shutdown)
+var retryableExitCodes = map[int]bool{124: true, 130: true, 137: true, 143: true}
+
+// retryableHarnessKeywords are lower-case substrings in a "blocked" reason that
+// indicate a transient network / rate-limit condition rather than a hard failure.
+var retryableHarnessKeywords = []string{
+	"network",
+	"timeout",
+	"connection refused",
+	"503",
+	"5xx",
+	"rate limit",
+	"temporary",
+	"i/o error",
+}
+
+// IsRetryable returns true when cause represents a transient condition worth
+// automatically retrying. Deterministic failures (lint errors, malformed plans,
+// explicit user cancellations, hard BLOCKED: sentinels) return false.
+func IsRetryable(cause *types.FailureCause) bool {
+	if cause == nil {
+		return false
+	}
+	switch cause.Kind {
+	case "exit_code":
+		// ExitCode == 0 means the field was not populated (legacy path before
+		// manager.go was updated to stamp ExitCode on FailureCause). Treat as
+		// "exit code missing" → retryable per the plan spec.
+		if cause.ExitCode == 0 {
+			return true
+		}
+		return retryableExitCodes[cause.ExitCode]
+	case "signal":
+		// Process killed by OS (SIGKILL) or graceful shutdown (SIGTERM) are
+		// transient. SIGINT usually means the user cancelled — but the signal
+		// string may be "signal: interrupt" which we conservatively allow since
+		// the cancellation could be harness-side, not user-initiated.
+		return strings.Contains(cause.Signal, "killed") ||
+			strings.Contains(cause.Signal, "terminated") ||
+			strings.Contains(cause.Signal, "interrupt")
+	case "blocked":
+		// BLOCKED: from the worker is a hard failure in the general case
+		// (lint error, malformed plan, etc.). Only retry when the reason text
+		// contains clear network / transient indicators.
+		r := strings.ToLower(cause.Reason)
+		for _, kw := range retryableHarnessKeywords {
+			if strings.Contains(r, kw) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}

--- a/internal/cardstate/retry_test.go
+++ b/internal/cardstate/retry_test.go
@@ -1,0 +1,55 @@
+package cardstate
+
+import (
+	"testing"
+
+	"prismconductor/internal/types"
+)
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name  string
+		cause *types.FailureCause
+		want  bool
+	}{
+		{"nil cause", nil, false},
+		{"unknown kind", &types.FailureCause{Kind: "unknown"}, false},
+
+		// exit_code cases
+		{"exit_code zero (legacy missing)", &types.FailureCause{Kind: "exit_code", ExitCode: 0}, true},
+		{"exit_code 124 timeout", &types.FailureCause{Kind: "exit_code", ExitCode: 124}, true},
+		{"exit_code 130 SIGINT", &types.FailureCause{Kind: "exit_code", ExitCode: 130}, true},
+		{"exit_code 137 SIGKILL", &types.FailureCause{Kind: "exit_code", ExitCode: 137}, true},
+		{"exit_code 143 SIGTERM", &types.FailureCause{Kind: "exit_code", ExitCode: 143}, true},
+		{"exit_code 1 generic error", &types.FailureCause{Kind: "exit_code", ExitCode: 1}, false},
+		{"exit_code 2 usage error", &types.FailureCause{Kind: "exit_code", ExitCode: 2}, false},
+
+		// signal cases
+		{"signal killed", &types.FailureCause{Kind: "signal", Signal: "signal: killed"}, true},
+		{"signal terminated", &types.FailureCause{Kind: "signal", Signal: "signal: terminated"}, true},
+		{"signal interrupt", &types.FailureCause{Kind: "signal", Signal: "signal: interrupt"}, true},
+		{"signal SIGBUS hard failure", &types.FailureCause{Kind: "signal", Signal: "signal: bus error"}, false},
+
+		// blocked cases
+		{"blocked network", &types.FailureCause{Kind: "blocked", Reason: "network unreachable"}, true},
+		{"blocked timeout", &types.FailureCause{Kind: "blocked", Reason: "operation timeout"}, true},
+		{"blocked connection refused", &types.FailureCause{Kind: "blocked", Reason: "connection refused by host"}, true},
+		{"blocked 503", &types.FailureCause{Kind: "blocked", Reason: "upstream returned 503"}, true},
+		{"blocked 5xx", &types.FailureCause{Kind: "blocked", Reason: "server error 5xx"}, true},
+		{"blocked rate limit", &types.FailureCause{Kind: "blocked", Reason: "rate limit exceeded"}, true},
+		{"blocked temporary", &types.FailureCause{Kind: "blocked", Reason: "temporary unavailable"}, true},
+		{"blocked i/o error", &types.FailureCause{Kind: "blocked", Reason: "i/o error reading file"}, true},
+		{"blocked keyword case insensitive", &types.FailureCause{Kind: "blocked", Reason: "Network Error"}, true},
+		{"blocked lint error", &types.FailureCause{Kind: "blocked", Reason: "lint failed — go vet exited 1"}, false},
+		{"blocked malformed plan", &types.FailureCause{Kind: "blocked", Reason: "malformed plan JSON"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsRetryable(tt.cause)
+			if got != tt.want {
+				t.Errorf("IsRetryable(%+v) = %v, want %v", tt.cause, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -61,6 +61,12 @@ const (
 
 	// Issue #209: workspace collections (Phase A of #208).
 	EvtCollectionsUpdated EventType = "collections_updated"
+
+	// Issue #221: auto-retry with exponential backoff for transient execute failures.
+	EvtRetryScheduled EventType = "retry_scheduled"
+	EvtRetryFired     EventType = "retry_fired"
+	EvtRetryCancelled EventType = "retry_cancelled"
+	EvtRetryExhausted EventType = "retry_exhausted"
 )
 
 type Event struct {
@@ -180,6 +186,40 @@ type OrphanPRDetected struct {
 type OrphanPRCleared struct {
 	WorkspaceID string `json:"workspace_id"`
 	IssueNumber int    `json:"issue_number"`
+}
+
+// RetryScheduled is the payload for EvtRetryScheduled (#221). Published when
+// the scheduler queues an automatic re-spawn for a transient execute failure.
+type RetryScheduled struct {
+	WorkspaceID string `json:"workspace_id"`
+	IssueNumber int    `json:"issue_number"`
+	Attempt     int    `json:"attempt"`
+	MaxAttempts int    `json:"max_attempts"`
+	NotBefore   int64  `json:"not_before"` // unix seconds
+}
+
+// RetryFired is the payload for EvtRetryFired (#221). Published immediately
+// before the scheduler calls the fire callback.
+type RetryFired struct {
+	WorkspaceID string `json:"workspace_id"`
+	IssueNumber int    `json:"issue_number"`
+	Attempt     int    `json:"attempt"`
+}
+
+// RetryCancelled is the payload for EvtRetryCancelled (#221). Published when
+// a pending retry is cancelled (user action or budget exceeded).
+type RetryCancelled struct {
+	WorkspaceID string `json:"workspace_id"`
+	IssueNumber int    `json:"issue_number"`
+	Reason      string `json:"reason,omitempty"` // "user" | "budget" | "policy"
+}
+
+// RetryExhausted is the payload for EvtRetryExhausted (#221). Published when
+// all attempts have been consumed and the card should show a permanent error.
+type RetryExhausted struct {
+	WorkspaceID string `json:"workspace_id"`
+	IssueNumber int    `json:"issue_number"`
+	Attempts    int    `json:"attempts"`
 }
 
 type Handler func(Event)

--- a/internal/issueview/assembler.go
+++ b/internal/issueview/assembler.go
@@ -32,6 +32,15 @@ type conflictEntry struct {
 	info eventbus.PRConflictsDetected
 }
 
+// retryEntry is the in-memory pending-retry state the Assembler keeps per
+// issue. Set on EvtRetryScheduled, cleared on EvtRetryFired / EvtRetryCancelled
+// / EvtRetryExhausted / new execute session start (#221).
+type retryEntry struct {
+	attempt     int
+	maxAttempts int
+	notBefore   int64 // unix seconds
+}
+
 // issueStore is the subset of *store.Store that the Assembler needs.
 type issueStore interface {
 	LoadIssue(workspaceID string, number int) (types.Issue, error)
@@ -53,6 +62,7 @@ type Assembler struct {
 	checkFails    map[string]*checkFailEntry  // "wsID#num" → latest check failure
 	conflictFails map[string]*conflictEntry   // "wsID#num" → latest conflict state
 	orphanPRs     map[string]string           // "wsID#num" → branch name (#194)
+	pendingRetries map[string]*retryEntry     // "wsID#num" → pending retry (#221)
 
 	// repoPathFn resolves a workspace ID to its local repo path. When set,
 	// Assemble probes the questions directory to detect orphan question files
@@ -63,12 +73,13 @@ type Assembler struct {
 // New wires the Assembler to the bus. Call once at startup after the store is ready.
 func New(bus *eventbus.Bus, st issueStore) *Assembler {
 	a := &Assembler{
-		store:         st,
-		bus:           bus,
-		cache:         make(map[string]string),
-		checkFails:    make(map[string]*checkFailEntry),
-		conflictFails: make(map[string]*conflictEntry),
-		orphanPRs:     make(map[string]string),
+		store:          st,
+		bus:            bus,
+		cache:          make(map[string]string),
+		checkFails:     make(map[string]*checkFailEntry),
+		conflictFails:  make(map[string]*conflictEntry),
+		orphanPRs:      make(map[string]string),
+		pendingRetries: make(map[string]*retryEntry),
 	}
 	bus.Subscribe(a.handleEvent)
 	return a
@@ -98,6 +109,11 @@ var issueRelevantEvents = map[eventbus.EventType]bool{
 	eventbus.EvtPRCommentReceived: true,
 	eventbus.EvtOrphanPRDetected:  true,
 	eventbus.EvtOrphanPRCleared:   true,
+	// Issue #221: auto-retry schedule changes affect the card state.
+	eventbus.EvtRetryScheduled:  true,
+	eventbus.EvtRetryFired:      true,
+	eventbus.EvtRetryCancelled:  true,
+	eventbus.EvtRetryExhausted:  true,
 }
 
 func (a *Assembler) handleEvent(e eventbus.Event) {
@@ -160,6 +176,26 @@ func (a *Assembler) handleEvent(e eventbus.Event) {
 			delete(a.orphanPRs, key)
 			a.mu.Unlock()
 		}
+
+	// Issue #221: keep pending-retry state in sync with the scheduler.
+	case eventbus.EvtRetryScheduled:
+		if p, ok := e.Payload.(eventbus.RetryScheduled); ok {
+			key := p.WorkspaceID + "#" + strconv.Itoa(p.IssueNumber)
+			a.mu.Lock()
+			a.pendingRetries[key] = &retryEntry{
+				attempt:     p.Attempt,
+				maxAttempts: p.MaxAttempts,
+				notBefore:   p.NotBefore,
+			}
+			a.mu.Unlock()
+		}
+	case eventbus.EvtRetryFired, eventbus.EvtRetryCancelled, eventbus.EvtRetryExhausted:
+		if wsID != "" && issueNum != 0 {
+			key := wsID + "#" + strconv.Itoa(issueNum)
+			a.mu.Lock()
+			delete(a.pendingRetries, key)
+			a.mu.Unlock()
+		}
 	}
 	// Session-state changes are LOAD-BEARING for the frontend's glow ladder
 	// (running execute → purple, blocked → red, etc). The cache-diff gate
@@ -180,7 +216,13 @@ func (a *Assembler) handleEvent(e eventbus.Event) {
 		eventbus.EvtPRMerged,
 		eventbus.EvtPRClosedUnmerged,
 		eventbus.EvtOrphanPRDetected,
-		eventbus.EvtOrphanPRCleared:
+		eventbus.EvtOrphanPRCleared,
+		// Retry state changes must force-emit so the countdown appears/clears
+		// immediately without waiting for the cache-diff gate (#221).
+		eventbus.EvtRetryScheduled,
+		eventbus.EvtRetryFired,
+		eventbus.EvtRetryCancelled,
+		eventbus.EvtRetryExhausted:
 		a.reassembleAndForceEmit(wsID, issueNum)
 		return
 	}
@@ -316,6 +358,7 @@ func (a *Assembler) Assemble(workspaceID string, issueNumber int) (IssueView, er
 	a.mu.Lock()
 	cfEntry := a.checkFails[key]
 	conflEntry := a.conflictFails[key]
+	retryEnt := a.pendingRetries[key]
 	a.mu.Unlock()
 
 	var testsFailingInfo *TestsFailingInfo
@@ -388,6 +431,15 @@ func (a *Assembler) Assemble(workspaceID string, issueNumber int) (IssueView, er
 	// Derive the single authoritative CardState and its companion details (#30).
 	// Additive: emitted alongside the existing per-field view so the frontend
 	// can fall back to its own derivation until the Phase 2 cutover.
+	var pendingRetry *cardstate.PendingRetryInfo
+	if retryEnt != nil {
+		pendingRetry = &cardstate.PendingRetryInfo{
+			Attempt:     retryEnt.attempt,
+			MaxAttempts: retryEnt.maxAttempts,
+			NotBefore:   retryEnt.notBefore,
+		}
+	}
+
 	cs, csDetails := cardstate.DeriveCardState(cardstate.DeriveParams{
 		Column:            derivedColumn(iss, plan, active, lastFail),
 		PRNumber:          iss.PRNumber,
@@ -401,6 +453,7 @@ func (a *Assembler) Assemble(workspaceID string, issueNumber int) (IssueView, er
 		HasConflicts:      conflictsInfo != nil,
 		HasOrphanQuestion: orphanQuestion != nil,
 		PlanFailed:        planFailed,
+		PendingRetry:      pendingRetry,
 	})
 	var csDetailsPtr *cardstate.CardStateDetails
 	if cs != cardstate.CardStateTodo && cs != cardstate.CardStateDone {
@@ -681,6 +734,14 @@ func extractIssueKey(e eventbus.Event) (wsID string, issueNum int) {
 	case eventbus.NeedsPREvent:
 		return p.WorkspaceID, p.IssueNumber
 	case eventbus.PRCommentReceived:
+		return p.WorkspaceID, p.IssueNumber
+	case eventbus.RetryScheduled:
+		return p.WorkspaceID, p.IssueNumber
+	case eventbus.RetryFired:
+		return p.WorkspaceID, p.IssueNumber
+	case eventbus.RetryCancelled:
+		return p.WorkspaceID, p.IssueNumber
+	case eventbus.RetryExhausted:
 		return p.WorkspaceID, p.IssueNumber
 	case map[string]any:
 		wsID, _ = p["workspace_id"].(string)

--- a/internal/retry/persistence.go
+++ b/internal/retry/persistence.go
@@ -1,0 +1,5 @@
+package retry
+
+// Phase 2 persistence lives here: loading and saving the retry_queue table so
+// pending retries survive conductor restarts. Not implemented in Phase 1 (the
+// in-memory queue in Scheduler is lost on restart).

--- a/internal/retry/scheduler.go
+++ b/internal/retry/scheduler.go
@@ -1,0 +1,268 @@
+// Package retry implements the automatic-retry scheduler for transient execute
+// session failures (issue #221, Phase 1: in-memory queue, lost on restart).
+package retry
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"sync"
+	"time"
+
+	"prismconductor/internal/cardstate"
+	"prismconductor/internal/eventbus"
+	"prismconductor/internal/types"
+)
+
+// FireFunc is called by the Scheduler when a retry is due. The implementation
+// in app.go re-spawns the execute session using the existing approved plan.
+type FireFunc func(workspaceID string, issueNumber int, attempt int, priorSessionID string)
+
+// PendingRetry is the scheduler's in-memory record for one queued retry.
+type PendingRetry struct {
+	WorkspaceID    string
+	IssueNumber    int
+	Attempt        int
+	MaxAttempts    int
+	NotBefore      time.Time
+	LastCause      *types.FailureCause
+	PriorSessionID string
+}
+
+// Scheduler maintains an in-memory queue of pending retries and fires them
+// after their NotBefore time elapses. Safe for concurrent use.
+type Scheduler struct {
+	mu      sync.Mutex
+	pending map[string]*PendingRetry // key: "wsID#issueNum"
+	bus     *eventbus.Bus
+	fire    FireFunc
+	stop    chan struct{}
+}
+
+// NewScheduler creates a Scheduler and starts the background tick goroutine.
+// Call Stop() to shut it down cleanly.
+func NewScheduler(bus *eventbus.Bus, fire FireFunc) *Scheduler {
+	s := &Scheduler{
+		pending: make(map[string]*PendingRetry),
+		bus:     bus,
+		fire:    fire,
+		stop:    make(chan struct{}),
+	}
+	go s.run()
+	return s
+}
+
+// Schedule enqueues an automatic retry for a failed execute session. Returns
+// false (no-op) when the cause is not retryable, the cap is reached, or a
+// retry is already pending for this issue.
+func (s *Scheduler) Schedule(ws types.Workspace, sess types.Session, cause *types.FailureCause) bool {
+	if !cardstate.IsRetryable(cause) {
+		return false
+	}
+	policy := effectivePolicy(ws)
+	if policy.MaxAttempts == 0 {
+		return false
+	}
+
+	nextAttempt := sess.RetryAttempt + 1
+	maxAllowed := policy.MaxAttempts
+	if maxAllowed > types.GlobalRetryMaxAttempts {
+		maxAllowed = types.GlobalRetryMaxAttempts
+	}
+	if nextAttempt > maxAllowed {
+		s.bus.Publish(eventbus.EvtRetryExhausted, eventbus.RetryExhausted{
+			WorkspaceID: ws.ID,
+			IssueNumber: sess.IssueNumber,
+			Attempts:    sess.RetryAttempt,
+		})
+		return false
+	}
+
+	delay := backoffWithJitter(nextAttempt, policy)
+	if delay > types.GlobalRetryMaxWindow {
+		s.bus.Publish(eventbus.EvtRetryExhausted, eventbus.RetryExhausted{
+			WorkspaceID: ws.ID,
+			IssueNumber: sess.IssueNumber,
+			Attempts:    sess.RetryAttempt,
+		})
+		return false
+	}
+
+	notBefore := time.Now().Add(delay)
+	key := issueKey(ws.ID, sess.IssueNumber)
+
+	s.mu.Lock()
+	if _, exists := s.pending[key]; exists {
+		s.mu.Unlock()
+		return false // already queued
+	}
+	p := &PendingRetry{
+		WorkspaceID:    ws.ID,
+		IssueNumber:    sess.IssueNumber,
+		Attempt:        nextAttempt,
+		MaxAttempts:    maxAllowed,
+		NotBefore:      notBefore,
+		LastCause:      cause,
+		PriorSessionID: sess.ID,
+	}
+	s.pending[key] = p
+	s.mu.Unlock()
+
+	log.Printf("retry: scheduled attempt %d/%d for #%d in %s (cause: %s)",
+		nextAttempt, maxAllowed, sess.IssueNumber, delay.Round(time.Second), cause.Kind)
+
+	s.bus.Publish(eventbus.EvtRetryScheduled, eventbus.RetryScheduled{
+		WorkspaceID: ws.ID,
+		IssueNumber: sess.IssueNumber,
+		Attempt:     nextAttempt,
+		MaxAttempts: maxAllowed,
+		NotBefore:   notBefore.Unix(),
+	})
+	return true
+}
+
+// Cancel removes a pending retry for the given issue without firing it.
+// Returns true if a retry was present and cancelled.
+func (s *Scheduler) Cancel(workspaceID string, issueNumber int) bool {
+	key := issueKey(workspaceID, issueNumber)
+	s.mu.Lock()
+	_, existed := s.pending[key]
+	delete(s.pending, key)
+	s.mu.Unlock()
+	if existed {
+		s.bus.Publish(eventbus.EvtRetryCancelled, eventbus.RetryCancelled{
+			WorkspaceID: workspaceID,
+			IssueNumber: issueNumber,
+			Reason:      "user",
+		})
+	}
+	return existed
+}
+
+// FireNow fires the pending retry immediately, ignoring the NotBefore time.
+// Returns true if a retry was present and dispatched.
+func (s *Scheduler) FireNow(workspaceID string, issueNumber int) bool {
+	key := issueKey(workspaceID, issueNumber)
+	s.mu.Lock()
+	p, exists := s.pending[key]
+	if exists {
+		delete(s.pending, key)
+	}
+	s.mu.Unlock()
+	if !exists {
+		return false
+	}
+	s.dispatch(p)
+	return true
+}
+
+// List returns a snapshot of the pending retries for a workspace.
+func (s *Scheduler) List(workspaceID string) []PendingRetry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []PendingRetry
+	for _, p := range s.pending {
+		if p.WorkspaceID == workspaceID {
+			out = append(out, *p)
+		}
+	}
+	return out
+}
+
+// PendingRetryInfoFor returns a *cardstate.PendingRetryInfo for a specific
+// issue, or nil if no retry is queued for it.
+func (s *Scheduler) PendingRetryInfoFor(workspaceID string, issueNumber int) *cardstate.PendingRetryInfo {
+	key := issueKey(workspaceID, issueNumber)
+	s.mu.Lock()
+	p := s.pending[key]
+	s.mu.Unlock()
+	if p == nil {
+		return nil
+	}
+	return &cardstate.PendingRetryInfo{
+		Attempt:     p.Attempt,
+		MaxAttempts: p.MaxAttempts,
+		NotBefore:   p.NotBefore.Unix(),
+		LastCause:   p.LastCause,
+	}
+}
+
+// Stop terminates the background tick goroutine.
+func (s *Scheduler) Stop() {
+	close(s.stop)
+}
+
+// run is the background goroutine that checks for due retries every second.
+func (s *Scheduler) run() {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.stop:
+			return
+		case now := <-ticker.C:
+			s.tick(now)
+		}
+	}
+}
+
+func (s *Scheduler) tick(now time.Time) {
+	s.mu.Lock()
+	var due []*PendingRetry
+	for key, p := range s.pending {
+		if !now.Before(p.NotBefore) {
+			due = append(due, p)
+			delete(s.pending, key)
+		}
+	}
+	s.mu.Unlock()
+	for _, p := range due {
+		s.dispatch(p)
+	}
+}
+
+func (s *Scheduler) dispatch(p *PendingRetry) {
+	log.Printf("retry: firing attempt %d/%d for #%d", p.Attempt, p.MaxAttempts, p.IssueNumber)
+	s.bus.Publish(eventbus.EvtRetryFired, eventbus.RetryFired{
+		WorkspaceID: p.WorkspaceID,
+		IssueNumber: p.IssueNumber,
+		Attempt:     p.Attempt,
+	})
+	go s.fire(p.WorkspaceID, p.IssueNumber, p.Attempt, p.PriorSessionID)
+}
+
+// backoffWithJitter computes the delay for attempt n: base * 2^(n-1), capped
+// at MaxBackoff, then applies symmetric ±JitterPct% jitter.
+func backoffWithJitter(attempt int, policy types.RetryPolicy) time.Duration {
+	if attempt <= 0 {
+		attempt = 1
+	}
+	shift := attempt - 1
+	if shift > 30 {
+		shift = 30
+	}
+	d := policy.BaseBackoff * (1 << uint(shift))
+	if d > policy.MaxBackoff || d < 0 {
+		d = policy.MaxBackoff
+	}
+	if policy.JitterPct > 0 {
+		jitterRange := float64(d) * float64(policy.JitterPct) / 100.0
+		jitter := (rand.Float64()*2 - 1) * jitterRange //nolint:gosec
+		d = time.Duration(float64(d) + jitter)
+		if d < 0 {
+			d = 0
+		}
+	}
+	return d
+}
+
+func effectivePolicy(ws types.Workspace) types.RetryPolicy {
+	if ws.RetryPolicy != nil {
+		return *ws.RetryPolicy
+	}
+	return types.DefaultRetryPolicy
+}
+
+func issueKey(workspaceID string, issueNumber int) string {
+	return fmt.Sprintf("%s#%d", workspaceID, issueNumber)
+}

--- a/internal/retry/scheduler_test.go
+++ b/internal/retry/scheduler_test.go
@@ -1,0 +1,105 @@
+package retry
+
+import (
+	"testing"
+	"time"
+
+	"prismconductor/internal/types"
+)
+
+func TestBackoffWithJitter(t *testing.T) {
+	policy := types.RetryPolicy{
+		MaxAttempts: 3,
+		BaseBackoff: 10 * time.Second,
+		MaxBackoff:  5 * time.Minute,
+		JitterPct:   0, // no jitter for deterministic tests
+	}
+
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, 10 * time.Second},
+		{2, 20 * time.Second},
+		{3, 40 * time.Second},
+		{4, 80 * time.Second},
+	}
+
+	for _, tt := range tests {
+		got := backoffWithJitter(tt.attempt, policy)
+		if got != tt.want {
+			t.Errorf("backoffWithJitter(%d, ...) = %v, want %v", tt.attempt, got, tt.want)
+		}
+	}
+}
+
+func TestBackoffWithJitterCapsAtMax(t *testing.T) {
+	policy := types.RetryPolicy{
+		MaxAttempts: 10,
+		BaseBackoff: 10 * time.Second,
+		MaxBackoff:  60 * time.Second,
+		JitterPct:   0,
+	}
+	// attempt 4 would be 80s without cap; must be clamped to 60s
+	got := backoffWithJitter(4, policy)
+	if got != 60*time.Second {
+		t.Errorf("expected max cap 60s, got %v", got)
+	}
+}
+
+func TestBackoffWithJitterAttemptZeroTreatedAsOne(t *testing.T) {
+	policy := types.RetryPolicy{
+		MaxAttempts: 3,
+		BaseBackoff: 10 * time.Second,
+		MaxBackoff:  5 * time.Minute,
+		JitterPct:   0,
+	}
+	got0 := backoffWithJitter(0, policy)
+	got1 := backoffWithJitter(1, policy)
+	if got0 != got1 {
+		t.Errorf("attempt 0 should equal attempt 1: got0=%v got1=%v", got0, got1)
+	}
+}
+
+func TestBackoffWithJitterAppliesJitter(t *testing.T) {
+	policy := types.RetryPolicy{
+		MaxAttempts: 3,
+		BaseBackoff: 10 * time.Second,
+		MaxBackoff:  5 * time.Minute,
+		JitterPct:   25,
+	}
+	base := 10 * time.Second
+	minExpected := time.Duration(float64(base) * 0.75)
+	maxExpected := time.Duration(float64(base) * 1.25)
+
+	// Run several times to verify the jitter stays in range.
+	for i := 0; i < 50; i++ {
+		got := backoffWithJitter(1, policy)
+		if got < minExpected || got > maxExpected {
+			t.Errorf("jittered backoff %v outside [%v, %v]", got, minExpected, maxExpected)
+		}
+	}
+}
+
+func TestIssueKey(t *testing.T) {
+	if got := issueKey("ws-1", 42); got != "ws-1#42" {
+		t.Errorf("issueKey = %q, want %q", got, "ws-1#42")
+	}
+}
+
+func TestEffectivePolicyFallsBackToDefault(t *testing.T) {
+	ws := types.Workspace{}
+	p := effectivePolicy(ws)
+	if p.MaxAttempts != types.DefaultRetryPolicy.MaxAttempts {
+		t.Errorf("expected default MaxAttempts %d, got %d", types.DefaultRetryPolicy.MaxAttempts, p.MaxAttempts)
+	}
+}
+
+func TestEffectivePolicyUsesWorkspaceOverride(t *testing.T) {
+	custom := types.RetryPolicy{MaxAttempts: 7}
+	ws := types.Workspace{RetryPolicy: &custom}
+	p := effectivePolicy(ws)
+	if p.MaxAttempts != 7 {
+		t.Errorf("expected workspace MaxAttempts 7, got %d", p.MaxAttempts)
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1086,6 +1086,15 @@ func (m *Manager) tailAndParse(ctx context.Context, rs *runtimeSession) {
 		if waitErr != nil {
 			cause.Reason = waitErr.Error()
 		}
+		// Populate exit diagnostics on FailureCause so the retry classifier can
+		// inspect the exit code without needing access to the full Session (#221).
+		if rs.sess.ExitCode != nil {
+			cause.ExitCode = *rs.sess.ExitCode
+		}
+		if rs.sess.Signal != "" {
+			cause.Signal = rs.sess.Signal
+			cause.Kind = "signal"
+		}
 		rs.sess.FailureCause = cause
 	}
 	end := time.Now()

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -91,6 +91,10 @@ type Workspace struct {
 	// than ~10 minutes are cleaned up by the startup reconciler (issue #192).
 	Provisioning   bool       `json:"provisioning,omitempty"`
 	ProvisioningAt *time.Time `json:"provisioning_at,omitempty"`
+
+	// RetryPolicy configures auto-retry behaviour for execute sessions in this
+	// workspace. Nil means use DefaultRetryPolicy (#221).
+	RetryPolicy *RetryPolicy `json:"retry_policy,omitempty"`
 }
 
 // WorkspacePipeline is the per-workspace pipeline configuration (issue #146).
@@ -483,6 +487,29 @@ type FailureCause struct {
 	Signal   string `json:"signal,omitempty"`
 }
 
+// RetryPolicy configures the automatic-retry behaviour for execute sessions
+// (issue #221). A nil workspace RetryPolicy falls back to DefaultRetryPolicy.
+type RetryPolicy struct {
+	MaxAttempts int           `json:"max_attempts"`
+	BaseBackoff time.Duration `json:"base_backoff"`
+	MaxBackoff  time.Duration `json:"max_backoff"`
+	JitterPct   int           `json:"jitter_pct"`
+}
+
+// DefaultRetryPolicy is the conservative retry policy used when a workspace
+// has no explicit policy configured.
+var DefaultRetryPolicy = RetryPolicy{
+	MaxAttempts: 3,
+	BaseBackoff: 10 * time.Second,
+	MaxBackoff:  5 * time.Minute,
+	JitterPct:   25,
+}
+
+// GlobalRetryMaxAttempts and GlobalRetryMaxWindow are hard caps that override
+// any workspace-level policy (issue #221).
+const GlobalRetryMaxAttempts = 10
+const GlobalRetryMaxWindow = time.Hour
+
 // --- Session (§6.5) ---
 
 type Session struct {
@@ -541,6 +568,13 @@ type Session struct {
 	// FailureCause is set when the session reaches a terminal failed/blocked
 	// state. Nil for completed, paused, and needs_pr sessions (#30).
 	FailureCause *FailureCause `json:"failure_cause,omitempty"`
+
+	// RetryAttempt is the 1-based retry index when this session was spawned
+	// automatically by the retry scheduler. 0 for first-attempt sessions (#221).
+	RetryAttempt int `json:"retry_attempt,omitempty"`
+	// RetryOfSessionID is the ID of the session whose transient failure triggered
+	// this session. Empty for first-attempt sessions (#221).
+	RetryOfSessionID string `json:"retry_of_session_id,omitempty"`
 }
 
 // MidRunAnswer is the §6.4-shaped answer payload for a mid-run question

--- a/migrations/20260506_add_retry_queue.sql
+++ b/migrations/20260506_add_retry_queue.sql
@@ -1,0 +1,4 @@
+-- Issue #221 Phase 1: persist retry metadata on execute sessions so retried
+-- sessions are identifiable in the session log and cost rollups.
+ALTER TABLE sessions ADD COLUMN retry_attempt INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN retry_of_session_id TEXT DEFAULT NULL;


### PR DESCRIPTION
## Summary

- Adds a Phase 1 in-memory auto-retry scheduler that automatically re-queues execute sessions that fail with transient causes (SIGKILL/SIGTERM, timeout exit codes 124/130/137/143, network/503 `BLOCKED:` reasons).
- Adds a `RetryPolicyEditor` in workspace settings so users can tune max attempts and backoff parameters per workspace.
- Cards show a new `retry_scheduled` state with a live countdown, attempt badge, and manual "↺ Now" / "✕ Cancel" actions.

## Files modified

- `internal/types/types.go` — `RetryPolicy`, `DefaultRetryPolicy`, `GlobalRetryMaxAttempts/Window`, `Session.RetryAttempt/RetryOfSessionID`, `Workspace.RetryPolicy`
- `internal/cardstate/retry.go` *(new)* — `IsRetryable` classifier
- `internal/cardstate/retry_test.go` *(new)* — classifier unit tests
- `internal/cardstate/cardstate.go` — `CardStateRetryScheduled`, `PendingRetryInfo`, `DeriveParams.PendingRetry`
- `internal/eventbus/bus.go` — `EvtRetryScheduled/Fired/Cancelled/Exhausted` event types + payloads
- `internal/retry/scheduler.go` *(new)* — `Scheduler`, `PendingRetry`, `backoffWithJitter`
- `internal/retry/scheduler_test.go` *(new)* — backoff + policy unit tests
- `internal/retry/persistence.go` *(new)* — Phase 2 stub
- `internal/session/manager.go` — populate `ExitCode`/`Signal` on `FailureCause`
- `internal/issueview/assembler.go` — track pending retries via bus events → `DeriveParams`
- `app.go` — wire scheduler, `CancelRetries`/`RetryNow`/`GetRetryQueue` Wails methods
- `frontend/wailsjs/go/main/App.js` + `App.d.ts` — auto-regenerated bindings
- `frontend/wailsjs/go/models.ts` — auto-regenerated models
- `frontend/src/components/Card.tsx` — `retry_scheduled` UI
- `frontend/src/components/WorkspacesPanel.tsx` — `RetryPolicyEditor` settings section
- `migrations/20260506_add_retry_queue.sql` — `retry_attempt`, `retry_of_session_id` columns

## Verification

| Gate | Command | Result |
|------|---------|--------|
| Lint (Go) | `go vet ./...` | ✅ pass |
| Lint (TS) | `cd frontend && npx tsc --noEmit` | ✅ pass (no errors in changed files) |
| Build | `wails build` | ✅ pass (12s) |
| Smoke | `playwright test tests/e2e/startup.spec.ts` | ✅ pass (1/1, no console errors) |
| Tests | `go test ./...` | ✅ pass (33 packages) |

Commit tier: **Tier 1** (GitHub API `createCommitOnBranch`, signed by GitHub).

Workspace mode: per-execute worktree at `/Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-221`

Closes #221