### PR TITLE
feat(pools): new pools auto-assign priority; reconciler fixes ties (#231)

### DIFF
--- a/app.go
+++ b/app.go
@@ -177,6 +177,11 @@ func (a *App) startup(ctx context.Context) {
 		if err := a.migrateOrchestratorPool(); err != nil {
 			log.Printf("migrate orchestrator pool: %v", err)
 		}
+		if n, err := a.store.ReconcilePoolPriorities(); err != nil {
+			log.Printf("reconcile pool priorities: %v", err)
+		} else if n > 0 {
+			log.Printf("reconciled %d pool priority rows (issue #231)", n)
+		}
 		if rows, err := a.store.ListPools(); err == nil {
 			a.poolReg.Sync(rows)
 		} else {
@@ -2377,6 +2382,36 @@ func (a *App) SavePool(p types.Pool) error {
 		p.CreatedAt = time.Now()
 	}
 	if err := a.store.SavePool(p); err != nil {
+		return err
+	}
+	rows, err := a.store.ListPools()
+	if err != nil {
+		return err
+	}
+	a.poolReg.Sync(rows)
+	a.bus.Publish(eventbus.EvtAgentCountChanged, map[string]any{"pool_id": p.ID})
+	return nil
+}
+
+// CreatePool inserts a new pool, auto-assigning its priority to the end of
+// the preference order for its role, and re-syncs the registry.
+func (a *App) CreatePool(p types.Pool) error {
+	if a.store == nil {
+		return fmt.Errorf("store unavailable")
+	}
+	if p.ID == "" {
+		p.ID = uuid.NewString()
+	}
+	if p.Capacity < 0 {
+		p.Capacity = 0
+	}
+	if p.Capacity > 10 {
+		p.Capacity = 10
+	}
+	if p.CreatedAt.IsZero() {
+		p.CreatedAt = time.Now()
+	}
+	if err := a.store.CreatePool(p); err != nil {
 		return err
 	}
 	rows, err := a.store.ListPools()

--- a/frontend/src/components/PoolEditModal.tsx
+++ b/frontend/src/components/PoolEditModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import {
+  CreatePool,
   ListWorkspaces,
   ProbeProviderModels,
   SavePool,
@@ -200,7 +201,11 @@ export function PoolEditModal({
         scope,
         workspace_id: scope === "workspace" ? scopeWorkspaceID : "",
       });
-      await SavePool(pool);
+      if (initial) {
+        await SavePool(pool);
+      } else {
+        await CreatePool(pool);
+      }
       onSaved();
     } catch (err: any) {
       setSaveErr(String(err?.message ?? err ?? "save failed"));

--- a/frontend/src/components/PoolsPanel.tsx
+++ b/frontend/src/components/PoolsPanel.tsx
@@ -201,13 +201,12 @@ export function PoolsPanel() {
                   items={rows.map((r) => r.pool.id)}
                   strategy={verticalListSortingStrategy}
                 >
-                  {rows.map((row, idx) => (
+                  {rows.map((row) => (
                     <SortablePoolRow
                       key={row.pool.id}
                       row={row}
                       role={role}
-                      isFirst={idx === 0}
-                      isLast={idx === rows.length - 1}
+                      rolePeers={rows}
                       providerByKind={providerByKind}
                       workspaceByID={workspaceByID}
                       deleteErr={deleteErr[row.pool.id]}
@@ -284,11 +283,31 @@ export function PoolsPanel() {
   );
 }
 
+function preferenceState(
+  row: workerpool.PoolStatus,
+  rolePeers: workerpool.PoolStatus[],
+  providerByKind: Map<string, main.ProviderInfo>,
+): "preferred" | "shared" | "fallback" | null {
+  const capable = rolePeers.filter(
+    (r) => r.pool.enabled && r.pool.capacity > 0 && (providerByKind.get(r.pool.provider)?.can_spawn ?? false),
+  );
+  if (capable.length === 0) return null;
+  if (!capable.some((r) => r.pool.id === row.pool.id)) return null;
+  const sorted = [...capable].sort((a, b) => a.pool.priority - b.pool.priority);
+  const lowest = sorted[0].pool.priority;
+  const tiedAtLowest = sorted.filter((r) => r.pool.priority === lowest);
+  if (row.pool.priority !== lowest) {
+    if (row.pool.id === sorted[sorted.length - 1].pool.id) return "fallback";
+    return null;
+  }
+  if (tiedAtLowest.length === 1) return "preferred";
+  return "shared";
+}
+
 function SortablePoolRow({
   row,
   role,
-  isFirst,
-  isLast,
+  rolePeers,
   providerByKind,
   workspaceByID,
   deleteErr,
@@ -300,8 +319,7 @@ function SortablePoolRow({
 }: {
   row: workerpool.PoolStatus;
   role: Role;
-  isFirst: boolean;
-  isLast: boolean;
+  rolePeers: workerpool.PoolStatus[];
   providerByKind: Map<string, main.ProviderInfo>;
   workspaceByID: Map<string, types.Workspace>;
   deleteErr?: string;
@@ -329,7 +347,22 @@ function SortablePoolRow({
       ⠿
     </span>
   );
-  const hint = isFirst ? "← preferred" : isLast ? "← fallback" : null;
+  const state = preferenceState(row, rolePeers, providerByKind);
+  let hint: React.ReactNode;
+  if (state === "preferred") {
+    hint = <span className="text-slate-600 font-normal">← preferred</span>;
+  } else if (state === "shared") {
+    hint = (
+      <span
+        className="text-amber-500 font-normal"
+        title="Pools tied at the same priority share load via round-robin. Drag to assign distinct priorities."
+      >
+        ← shared (round-robin)
+      </span>
+    );
+  } else if (state === "fallback") {
+    hint = <span className="text-slate-600 font-normal">← fallback</span>;
+  }
   return (
     <div ref={setNodeRef} style={style}>
       <PoolRow
@@ -339,7 +372,7 @@ function SortablePoolRow({
         workspaceByID={workspaceByID}
         deleteErr={deleteErr}
         dragHandle={dragHandle}
-        preferenceHint={hint ?? undefined}
+        preferenceHint={hint}
         spendToday={spendToday}
         spendWeek={spendWeek}
         onToggleEnabled={onToggleEnabled}
@@ -383,7 +416,7 @@ function PoolRow({
   workspaceByID: Map<string, types.Workspace>;
   deleteErr?: string;
   dragHandle: React.ReactNode;
-  preferenceHint?: string;
+  preferenceHint?: React.ReactNode;
   spendToday: number;
   spendWeek: number;
   onToggleEnabled: (p: types.Pool, next: boolean) => void;
@@ -402,9 +435,7 @@ function PoolRow({
               ({info?.display_name ?? row.pool.provider})
             </span>
             {poolScopeBadge(row.pool, workspaceByID)}
-            {preferenceHint && (
-              <span className="text-slate-600 font-normal">{preferenceHint}</span>
-            )}
+            {preferenceHint}
           </div>
           <div className="text-slate-500 text-xs">
             {row.pool.model || "—"}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -41,6 +41,8 @@ export function CreateCollection(arg1:string):Promise<types.Collection>;
 
 export function CreateLabel(arg1:string,arg2:types.Label):Promise<types.Label>;
 
+export function CreatePool(arg1:types.Pool):Promise<void>;
+
 export function CreateRemoteWorkspace(arg1:main.RemoteWorkspaceForm):Promise<main.RemoteDeployResult>;
 
 export function DeleteCollection(arg1:string):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -58,6 +58,10 @@ export function CreateLabel(arg1, arg2) {
   return window['go']['main']['App']['CreateLabel'](arg1, arg2);
 }
 
+export function CreatePool(arg1) {
+  return window['go']['main']['App']['CreatePool'](arg1);
+}
+
 export function CreateRemoteWorkspace(arg1) {
   return window['go']['main']['App']['CreateRemoteWorkspace'](arg1);
 }

--- a/internal/store/pools.go
+++ b/internal/store/pools.go
@@ -17,6 +17,27 @@ var ErrInvalidRole = errors.New("invalid pool role")
 // enabled orchestrator pool. At-most-one is enforced in Go (issue #39 q4).
 var ErrOrchestratorPoolExists = errors.New("an enabled orchestrator pool already exists; disable it first")
 
+// ErrPoolExists is returned by CreatePool when a row with the same ID already exists.
+var ErrPoolExists = errors.New("pool with that ID already exists")
+
+// validatePool sets Role/CreatedAt defaults and validates required fields
+// shared by CreatePool and SavePool.
+func validatePool(p types.Pool) (types.Pool, error) {
+	if p.ID == "" {
+		return p, errors.New("pool ID required")
+	}
+	if p.Role == "" {
+		p.Role = types.RoleWork
+	}
+	if !types.ValidRole(p.Role) {
+		return p, fmt.Errorf("%w: %q", ErrInvalidRole, string(p.Role))
+	}
+	if p.CreatedAt.IsZero() {
+		p.CreatedAt = time.Now()
+	}
+	return p, nil
+}
+
 // ListPools returns every pool row, oldest first.
 func (s *Store) ListPools() ([]types.Pool, error) {
 	if s == nil || s.DB == nil {
@@ -77,24 +98,15 @@ FROM pools WHERE id = ?`, id)
 	return scanPool(row)
 }
 
-// SavePool upserts a pool by ID. Defaults Role to 'work' for backwards
-// compatibility, validates membership, and refuses a second enabled
-// orchestrator pool.
+// SavePool upserts a pool by ID. Use CreatePool for new rows — it auto-assigns
+// priority so new pools land at the end of the preference order.
 func (s *Store) SavePool(p types.Pool) error {
 	if s == nil || s.DB == nil {
 		return errors.New("store unavailable")
 	}
-	if p.ID == "" {
-		return errors.New("pool ID required")
-	}
-	if p.Role == "" {
-		p.Role = types.RoleWork
-	}
-	if !types.ValidRole(p.Role) {
-		return fmt.Errorf("%w: %q", ErrInvalidRole, string(p.Role))
-	}
-	if p.CreatedAt.IsZero() {
-		p.CreatedAt = time.Now()
+	var err error
+	if p, err = validatePool(p); err != nil {
+		return err
 	}
 	if p.Role == types.RoleOrchestrator && p.Enabled {
 		// Refuse a second enabled orchestrator pool. Allowed when this row
@@ -125,7 +137,7 @@ func (s *Store) SavePool(p types.Pool) error {
 	if scope == "" {
 		scope = string(types.PoolScopeShared)
 	}
-	_, err := s.DB.Exec(`
+	_, err = s.DB.Exec(`
 INSERT INTO pools (id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
@@ -149,6 +161,140 @@ ON CONFLICT(id) DO UPDATE SET
 		p.Capacity, enabled, p.APIKey, string(p.Role), p.CreatedAt.Unix(), p.Priority, p.Temperature,
 		p.MaxTurns, p.MaxInputTokens, bashTimeoutMs, p.OutputCap, scope, p.WorkspaceID)
 	return err
+}
+
+// CreatePool inserts a brand-new pool, auto-assigning priority to the end of
+// the preference order for its role. Only enabled same-role rows contribute to
+// the MAX; a new pool with no enabled peers lands at priority=0. Returns
+// ErrPoolExists if a row with this ID already exists.
+func (s *Store) CreatePool(p types.Pool) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	var err error
+	if p, err = validatePool(p); err != nil {
+		return err
+	}
+	tx, err := s.DB.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var count int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM pools WHERE id = ?`, p.ID).Scan(&count); err != nil {
+		return err
+	}
+	if count > 0 {
+		return ErrPoolExists
+	}
+
+	if p.Role == types.RoleOrchestrator && p.Enabled {
+		var orchCount int
+		if err := tx.QueryRow(`SELECT COUNT(*) FROM pools WHERE role = 'orchestrator' AND enabled = 1`).Scan(&orchCount); err != nil {
+			return err
+		}
+		if orchCount > 0 {
+			return ErrOrchestratorPoolExists
+		}
+	}
+
+	// Priority = MAX(priority)+1 over enabled same-role rows; COALESCE(-1)+1=0 when no peers.
+	var maxPri int
+	if err := tx.QueryRow(`SELECT COALESCE(MAX(priority), -1) FROM pools WHERE role = ? AND enabled = 1`, string(p.Role)).Scan(&maxPri); err != nil {
+		return err
+	}
+	p.Priority = maxPri + 1
+
+	enabled := 0
+	if p.Enabled {
+		enabled = 1
+	}
+	var bashTimeoutMs *int64
+	if p.BashTimeout != nil {
+		ms := p.BashTimeout.Milliseconds()
+		bashTimeoutMs = &ms
+	}
+	scope := string(p.Scope)
+	if scope == "" {
+		scope = string(types.PoolScopeShared)
+	}
+	_, err = tx.Exec(`
+INSERT INTO pools (id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		p.ID, p.Name, string(p.Provider), p.Endpoint, p.Model,
+		p.Capacity, enabled, p.APIKey, string(p.Role), p.CreatedAt.Unix(), p.Priority, p.Temperature,
+		p.MaxTurns, p.MaxInputTokens, bashTimeoutMs, p.OutputCap, scope, p.WorkspaceID)
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// ReconcilePoolPriorities walks each role and reassigns sequential priorities
+// to any rows tied at the same priority value. Display order (priority ASC,
+// created_at ASC, id ASC — matching ListPools) is preserved. Idempotent:
+// no-op when every role already has strictly increasing priorities.
+// Returns the number of rows mutated.
+func (s *Store) ReconcilePoolPriorities() (int, error) {
+	if s == nil || s.DB == nil {
+		return 0, errors.New("store unavailable")
+	}
+	roles := []types.Role{types.RolePlan, types.RoleWork, types.RoleOrchestrator}
+	total := 0
+	for _, role := range roles {
+		rows, err := s.DB.Query(`
+SELECT id, priority FROM pools
+WHERE role = ?
+ORDER BY priority ASC, created_at ASC, id ASC`, string(role))
+		if err != nil {
+			return total, err
+		}
+		type poolRow struct {
+			id       string
+			priority int
+		}
+		var poolRows []poolRow
+		for rows.Next() {
+			var r poolRow
+			if err := rows.Scan(&r.id, &r.priority); err != nil {
+				rows.Close()
+				return total, err
+			}
+			poolRows = append(poolRows, r)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return total, err
+		}
+
+		hasTies := false
+		for i := 1; i < len(poolRows); i++ {
+			if poolRows[i].priority == poolRows[i-1].priority {
+				hasTies = true
+				break
+			}
+		}
+		if !hasTies {
+			continue
+		}
+
+		tx, err := s.DB.Begin()
+		if err != nil {
+			return total, err
+		}
+		for i, r := range poolRows {
+			if _, err := tx.Exec(`UPDATE pools SET priority = ? WHERE id = ?`, i, r.id); err != nil {
+				_ = tx.Rollback()
+				return total, err
+			}
+			total++
+		}
+		if err := tx.Commit(); err != nil {
+			return total, err
+		}
+	}
+	return total, nil
 }
 
 // RebindWorkspacePools sets scope='shared' and workspace_id='' for every pool

--- a/internal/store/pools_test.go
+++ b/internal/store/pools_test.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -87,5 +89,202 @@ func TestListPoolsOrdering(t *testing.T) {
 	}
 	if rows[0].ID != "earlier" {
 		t.Errorf("rows[0] = %s, want earlier (ordered by created_at asc)", rows[0].ID)
+	}
+}
+
+func TestCreatePool_AssignsNextPriority(t *testing.T) {
+	s := openTempStore(t)
+	now := time.Now()
+	ids := []string{"p1", "p2", "p3"}
+	for i, id := range ids {
+		p := types.Pool{
+			ID:        id,
+			Provider:  types.ProviderClaude,
+			Model:     "m",
+			Capacity:  1,
+			Enabled:   true,
+			Role:      types.RoleWork,
+			CreatedAt: now.Add(time.Duration(i) * time.Second),
+		}
+		if err := s.CreatePool(p); err != nil {
+			t.Fatalf("CreatePool %s: %v", id, err)
+		}
+	}
+	for i, id := range ids {
+		got, err := s.GetPool(id)
+		if err != nil {
+			t.Fatalf("GetPool %s: %v", id, err)
+		}
+		if got.Priority != i {
+			t.Errorf("pool %s: priority = %d, want %d", id, got.Priority, i)
+		}
+	}
+}
+
+func TestCreatePool_IgnoresUserSuppliedPriority(t *testing.T) {
+	s := openTempStore(t)
+	p := types.Pool{ID: "p1", Provider: types.ProviderClaude, Model: "m", Capacity: 1, Enabled: true, Role: types.RoleWork, Priority: 99, CreatedAt: time.Now()}
+	if err := s.CreatePool(p); err != nil {
+		t.Fatalf("CreatePool: %v", err)
+	}
+	got, _ := s.GetPool("p1")
+	if got.Priority != 0 {
+		t.Errorf("Priority = %d, want 0 (MAX+1 with no enabled peers)", got.Priority)
+	}
+}
+
+func TestCreatePool_OnlyConsidersEnabledSameRole(t *testing.T) {
+	s := openTempStore(t)
+	now := time.Now()
+	// Disabled work pool at priority=5 — must not count toward MAX.
+	disabled := types.Pool{ID: "disabled-work", Provider: types.ProviderClaude, Model: "m", Capacity: 1, Enabled: false, Role: types.RoleWork, Priority: 5, CreatedAt: now}
+	if err := s.SavePool(disabled); err != nil {
+		t.Fatalf("SavePool disabled: %v", err)
+	}
+	// Enabled plan pool at priority=10 — different role, must be ignored.
+	plan := types.Pool{ID: "plan-pool", Provider: types.ProviderClaude, Model: "m", Capacity: 1, Enabled: true, Role: types.RolePlan, Priority: 10, CreatedAt: now}
+	if err := s.SavePool(plan); err != nil {
+		t.Fatalf("SavePool plan: %v", err)
+	}
+	// New enabled work pool — no enabled work peers → priority=0.
+	newWork := types.Pool{ID: "new-work", Provider: types.ProviderClaude, Model: "m", Capacity: 1, Enabled: true, Role: types.RoleWork, CreatedAt: now.Add(time.Second)}
+	if err := s.CreatePool(newWork); err != nil {
+		t.Fatalf("CreatePool: %v", err)
+	}
+	got, _ := s.GetPool("new-work")
+	if got.Priority != 0 {
+		t.Errorf("Priority = %d, want 0 (disabled peer excluded from MAX)", got.Priority)
+	}
+}
+
+func TestCreatePool_RejectsDuplicateID(t *testing.T) {
+	s := openTempStore(t)
+	p := types.Pool{ID: "dup", Provider: types.ProviderClaude, Model: "m", Capacity: 1, Enabled: true, Role: types.RoleWork, CreatedAt: time.Now()}
+	if err := s.CreatePool(p); err != nil {
+		t.Fatalf("first CreatePool: %v", err)
+	}
+	if err := s.CreatePool(p); !errors.Is(err, ErrPoolExists) {
+		t.Errorf("second CreatePool: got %v, want ErrPoolExists", err)
+	}
+}
+
+func TestSavePool_PreservesPriorityOnUpdate(t *testing.T) {
+	s := openTempStore(t)
+	p := types.Pool{ID: "p1", Provider: types.ProviderClaude, Model: "m", Capacity: 1, Enabled: true, Role: types.RoleWork, CreatedAt: time.Now()}
+	if err := s.CreatePool(p); err != nil {
+		t.Fatalf("CreatePool: %v", err)
+	}
+	got, _ := s.GetPool("p1")
+	got.Priority = 7
+	if err := s.SavePool(got); err != nil {
+		t.Fatalf("SavePool: %v", err)
+	}
+	after, _ := s.GetPool("p1")
+	if after.Priority != 7 {
+		t.Errorf("Priority after SavePool = %d, want 7", after.Priority)
+	}
+}
+
+func TestReconcilePoolPriorities_TiedAtZero(t *testing.T) {
+	s := openTempStore(t)
+	t1 := time.Unix(1700000000, 0)
+	t2 := time.Unix(1700000100, 0)
+	_ = s.SavePool(types.Pool{ID: "older", Provider: types.ProviderClaude, Model: "m", Capacity: 1, Enabled: true, Role: types.RoleWork, Priority: 0, CreatedAt: t1})
+	_ = s.SavePool(types.Pool{ID: "newer", Provider: types.ProviderClaude, Model: "m", Capacity: 1, Enabled: true, Role: types.RoleWork, Priority: 0, CreatedAt: t2})
+
+	n, err := s.ReconcilePoolPriorities()
+	if err != nil {
+		t.Fatalf("ReconcilePoolPriorities: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("mutated rows = %d, want 2", n)
+	}
+	olderAfter, _ := s.GetPool("older")
+	newerAfter, _ := s.GetPool("newer")
+	if olderAfter.Priority != 0 {
+		t.Errorf("older.Priority = %d, want 0", olderAfter.Priority)
+	}
+	if newerAfter.Priority != 1 {
+		t.Errorf("newer.Priority = %d, want 1", newerAfter.Priority)
+	}
+}
+
+func TestReconcilePoolPriorities_AlreadyOrdered_Noop(t *testing.T) {
+	s := openTempStore(t)
+	for i := 0; i < 3; i++ {
+		p := types.Pool{
+			ID:       fmt.Sprintf("p%d", i),
+			Provider: types.ProviderClaude,
+			Model:    "m",
+			Capacity: 1,
+			Enabled:  true,
+			Role:     types.RoleWork,
+			Priority: i,
+			CreatedAt: time.Unix(1700000000+int64(i)*100, 0),
+		}
+		if err := s.SavePool(p); err != nil {
+			t.Fatalf("SavePool p%d: %v", i, err)
+		}
+	}
+	n, err := s.ReconcilePoolPriorities()
+	if err != nil {
+		t.Fatalf("ReconcilePoolPriorities: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("mutated rows = %d, want 0 (no ties)", n)
+	}
+	for i := 0; i < 3; i++ {
+		got, _ := s.GetPool(fmt.Sprintf("p%d", i))
+		if got.Priority != i {
+			t.Errorf("p%d.Priority = %d, want %d", i, got.Priority, i)
+		}
+	}
+}
+
+func TestReconcilePoolPriorities_PerRoleScope(t *testing.T) {
+	s := openTempStore(t)
+	t1 := time.Unix(1700000000, 0)
+	t2 := time.Unix(1700000100, 0)
+	// Two work pools tied at 0.
+	_ = s.SavePool(types.Pool{ID: "w1", Provider: types.ProviderClaude, Model: "m", Capacity: 1, Enabled: true, Role: types.RoleWork, Priority: 0, CreatedAt: t1})
+	_ = s.SavePool(types.Pool{ID: "w2", Provider: types.ProviderClaude, Model: "m", Capacity: 1, Enabled: true, Role: types.RoleWork, Priority: 0, CreatedAt: t2})
+	// Plan pools already at 0,1 — no ties.
+	_ = s.SavePool(types.Pool{ID: "plan1", Provider: types.ProviderClaude, Model: "m", Capacity: 1, Enabled: true, Role: types.RolePlan, Priority: 0, CreatedAt: t1})
+	_ = s.SavePool(types.Pool{ID: "plan2", Provider: types.ProviderClaude, Model: "m", Capacity: 1, Enabled: true, Role: types.RolePlan, Priority: 1, CreatedAt: t2})
+
+	n, err := s.ReconcilePoolPriorities()
+	if err != nil {
+		t.Fatalf("ReconcilePoolPriorities: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("mutated rows = %d, want 2 (work role only)", n)
+	}
+	p1, _ := s.GetPool("plan1")
+	p2, _ := s.GetPool("plan2")
+	if p1.Priority != 0 || p2.Priority != 1 {
+		t.Errorf("plan priorities changed: plan1=%d plan2=%d, want 0,1", p1.Priority, p2.Priority)
+	}
+}
+
+func TestReconcilePoolPriorities_Idempotent(t *testing.T) {
+	s := openTempStore(t)
+	t1 := time.Unix(1700000000, 0)
+	t2 := time.Unix(1700000100, 0)
+	_ = s.SavePool(types.Pool{ID: "w1", Provider: types.ProviderClaude, Model: "m", Capacity: 1, Enabled: true, Role: types.RoleWork, Priority: 0, CreatedAt: t1})
+	_ = s.SavePool(types.Pool{ID: "w2", Provider: types.ProviderClaude, Model: "m", Capacity: 1, Enabled: true, Role: types.RoleWork, Priority: 0, CreatedAt: t2})
+
+	n1, err := s.ReconcilePoolPriorities()
+	if err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	if n1 != 2 {
+		t.Errorf("first reconcile: mutated %d rows, want 2", n1)
+	}
+	n2, err := s.ReconcilePoolPriorities()
+	if err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if n2 != 0 {
+		t.Errorf("second reconcile: mutated %d rows, want 0", n2)
 	}
 }


### PR DESCRIPTION
## Summary

- New pools inserted via the Settings → Pools UI now land **behind** every existing pool of the same role (priority = MAX(enabled peers)+1 instead of defaulting to 0), eliminating the silent 50/50 round-robin split.
- A one-time idempotent startup reconciler (`ReconcilePoolPriorities`) walks each role and assigns sequential priorities to any tied rows, fixing existing databases on first launch without requiring the user to drag anything.
- The UI preference label now shows three honest states: **← preferred** (unique lowest priority), **← shared (round-robin)** (amber, tied at lowest), and **← fallback** (last in the capable list).

## Files modified

- `internal/store/pools.go` — `ErrPoolExists`, `validatePool` helper, `CreatePool` (with tx), `ReconcilePoolPriorities`
- `internal/store/pools_test.go` — 9 new tests (CreatePool priority assignment, duplicate rejection, enabled-only scoping, SavePool update preservation, reconciler correctness/idempotency/per-role scoping)
- `app.go` — `App.CreatePool` Wails binding; startup call to `ReconcilePoolPriorities` before pool-registry sync
- `frontend/src/components/PoolEditModal.tsx` — calls `CreatePool` for new rows, `SavePool` for edits
- `frontend/src/components/PoolsPanel.tsx` — `preferenceState()` function; `SortablePoolRow` receives `rolePeers` instead of `isFirst`/`isLast`; `PoolRow.preferenceHint` widened to `React.ReactNode`
- `frontend/wailsjs/go/main/App.{d.ts,js}` — `CreatePool` binding (regenerated by `wails build`)

## Verification

| Gate | Command | Result |
|------|---------|--------|
| Go vet | `go vet ./internal/store/... ./internal/types/...` | **pass** |
| Go tests | `go test ./internal/store/...` | **pass** — 11/11 tests (9 new) |
| TypeScript | `npx tsc --noEmit` (frontend/) | **pass** |
| Build | `wails build` | **pass** (9.5 s) |
| Smoke test | `npx playwright test tests/e2e/startup.spec.ts` | **pass** (1/1) |

Commit tier: **Tier 2b** (unsigned local commit — no GPG key available, signed commits not required on this branch).

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-231

Closes #231