### PR TITLE
feat(eventbus): observable Wails event bridge with dev diagnostics (#228)

### DIFF
--- a/app.go
+++ b/app.go
@@ -45,6 +45,7 @@ import (
 	"prismconductor/internal/skills/bundle"
 	"prismconductor/internal/store"
 	"prismconductor/internal/types"
+	"prismconductor/internal/wailsbus"
 	"prismconductor/internal/workerpool"
 	"prismconductor/internal/workspace"
 )
@@ -135,7 +136,7 @@ func (a *App) startup(ctx context.Context) {
 			}
 		}
 		if a.ctx != nil {
-			wruntime.EventsEmit(a.ctx, "pool.usage_updated", nil)
+			wailsbus.EmitEvent(a.ctx, "pool.usage_updated", nil)
 		}
 	}
 
@@ -220,7 +221,7 @@ func (a *App) startup(ctx context.Context) {
 	a.mgr.SetOnPROpened(a.handlePROpened)
 	a.mgr.SetOnNeedsPR(a.handleNeedsPR)
 	a.mgr.SetOnActivity(func(act types.SessionActivity) {
-		wruntime.EventsEmit(a.ctx, "session.activity", act)
+		wailsbus.EmitEvent(a.ctx, "session.activity", act)
 	})
 	a.mgr.SetOnRateLimit(rateLimitSink)
 
@@ -287,7 +288,7 @@ func (a *App) startup(ctx context.Context) {
 		// Persist every event for debugging + Phase 7 transcript pattern detector.
 		a.bus.Subscribe(func(e eventbus.Event) {
 			_ = a.store.LogEvent(string(e.Type), e.Payload)
-			wruntime.EventsEmit(a.ctx, "bus."+string(e.Type), e.Payload)
+			wailsbus.EmitEvent(a.ctx, "bus."+string(e.Type), e.Payload)
 			a.notifyOnPRStateChange(e)
 		})
 
@@ -450,7 +451,7 @@ func (a *App) startup(ctx context.Context) {
 // handleSessionStateChange runs on every session state transition. Fans the
 // new state to the UI as a Wails event and fires an in-app toast per §15.6.
 func (a *App) handleSessionStateChange(sess types.Session, prev types.SessionState) {
-	wruntime.EventsEmit(a.ctx, "session.state", sess)
+	wailsbus.EmitEvent(a.ctx, "session.state", sess)
 	a.bus.Publish(eventbus.EvtSessionStateChanged, eventbus.SessionStateChanged{
 		WorkspaceID: sess.WorkspaceID,
 		IssueNumber: sess.IssueNumber,
@@ -645,7 +646,7 @@ func nowUnix() int64 {
 
 // emitLine fans PTY output out as a Wails event for the frontend SessionDrawer.
 func (a *App) emitLine(sessionID, line string) {
-	wruntime.EventsEmit(a.ctx, "session.line", map[string]string{
+	wailsbus.EmitEvent(a.ctx, "session.line", map[string]string{
 		"session_id": sessionID,
 		"line":       line,
 	})
@@ -668,7 +669,7 @@ func (a *App) emitToast(level, title, body string, payload map[string]any) {
 	for k, v := range payload {
 		msg[k] = v
 	}
-	wruntime.EventsEmit(a.ctx, "toast", msg)
+	wailsbus.EmitEvent(a.ctx, "toast", msg)
 }
 
 // gcWorktreesAll prunes orphan worktree records and removes any
@@ -859,7 +860,7 @@ func (a *App) CreateCollection(name string) (types.Collection, error) {
 		a.bus.Publish(eventbus.EvtCollectionsUpdated, nil)
 	}
 	if a.ctx != nil {
-		wruntime.EventsEmit(a.ctx, "collections.updated", nil)
+		wailsbus.EmitEvent(a.ctx, "collections.updated", nil)
 	}
 	return col, nil
 }
@@ -876,7 +877,7 @@ func (a *App) RenameCollection(id, name string) error {
 		a.bus.Publish(eventbus.EvtCollectionsUpdated, nil)
 	}
 	if a.ctx != nil {
-		wruntime.EventsEmit(a.ctx, "collections.updated", nil)
+		wailsbus.EmitEvent(a.ctx, "collections.updated", nil)
 	}
 	return nil
 }
@@ -893,7 +894,7 @@ func (a *App) DeleteCollection(id string) error {
 		a.bus.Publish(eventbus.EvtCollectionsUpdated, nil)
 	}
 	if a.ctx != nil {
-		wruntime.EventsEmit(a.ctx, "collections.updated", nil)
+		wailsbus.EmitEvent(a.ctx, "collections.updated", nil)
 	}
 	return nil
 }
@@ -910,7 +911,7 @@ func (a *App) AddWorkspaceToCollection(collectionID, workspaceID string) error {
 		a.bus.Publish(eventbus.EvtCollectionsUpdated, nil)
 	}
 	if a.ctx != nil {
-		wruntime.EventsEmit(a.ctx, "collections.updated", nil)
+		wailsbus.EmitEvent(a.ctx, "collections.updated", nil)
 	}
 	return nil
 }
@@ -927,7 +928,7 @@ func (a *App) RemoveWorkspaceFromCollection(collectionID, workspaceID string) er
 		a.bus.Publish(eventbus.EvtCollectionsUpdated, nil)
 	}
 	if a.ctx != nil {
-		wruntime.EventsEmit(a.ctx, "collections.updated", nil)
+		wailsbus.EmitEvent(a.ctx, "collections.updated", nil)
 	}
 	return nil
 }
@@ -944,7 +945,7 @@ func (a *App) UpdateCollectionContext(collectionID, body string) error {
 		a.bus.Publish(eventbus.EvtCollectionsUpdated, nil)
 	}
 	if a.ctx != nil {
-		wruntime.EventsEmit(a.ctx, "collections.updated", nil)
+		wailsbus.EmitEvent(a.ctx, "collections.updated", nil)
 	}
 	return nil
 }
@@ -1635,7 +1636,7 @@ func (a *App) MoveIssueColumn(workspaceID string, number int, column string) err
 		if sess, err := a.store.AcknowledgeLatestFailure(workspaceID, number); err != nil {
 			log.Printf("MoveIssueColumn: acknowledge failure for #%d: %v", number, err)
 		} else if sess != nil {
-			wruntime.EventsEmit(a.ctx, "session.state", *sess)
+			wailsbus.EmitEvent(a.ctx, "session.state", *sess)
 			log.Printf("MoveIssueColumn: acknowledged blocked session %s for #%d on move to %s", sess.ID[:8], number, column)
 		}
 	}
@@ -1734,7 +1735,7 @@ func (a *App) ClearIssueFailure(workspaceID string, issueNumber int) error {
 		})
 	}
 	if sess != nil {
-		wruntime.EventsEmit(a.ctx, "session.state", *sess)
+		wailsbus.EmitEvent(a.ctx, "session.state", *sess)
 		// Publish to the in-process bus too so the IssueView assembler
 		// reassembles and emits a fresh bus.issue_view_updated. Without
 		// this, the assembler keeps surfacing the now-acknowledged session
@@ -1801,7 +1802,7 @@ func (a *App) OpenOrphanPR(workspaceID string, issueNumber int) error {
 			"pr_url":       prURL,
 		})
 	}
-	wruntime.EventsEmit(a.ctx, "pr.opened", map[string]any{
+	wailsbus.EmitEvent(a.ctx, "pr.opened", map[string]any{
 		"workspace_id": workspaceID,
 		"issue_number": issueNumber,
 		"pr_number":    prNum,
@@ -3035,7 +3036,7 @@ func (a *App) handleMidRunAnswerArrived(ps store.PausedSession) {
 		// store refreshes the OLD row's state from `paused_for_question` to
 		// `completed`. Without this, the Card's pausedSession selector keeps
 		// the orange overlay until the next Wails reload.
-		wruntime.EventsEmit(a.ctx, "session.state", types.Session{
+		wailsbus.EmitEvent(a.ctx, "session.state", types.Session{
 			ID:          ps.SessionID,
 			WorkspaceID: ps.WorkspaceID,
 			IssueNumber: ps.IssueNumber,
@@ -3084,7 +3085,7 @@ func (a *App) handleOrphanQuestion(ps store.PausedSession) {
 		})
 	}
 	if a.ctx != nil {
-		wruntime.EventsEmit(a.ctx, "session.state", *sess)
+		wailsbus.EmitEvent(a.ctx, "session.state", *sess)
 	}
 	if a.bus != nil {
 		a.bus.Publish(eventbus.EvtSessionStateChanged, eventbus.SessionStateChanged{
@@ -3127,7 +3128,7 @@ func (a *App) RecoverOrphanQuestion(workspaceID string, issueNumber int) error {
 		})
 	}
 	if a.ctx != nil {
-		wruntime.EventsEmit(a.ctx, "session.state", *sess)
+		wailsbus.EmitEvent(a.ctx, "session.state", *sess)
 	}
 	if a.bus != nil {
 		a.bus.Publish(eventbus.EvtSessionStateChanged, eventbus.SessionStateChanged{
@@ -4538,14 +4539,14 @@ func thisWeekUTC() time.Time {
 // --- Agent terminal (issue #161) ---
 
 func (a *App) emitAgentData(workspaceID, dataB64 string) {
-	wruntime.EventsEmit(a.ctx, "agentterm.output", map[string]string{
+	wailsbus.EmitEvent(a.ctx, "agentterm.output", map[string]string{
 		"workspace_id": workspaceID,
 		"data":         dataB64,
 	})
 }
 
 func (a *App) emitAgentExit(workspaceID string, exitCode int) {
-	wruntime.EventsEmit(a.ctx, "agentterm.exit", map[string]any{
+	wailsbus.EmitEvent(a.ctx, "agentterm.exit", map[string]any{
 		"workspace_id": workspaceID,
 		"exit_code":    exitCode,
 	})
@@ -4615,4 +4616,19 @@ func (a *App) KillAgentSession(workspaceID string) error {
 		return fmt.Errorf("agent terminal manager unavailable")
 	}
 	return a.agentTerm.Kill(workspaceID)
+}
+
+// GetEventBusDebugEmits returns a snapshot of the wailsbus ring buffer (most
+// recent first) so the developer diagnostics panel can display send-side history.
+func (a *App) GetEventBusDebugEmits() []wailsbus.EmitRecord {
+	return wailsbus.GetDebugEmits()
+}
+
+// ReplayEventBusEmit re-emits the most recent buffered event whose name matches.
+// Returns an error if no matching event is found in the ring buffer.
+func (a *App) ReplayEventBusEmit(name string) error {
+	if !wailsbus.ReplayLatest(a.ctx, name) {
+		return fmt.Errorf("no buffered event with name %q", name)
+	}
+	return nil
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { EventsOn } from "../wailsjs/runtime/runtime";
+import { EventsOnWrapped } from "./lib/eventBus";
 import {
   GetAutoPullPaused,
   ListArchivedIssues,
@@ -98,36 +98,36 @@ function App() {
         );
       })
       .catch(() => {});
-    const offLine = EventsOn("session.line", (data: { session_id: string; line: string }) => {
+    const offLine = EventsOnWrapped("session.line", (data: { session_id: string; line: string }) => {
       appendLine(data.session_id, data.line);
     });
-    const offState = EventsOn("session.state", (sess: types.Session) => {
+    const offState = EventsOnWrapped("session.state", (sess: types.Session) => {
       // eslint-disable-next-line no-console
       console.debug(
         `[bus] session.state id=${sess.id?.slice(0, 8)} ws=${sess.workspace_id} #${sess.issue_number} mode=${sess.mode} state=${sess.state}`,
       );
       setMeta(sess);
     });
-    const offActivity = EventsOn("session.activity", (act: SessionActivity) => {
+    const offActivity = EventsOnWrapped("session.activity", (act: SessionActivity) => {
       useSessionStore.getState().setActivity(act);
     });
-    const offGoal = EventsOn("bus.goal_activated", () => {
+    const offGoal = EventsOnWrapped("bus.goal_activated", () => {
       refreshGoals();
       refreshIssues(selectedWorkspace ?? "");
     });
-    const offGoalUpd = EventsOn("bus.goal_updated", () => refreshGoals());
-    const offIssue = EventsOn("bus.issue_added", () => refreshIssues(selectedWorkspace ?? ""));
+    const offGoalUpd = EventsOnWrapped("bus.goal_updated", () => refreshGoals());
+    const offIssue = EventsOnWrapped("bus.issue_added", () => refreshIssues(selectedWorkspace ?? ""));
     // pending_pool_* events flip Issue.WaitingForPool on the server side.
     // Without re-fetching here, the card stays in the pink "waiting for
     // available agent pool" state visually even after the orchestrator has
     // drained the queue, spawned the worker, and moved the card to
     // IN_PROGRESS — the pool counter will (correctly) show the slot taken
     // while the card display is stale.
-    const offPendingEnq = EventsOn(
+    const offPendingEnq = EventsOnWrapped(
       "bus.pending_pool_enqueued",
       () => refreshIssues(selectedWorkspace ?? ""),
     );
-    const offPendingDeq = EventsOn(
+    const offPendingDeq = EventsOnWrapped(
       "bus.pending_pool_dequeued",
       () => refreshIssues(selectedWorkspace ?? ""),
     );
@@ -135,7 +135,7 @@ function App() {
     // Card glow + toast carry the signal; queue the arrival and drain on close.
     // Any future auto-open path (bus.plan_revised, etc.) must use the same
     // functional-setPlanTarget guard, never an unconditional set.
-    const offPlanReady = EventsOn(
+    const offPlanReady = EventsOnWrapped(
       "bus.plan_ready",
       (data: { workspace_id: string; issue_number: number; revision: number }) => {
         refreshIssues(selectedWorkspace ?? "");
@@ -166,35 +166,35 @@ function App() {
         });
       },
     );
-    const offPROpened = EventsOn(
+    const offPROpened = EventsOnWrapped(
       "bus.pr_opened",
       (_data: { workspace_id: string; issue_number: number; pr_number: number; pr_url: string }) => {
         refreshIssues(selectedWorkspace ?? "");
       },
     );
-    const offPRMerged = EventsOn("bus.pr_merged", () => refreshIssues(selectedWorkspace ?? ""));
-    const offPRClosedUnmerged = EventsOn(
+    const offPRMerged = EventsOnWrapped("bus.pr_merged", () => refreshIssues(selectedWorkspace ?? ""));
+    const offPRClosedUnmerged = EventsOnWrapped(
       "bus.pr_closed_unmerged",
       () => refreshIssues(selectedWorkspace ?? ""),
     );
-    const offPlanApproved = EventsOn(
+    const offPlanApproved = EventsOnWrapped(
       "bus.plan_approved",
       (data: { workspace_id: string; issue_number: number }) => {
         refreshIssues(selectedWorkspace ?? "");
         if (data) clearPlanReady(data.workspace_id, data.issue_number);
       },
     );
-    const offPlanRejected = EventsOn(
+    const offPlanRejected = EventsOnWrapped(
       "bus.plan_rejected",
       (data: { workspace_id: string; issue_number: number }) => {
         if (data) clearPlanReady(data.workspace_id, data.issue_number);
       },
     );
-    const offGhPoll = EventsOn("bus.github_poll_done", () => refreshIssues(selectedWorkspace ?? ""));
-    const offGhIssue = EventsOn("bus.issue_added", () => refreshIssues(selectedWorkspace ?? ""));
-    const offGhClosed = EventsOn("bus.issue_closed", () => refreshIssues(selectedWorkspace ?? ""));
-    const offGhLabel = EventsOn("bus.issue_label_changed", () => refreshIssues(selectedWorkspace ?? ""));
-    const offLabelsUpdated = EventsOn(
+    const offGhPoll = EventsOnWrapped("bus.github_poll_done", () => refreshIssues(selectedWorkspace ?? ""));
+    const offGhIssue = EventsOnWrapped("bus.issue_added", () => refreshIssues(selectedWorkspace ?? ""));
+    const offGhClosed = EventsOnWrapped("bus.issue_closed", () => refreshIssues(selectedWorkspace ?? ""));
+    const offGhLabel = EventsOnWrapped("bus.issue_label_changed", () => refreshIssues(selectedWorkspace ?? ""));
+    const offLabelsUpdated = EventsOnWrapped(
       "bus.labels_updated",
       (data: { workspace_id: string }) => {
         if (data?.workspace_id) {
@@ -203,24 +203,24 @@ function App() {
       },
     );
     usePoolsStore.getState().refresh();
-    const offPoolChanged = EventsOn("bus.agent_count_changed", () => {
+    const offPoolChanged = EventsOnWrapped("bus.agent_count_changed", () => {
       usePoolsStore.getState().refresh();
     });
     GetAutoPullPaused().then(setAutoPaused).catch(() => {});
-    const offPause = EventsOn(
+    const offPause = EventsOnWrapped(
       "bus.auto_pull_paused_changed",
       (data: { paused: boolean }) => setAutoPaused(!!data?.paused),
     );
-    const offArchived = EventsOn("bus.issues_archived", () => {
+    const offArchived = EventsOnWrapped("bus.issues_archived", () => {
       refreshIssues(selectedWorkspace ?? "");
       refreshArchived(selectedWorkspace ?? "");
       refreshArchivedCount();
     });
     const pushToast = useToastStore.getState().push;
     const dismissToast = useToastStore.getState().dismiss;
-    const offToast = EventsOn("toast", (t: ToastT) => pushToast(t));
+    const offToast = EventsOnWrapped("toast", (t: ToastT) => pushToast(t));
 
-    const offWsAdded = EventsOn(
+    const offWsAdded = EventsOnWrapped(
       "bus.workspace_added",
       async (data: { workspace_id: string; workspace_name: string }) => {
         await refreshWorkspaces();
@@ -238,7 +238,7 @@ function App() {
       },
     );
 
-    const offWsFetchDone = EventsOn(
+    const offWsFetchDone = EventsOnWrapped(
       "bus.workspace_fetch_complete",
       (data: { workspace_id: string; workspace_name: string; success: boolean; issue_count: number; error?: string }) => {
         dismissToast(`ws-fetch-${data.workspace_id}`);

--- a/frontend/src/components/AgentTerminalDrawer.tsx
+++ b/frontend/src/components/AgentTerminalDrawer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
-import { EventsOn } from "../../wailsjs/runtime/runtime";
+import { EventsOnWrapped } from "../lib/eventBus";
 import { KillAgentSession, ResizeAgentTerm, WriteAgentInput } from "../../wailsjs/go/main/App";
 import { useAgentTerminalStore } from "../stores/useAgentTerminalStore";
 import { useWorkspaceStore } from "../stores/workspaceStore";
@@ -97,7 +97,7 @@ export function AgentTerminalDrawer() {
 
   // Stream PTY output into the terminal.
   useEffect(() => {
-    const off = EventsOn(
+    const off = EventsOnWrapped(
       "agentterm.output",
       (data: { workspace_id: string; data: string }) => {
         if (data.workspace_id !== workspaceID) return;
@@ -114,7 +114,7 @@ export function AgentTerminalDrawer() {
 
   // Handle session exit.
   useEffect(() => {
-    const off = EventsOn(
+    const off = EventsOnWrapped(
       "agentterm.exit",
       (data: { workspace_id: string; exit_code: number }) => {
         if (data.workspace_id !== workspaceID) return;

--- a/frontend/src/components/EventDiagnostics.tsx
+++ b/frontend/src/components/EventDiagnostics.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState, useCallback } from "react";
+import { GetEventBusDebugEmits, ReplayEventBusEmit } from "../../wailsjs/go/main/App";
+import { wailsbus } from "../../wailsjs/go/models";
+import type { EventRecord } from "../lib/eventBus";
+
+type View = "receives" | "sends";
+
+function fmtTime(ts: number | string): string {
+  const d = typeof ts === "number" ? new Date(ts) : new Date(ts);
+  return d.toLocaleTimeString(undefined, { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit", fractionalSecondDigits: 3 } as Intl.DateTimeFormatOptions);
+}
+
+function RowReceive({ rec }: { rec: EventRecord }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border-b border-slate-800 text-[11px]">
+      <button
+        className="w-full text-left flex items-center gap-2 px-2 py-1 hover:bg-slate-800/50"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="text-slate-500 font-mono shrink-0">{fmtTime(rec.receivedAt)}</span>
+        <span className="text-emerald-400 font-mono">{rec.name}</span>
+        <span className="text-slate-600 ml-auto">{open ? "▲" : "▼"}</span>
+      </button>
+      {open && (
+        <pre className="px-4 py-2 text-slate-300 overflow-x-auto bg-slate-950/40 text-[10px]">
+          {JSON.stringify(rec.payload, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function RowSend({ rec, onReplay }: { rec: wailsbus.EmitRecord; onReplay: (name: string) => void }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border-b border-slate-800 text-[11px]">
+      <button
+        className="w-full text-left flex items-center gap-2 px-2 py-1 hover:bg-slate-800/50"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="text-slate-500 font-mono shrink-0">{typeof rec.sent_at === "string" ? fmtTime(rec.sent_at) : "—"}</span>
+        <span className="text-sky-400 font-mono">{rec.name}</span>
+        <button
+          className="ml-auto text-[10px] px-1.5 py-0.5 border border-slate-700 rounded hover:bg-slate-700 text-slate-400"
+          onClick={(e) => { e.stopPropagation(); onReplay(rec.name); }}
+        >
+          replay
+        </button>
+        <span className="text-slate-600">{open ? "▲" : "▼"}</span>
+      </button>
+      {open && (
+        <pre className="px-4 py-2 text-slate-300 overflow-x-auto bg-slate-950/40 text-[10px]">
+          {JSON.stringify(rec.payload, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+export function EventDiagnostics() {
+  const [view, setView] = useState<View>("receives");
+  const [filter, setFilter] = useState("");
+  const [receives, setReceives] = useState<EventRecord[]>([]);
+  const [sends, setSends] = useState<wailsbus.EmitRecord[]>([]);
+  const [replayStatus, setReplayStatus] = useState("");
+
+  const refresh = useCallback(() => {
+    setReceives(window.__pcEventBuffer?.receives ?? []);
+    GetEventBusDebugEmits()
+      .then((r) => setSends(r ?? []))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, 1000);
+    return () => clearInterval(id);
+  }, [refresh]);
+
+  const handleReplay = useCallback(async (name: string) => {
+    try {
+      await ReplayEventBusEmit(name);
+      setReplayStatus(`replayed: ${name}`);
+      setTimeout(() => setReplayStatus(""), 2000);
+    } catch (e: unknown) {
+      setReplayStatus(`error: ${e instanceof Error ? e.message : String(e)}`);
+      setTimeout(() => setReplayStatus(""), 3000);
+    }
+  }, []);
+
+  const filteredReceives = filter
+    ? receives.filter((r) => r.name.includes(filter))
+    : receives;
+
+  const filteredSends = filter
+    ? sends.filter((s) => s.name.includes(filter))
+    : sends;
+
+  // Compute names present in sends but not in receives for the last 500 events,
+  // to highlight potential send-without-receive mismatches.
+  const receivedNames = new Set(receives.map((r) => r.name));
+  const orphanSends = new Set(sends.map((s) => s.name).filter((n) => !receivedNames.has(n)));
+
+  return (
+    <div className="flex flex-col gap-3 text-sm">
+      <div className="flex items-center gap-2 text-xs text-slate-400">
+        <span>Event Bus Diagnostics</span>
+        <span className="text-slate-600">·</span>
+        <span className="text-emerald-500">{receives.length} received</span>
+        <span className="text-slate-600">·</span>
+        <span className="text-sky-500">{sends.length} sent</span>
+        {orphanSends.size > 0 && (
+          <>
+            <span className="text-slate-600">·</span>
+            <span className="text-amber-400" title="Events sent but no matching receive recorded">
+              ⚠ {orphanSends.size} unmatched send{orphanSends.size > 1 ? "s" : ""}
+            </span>
+          </>
+        )}
+        {replayStatus && (
+          <span className="text-violet-400 ml-2">{replayStatus}</span>
+        )}
+        <button
+          className="ml-auto text-[11px] px-2 py-0.5 border border-slate-700 rounded hover:bg-slate-800 text-slate-400"
+          onClick={refresh}
+        >
+          ↻ refresh
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <div className="flex gap-1 text-xs">
+          <button
+            onClick={() => setView("receives")}
+            className={
+              "px-2 py-1 rounded " +
+              (view === "receives" ? "bg-emerald-900/40 text-emerald-300 border border-emerald-800" : "text-slate-400 hover:text-slate-200")
+            }
+          >
+            Received ({receives.length})
+          </button>
+          <button
+            onClick={() => setView("sends")}
+            className={
+              "px-2 py-1 rounded " +
+              (view === "sends" ? "bg-sky-900/40 text-sky-300 border border-sky-800" : "text-slate-400 hover:text-slate-200")
+            }
+          >
+            Sent ({sends.length})
+          </button>
+        </div>
+        <input
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="filter by name…"
+          className="flex-1 text-xs bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-200 placeholder-slate-600 outline-none focus:border-slate-500"
+        />
+      </div>
+
+      {orphanSends.size > 0 && (
+        <div className="text-xs bg-amber-950/30 border border-amber-800/50 rounded px-3 py-2 text-amber-300">
+          Send-without-receive: {[...orphanSends].join(", ")}
+        </div>
+      )}
+
+      <div className="border border-slate-800 rounded overflow-y-auto" style={{ maxHeight: "420px" }}>
+        {view === "receives" && (
+          filteredReceives.length === 0
+            ? <div className="px-3 py-4 text-xs text-slate-500 text-center">No receives yet{filter ? " matching filter" : ""}</div>
+            : filteredReceives.map((r, i) => <RowReceive key={i} rec={r} />)
+        )}
+        {view === "sends" && (
+          filteredSends.length === 0
+            ? <div className="px-3 py-4 text-xs text-slate-500 text-center">No sends yet{filter ? " matching filter" : ""}</div>
+            : filteredSends.map((s, i) => <RowSend key={i} rec={s} onReplay={handleReplay} />)
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PoolsHeader.tsx
+++ b/frontend/src/components/PoolsHeader.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { EventsOn } from "../../wailsjs/runtime/runtime";
+import { EventsOnWrapped } from "../lib/eventBus";
 import { ListPools } from "../../wailsjs/go/main/App";
 import { workerpool } from "../../wailsjs/go/models";
 import { resolveProviderIcon } from "../lib/providerIcon";
@@ -16,11 +16,11 @@ export function PoolsHeader({ onOpenPools }: Props) {
         .then((rows) => setPools(rows ?? []))
         .catch(() => {});
     refresh();
-    const offFreed = EventsOn("bus.worker_slot_freed", refresh);
-    const offChanged = EventsOn("bus.agent_count_changed", refresh);
-    const offState = EventsOn("session.state", refresh);
-    const offPending = EventsOn("bus.pending_pool_enqueued", refresh);
-    const offDequeued = EventsOn("bus.pending_pool_dequeued", refresh);
+    const offFreed = EventsOnWrapped("bus.worker_slot_freed", refresh);
+    const offChanged = EventsOnWrapped("bus.agent_count_changed", refresh);
+    const offState = EventsOnWrapped("session.state", refresh);
+    const offPending = EventsOnWrapped("bus.pending_pool_enqueued", refresh);
+    const offDequeued = EventsOnWrapped("bus.pending_pool_dequeued", refresh);
     return () => {
       if (typeof offFreed === "function") offFreed();
       if (typeof offChanged === "function") offChanged();

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -6,8 +6,9 @@ import { NotifyPanel } from "./NotifyPanel";
 import { LogsPanel } from "./LogsPanel";
 import { AppearancePanel } from "./AppearancePanel";
 import { CollectionsPanel } from "./CollectionsPanel";
+import { EventDiagnostics } from "./EventDiagnostics";
 
-type Tab = "workspaces" | "collections" | "pools" | "skills" | "notify" | "appearance" | "logs";
+type Tab = "workspaces" | "collections" | "pools" | "skills" | "notify" | "appearance" | "logs" | "diagnostics";
 
 export function Settings({
   open,
@@ -38,6 +39,7 @@ export function Settings({
                 ["notify", "Notifications"],
                 ["appearance", "Appearance"],
                 ["logs", "Logs"],
+                ...(import.meta.env.DEV ? [["diagnostics", "Diagnostics"] as [Tab, string]] : []),
               ] as [Tab, string][]
             ).map(([k, label]) => (
               <button
@@ -60,6 +62,7 @@ export function Settings({
             {tab === "notify" && <NotifyPanel />}
             {tab === "appearance" && <AppearancePanel />}
             {tab === "logs" && <LogsPanel />}
+            {tab === "diagnostics" && import.meta.env.DEV && <EventDiagnostics />}
           </div>
         </div>
       </div>

--- a/frontend/src/lib/eventBus.test.ts
+++ b/frontend/src/lib/eventBus.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the Wails runtime before importing eventBus so EventsOn is controlled.
+vi.mock("../../wailsjs/runtime/runtime", () => {
+  let lastHandler: ((p: unknown) => void) | null = null;
+  const EventsOn = vi.fn((_name: string, handler: (payload: unknown) => void) => {
+    lastHandler = handler;
+    return () => {};
+  });
+  (EventsOn as any).__trigger = (payload: unknown) => lastHandler?.(payload);
+  return { EventsOn };
+});
+
+import { EventsOn } from "../../wailsjs/runtime/runtime";
+import { EventsOnWrapped, debugEmit, getReceiveBuffer } from "./eventBus";
+
+function triggerWails(payload: unknown) {
+  (EventsOn as any).__trigger(payload);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Drain the receive buffer between tests by emitting nothing — buffer is
+  // module-level state so we clear it by slicing; use the splice trick.
+  getReceiveBuffer(); // just read; buffer drains via module-level array in tests below
+});
+
+describe("EventsOnWrapped", () => {
+  it("calls EventsOn and invokes the handler on receive", () => {
+    const handler = vi.fn();
+    EventsOnWrapped("test.event", handler);
+    triggerWails({ x: 1 });
+    expect(handler).toHaveBeenCalledWith({ x: 1 });
+  });
+
+  it("catches handler errors without propagating", () => {
+    const bad = vi.fn(() => { throw new Error("boom"); });
+    expect(() => {
+      EventsOnWrapped("test.err", bad);
+      triggerWails("payload");
+    }).not.toThrow();
+    expect(bad).toHaveBeenCalled();
+  });
+
+  it("records the event in the receive buffer", () => {
+    EventsOnWrapped("test.buf", vi.fn());
+    triggerWails({ key: "value" });
+    const buf = getReceiveBuffer();
+    const found = buf.find((r) => r.name === "test.buf");
+    expect(found).toBeDefined();
+    expect(found?.payload).toEqual({ key: "value" });
+  });
+
+  it("off function unregisters handler from registry", () => {
+    const handler = vi.fn();
+    const off = EventsOnWrapped("test.off", handler);
+    off();
+    debugEmit("test.off", "data");
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe("debugEmit", () => {
+  it("invokes registered handlers without going through EventsOn", () => {
+    const handler = vi.fn();
+    EventsOnWrapped("test.debug", handler);
+    debugEmit("test.debug", { key: "val" });
+    expect(handler).toHaveBeenCalledWith({ key: "val" });
+  });
+
+  it("records emit in the receive buffer", () => {
+    debugEmit("test.direct", 42);
+    const buf = getReceiveBuffer();
+    const found = buf.find((r) => r.name === "test.direct");
+    expect(found).toBeDefined();
+    expect(found?.payload).toBe(42);
+  });
+});

--- a/frontend/src/lib/eventBus.ts
+++ b/frontend/src/lib/eventBus.ts
@@ -1,0 +1,92 @@
+import { EventsOn } from "../../wailsjs/runtime/runtime";
+
+export type EventRecord = {
+  name: string;
+  payload: unknown;
+  receivedAt: number;
+};
+
+const BUF_CAP = 500;
+
+// Receive-side ring buffer — updated by every EventsOnWrapped handler.
+const receiveBuffer: EventRecord[] = [];
+
+// Handler registry for debugEmit (dev replay and e2e synthetic events).
+const registry = new Map<string, Set<(payload: unknown) => void>>();
+
+function pushReceive(name: string, payload: unknown) {
+  receiveBuffer.unshift({ name, payload, receivedAt: Date.now() });
+  if (receiveBuffer.length > BUF_CAP) receiveBuffer.pop();
+}
+
+/**
+ * Drop-in replacement for EventsOn that records each receive in a ring buffer
+ * and wraps handlers with try/catch so one bad handler can't break the others.
+ * Returns the same off-function as EventsOn.
+ */
+export function EventsOnWrapped<T>(
+  name: string,
+  handler: (payload: T) => void,
+): () => void {
+  const wrapped = (payload: T) => {
+    pushReceive(name, payload);
+    try {
+      handler(payload);
+    } catch (e) {
+      console.error(`[eventBus] handler error for "${name}":`, e);
+    }
+  };
+
+  if (!registry.has(name)) registry.set(name, new Set());
+  registry.get(name)!.add(handler as (payload: unknown) => void);
+
+  const off = EventsOn(name, wrapped as (payload: unknown) => void);
+
+  return () => {
+    registry.get(name)?.delete(handler as (payload: unknown) => void);
+    if (typeof off === "function") off();
+  };
+}
+
+/**
+ * Synthetically invoke all registered handlers for an event without going
+ * through the Wails IPC channel. Used by the EventDiagnostics replay button
+ * and by Playwright e2e tests via window.__pcEventBuffer.emit.
+ * Also exported directly so unit tests can call it without a browser global.
+ */
+export function debugEmit(name: string, payload: unknown) {
+  pushReceive(name, payload);
+  const handlers = registry.get(name);
+  if (!handlers) return;
+  for (const h of handlers) {
+    try {
+      h(payload);
+    } catch (e) {
+      console.error(`[eventBus] debugEmit handler error for "${name}":`, e);
+    }
+  }
+}
+
+/** Returns a snapshot of the receive buffer. Exported for unit tests. */
+export function getReceiveBuffer(): EventRecord[] {
+  return receiveBuffer.slice();
+}
+
+declare global {
+  interface Window {
+    __pcEventBuffer: {
+      readonly receives: EventRecord[];
+      emit: (name: string, payload: unknown) => void;
+    };
+  }
+}
+
+// Expose on window for Playwright e2e tests. Guard for Node.js test environments.
+if (typeof window !== "undefined") {
+  window.__pcEventBuffer = {
+    get receives() {
+      return receiveBuffer.slice();
+    },
+    emit: debugEmit,
+  };
+}

--- a/frontend/src/stores/useIssueViewStore.ts
+++ b/frontend/src/stores/useIssueViewStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { EventsOn } from "../../wailsjs/runtime/runtime";
+import { EventsOnWrapped } from "../lib/eventBus";
 import { ListIssueViews } from "../../wailsjs/go/main/App";
 import { issueview } from "../../wailsjs/go/models";
 
@@ -32,7 +32,7 @@ export const useIssueViewStore = create<State>((set, get) => ({
 }));
 
 // Incremental updates: subscribe once at module load so every card stays fresh.
-EventsOn("bus.issue_view_updated", (raw: any) => {
+EventsOnWrapped("bus.issue_view_updated", (raw: any) => {
   const view = issueview.IssueView.createFrom(raw);
   if (!view?.issue?.workspace_id || !view?.issue?.number) return;
   useIssueViewStore.setState((s) => ({

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -3,6 +3,7 @@
 import {types} from '../models';
 import {main} from '../models';
 import {diagnose} from '../models';
+import {wailsbus} from '../models';
 import {issueview} from '../models';
 import {githubauth} from '../models';
 import {github} from '../models';
@@ -64,6 +65,8 @@ export function FilterIssuesByActiveGoal(arg1:Array<types.Issue>):Promise<Array<
 export function GCWorktrees(arg1:string):Promise<number>;
 
 export function GetAutoPullPaused():Promise<boolean>;
+
+export function GetEventBusDebugEmits():Promise<Array<wailsbus.EmitRecord>>;
 
 export function GetIssueView(arg1:string,arg2:number):Promise<issueview.IssueView>;
 
@@ -182,6 +185,8 @@ export function ReplaceCFToken(arg1:string,arg2:string):Promise<void>;
 export function Replan(arg1:string,arg2:number):Promise<void>;
 
 export function ReplanForce(arg1:string,arg2:number):Promise<void>;
+
+export function ReplayEventBusEmit(arg1:string):Promise<void>;
 
 export function RequestFixForComments(arg1:string,arg2:number,arg3:Array<number>):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -110,6 +110,10 @@ export function GetAutoPullPaused() {
   return window['go']['main']['App']['GetAutoPullPaused']();
 }
 
+export function GetEventBusDebugEmits() {
+  return window['go']['main']['App']['GetEventBusDebugEmits']();
+}
+
 export function GetIssueView(arg1, arg2) {
   return window['go']['main']['App']['GetIssueView'](arg1, arg2);
 }
@@ -344,6 +348,10 @@ export function Replan(arg1, arg2) {
 
 export function ReplanForce(arg1, arg2) {
   return window['go']['main']['App']['ReplanForce'](arg1, arg2);
+}
+
+export function ReplayEventBusEmit(arg1) {
+  return window['go']['main']['App']['ReplayEventBusEmit'](arg1);
 }
 
 export function RequestFixForComments(arg1, arg2, arg3) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -2259,6 +2259,46 @@ export namespace types {
 
 }
 
+export namespace wailsbus {
+	
+	export class EmitRecord {
+	    name: string;
+	    payload: any;
+	    // Go type: time
+	    sent_at: any;
+	
+	    static createFrom(source: any = {}) {
+	        return new EmitRecord(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.name = source["name"];
+	        this.payload = source["payload"];
+	        this.sent_at = this.convertValues(source["sent_at"], null);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+
+}
+
 export namespace workerpool {
 	
 	export class PoolStatus {

--- a/internal/wailsbus/emit.go
+++ b/internal/wailsbus/emit.go
@@ -1,0 +1,77 @@
+// Package wailsbus wraps wruntime.EventsEmit with a bounded ring buffer so
+// every emission is observable by the developer diagnostics panel.
+package wailsbus
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	wruntime "github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+const BufCap = 500
+
+// EmitRecord captures metadata about one Wails event emission.
+type EmitRecord struct {
+	Name    string      `json:"name"`
+	Payload interface{} `json:"payload"`
+	SentAt  time.Time   `json:"sent_at"`
+}
+
+var (
+	mu      sync.RWMutex
+	entries [BufCap]EmitRecord
+	head    int
+	count   int
+)
+
+// EmitEvent records the event in the ring buffer then forwards it to the Wails
+// runtime. A nil ctx is accepted: the event is buffered but not forwarded
+// (safe to call during startup races before the Wails context is ready).
+func EmitEvent(ctx context.Context, name string, payload interface{}) {
+	mu.Lock()
+	entries[head] = EmitRecord{Name: name, Payload: payload, SentAt: time.Now()}
+	head = (head + 1) % BufCap
+	if count < BufCap {
+		count++
+	}
+	mu.Unlock()
+	if ctx != nil {
+		wruntime.EventsEmit(ctx, name, payload)
+	}
+}
+
+// GetDebugEmits returns a snapshot of the ring buffer, newest first.
+func GetDebugEmits() []EmitRecord {
+	mu.RLock()
+	defer mu.RUnlock()
+	n := count
+	out := make([]EmitRecord, n)
+	for i := 0; i < n; i++ {
+		idx := (head - 1 - i + BufCap) % BufCap
+		out[i] = entries[idx]
+	}
+	return out
+}
+
+// ReplayLatest re-emits the most recent buffered event whose name matches.
+// Returns false when no matching entry exists.
+func ReplayLatest(ctx context.Context, name string) bool {
+	mu.RLock()
+	var found *EmitRecord
+	for i := 0; i < count; i++ {
+		idx := (head - 1 - i + BufCap) % BufCap
+		if entries[idx].Name == name {
+			rec := entries[idx]
+			found = &rec
+			break
+		}
+	}
+	mu.RUnlock()
+	if found == nil {
+		return false
+	}
+	EmitEvent(ctx, found.Name, found.Payload)
+	return true
+}

--- a/internal/wailsbus/emit_test.go
+++ b/internal/wailsbus/emit_test.go
@@ -1,0 +1,64 @@
+package wailsbus
+
+import (
+	"testing"
+)
+
+func resetBuf() {
+	mu.Lock()
+	head = 0
+	count = 0
+	mu.Unlock()
+}
+
+func TestRingBufferOrdering(t *testing.T) {
+	resetBuf()
+	EmitEvent(nil, "a", 1)
+	EmitEvent(nil, "b", 2)
+	EmitEvent(nil, "c", 3)
+	snap := GetDebugEmits()
+	if len(snap) != 3 {
+		t.Fatalf("want 3 entries, got %d", len(snap))
+	}
+	if snap[0].Name != "c" || snap[1].Name != "b" || snap[2].Name != "a" {
+		t.Errorf("unexpected order: %v %v %v", snap[0].Name, snap[1].Name, snap[2].Name)
+	}
+}
+
+func TestRingBufferWraps(t *testing.T) {
+	resetBuf()
+	for i := 0; i < BufCap+10; i++ {
+		EmitEvent(nil, "e", i)
+	}
+	snap := GetDebugEmits()
+	if len(snap) != BufCap {
+		t.Fatalf("want %d entries after overflow, got %d", BufCap, len(snap))
+	}
+	// Most recent payload should be the last value emitted
+	if snap[0].Payload.(int) != BufCap+9 {
+		t.Errorf("newest payload: got %v, want %d", snap[0].Payload, BufCap+9)
+	}
+}
+
+func TestReplayLatest(t *testing.T) {
+	resetBuf()
+	EmitEvent(nil, "x", "first")
+	EmitEvent(nil, "y", "middle")
+	EmitEvent(nil, "x", "last")
+
+	// Nonexistent name returns false
+	if ReplayLatest(nil, "nonexistent") {
+		t.Error("should return false for unknown event name")
+	}
+
+	// Finds most recent "x" and re-emits (nil ctx = buffered only)
+	if !ReplayLatest(nil, "x") {
+		t.Error("should find and replay 'x'")
+	}
+
+	// The re-emitted entry should appear as the newest
+	snap := GetDebugEmits()
+	if snap[0].Name != "x" || snap[0].Payload.(string) != "last" {
+		t.Errorf("replayed entry mismatch: %+v", snap[0])
+	}
+}

--- a/tests/e2e/realtime.spec.ts
+++ b/tests/e2e/realtime.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect, ConsoleMessage } from "@playwright/test";
+
+const BASE_URL = process.env.PRISMCONDUCTOR_DEV_URL ?? "http://localhost:34115";
+const SETTLE_MS = Number(process.env.PRISMCONDUCTOR_SMOKE_SETTLE_MS ?? 5000);
+const CONVERGE_MS = 1000;
+
+test("event buffer is exposed and captures synthetic events within 1s", async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg: ConsoleMessage) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+
+  await page.goto(BASE_URL, { waitUntil: "domcontentloaded" });
+
+  // React must mount before we can test anything.
+  await page.waitForFunction(
+    () => {
+      const root = document.getElementById("root");
+      return !!root && root.children.length > 0;
+    },
+    { timeout: SETTLE_MS },
+  );
+
+  // The eventBus module must have initialised window.__pcEventBuffer.
+  const bufferReady = await page.evaluate(() => {
+    return (
+      typeof window.__pcEventBuffer !== "undefined" &&
+      Array.isArray(window.__pcEventBuffer.receives) &&
+      typeof window.__pcEventBuffer.emit === "function"
+    );
+  });
+  expect(bufferReady, "window.__pcEventBuffer must be initialised by eventBus.ts").toBe(true);
+
+  // Capture the receive-count before the synthetic emission.
+  const before = await page.evaluate(() => window.__pcEventBuffer.receives.length);
+
+  // Emit a synthetic session.state "completed" via the debug channel, bypassing
+  // Wails IPC entirely. This verifies the full handler → buffer pipeline: if the
+  // registered EventsOnWrapped handler runs and the buffer records the event, the
+  // UI would have received and processed it within the same tick.
+  await page.evaluate(() => {
+    window.__pcEventBuffer.emit("session.state", {
+      id: "e2e-test-session",
+      workspace_id: "ws-e2e",
+      issue_number: 9999,
+      state: "completed",
+      mode: "execute",
+    });
+  });
+
+  // The buffer must reflect the new entry within CONVERGE_MS.
+  await page.waitForFunction(
+    (count: number) => window.__pcEventBuffer.receives.length > count,
+    before,
+    { timeout: CONVERGE_MS },
+  );
+
+  const latest = await page.evaluate(() => window.__pcEventBuffer.receives[0]);
+  expect(latest.name).toBe("session.state");
+  expect((latest.payload as { state: string }).state).toBe("completed");
+
+  // No new console errors should have occurred during the test.
+  expect.soft(consoleErrors, `console.error: ${consoleErrors.join(" | ")}`).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- Adds a 500-entry send-side ring buffer (`internal/wailsbus`) wrapping every `wruntime.EventsEmit` call so backend emissions are observable and replayable.
- Adds a receive-side `EventsOnWrapped` wrapper in `frontend/src/lib/eventBus.ts` that records events into `window.__pcEventBuffer` and wraps handlers with try/catch so one bad handler cannot drop others.
- Adds a dev-only **Event Diagnostics** panel in Settings (visible only when `import.meta.env.DEV`) showing send/receive timelines, a filter, send-without-receive mismatch highlighting, and a per-event replay button.
- Adds `tests/e2e/realtime.spec.ts` that asserts `window.__pcEventBuffer` is initialised and a synthetic `session.state` emission appears within 1 s.

## Files modified

- `internal/wailsbus/emit.go` — NEW ring buffer, EmitEvent, GetDebugEmits, ReplayLatest
- `internal/wailsbus/emit_test.go` — NEW unit tests
- `app.go` — route all 20 EventsEmit calls through wailsbus; add GetEventBusDebugEmits / ReplayEventBusEmit bound methods
- `frontend/wailsjs/go/main/App.{js,d.ts}` + `models.ts` — auto-generated bindings (wailsbus.EmitRecord, new methods)
- `frontend/src/lib/eventBus.ts` — NEW EventsOnWrapped, debugEmit, getReceiveBuffer, window.__pcEventBuffer
- `frontend/src/lib/eventBus.test.ts` — NEW Vitest unit tests
- `frontend/src/components/EventDiagnostics.tsx` — NEW dev-only diagnostics panel
- `frontend/src/App.tsx`, `useIssueViewStore.ts`, `PoolsHeader.tsx`, `AgentTerminalDrawer.tsx`, `Settings.tsx` — EventsOn → EventsOnWrapped, add Diagnostics tab

## Verification

| Gate | Command | Result |
|------|---------|--------|
| Go lint | `go vet ./...` | pass |
| TS typecheck | `cd frontend && npx tsc --noEmit` | pass |
| Build | `wails build` | pass (8s) |
| Go tests | `go test ./...` | pass — 35 packages, wailsbus included |
| Frontend tests | `cd frontend && npm test` | pass — 92 tests (11 files, 6 new eventBus tests) |
| Smoke test | `npx --prefix tests playwright test tests/e2e/startup.spec.ts` | skipped locally — wails dev requires macOS GUI session unavailable in worker; CI runs via xvfb-run |

Commit tier: Tier 2b (unsigned — repo does not enforce signed commits)

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-228

Closes #228
