### PR TITLE
feat(#232): refuse ready plans when issue fetch fails; add content-relevance validator and UI banner

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -128,6 +128,21 @@ export function Card({ issue, workspaceColor, workspaceLabel, relatedSiblings, o
     return { revision: p.revision };
   })();
 
+  // Issue #232: detect plans where the planner admitted it could not fetch
+  // the GitHub issue body. Show a yellow warning banner on the card so the
+  // user knows the plan may be off-topic or incomplete.
+  const planHasFetchWarning = (() => {
+    const p = view?.latest_plan;
+    if (!p) return false;
+    const combined = [p.plan_markdown ?? "", (p as any).goal_summary ?? "", (p as any).executive_summary ?? ""].join(" ").toLowerCase();
+    return [
+      "i couldn't fetch", "i could not fetch", "failed to retrieve the issue",
+      "could not access the issue", "unable to fetch the issue", "i was unable to read",
+      "i could not read the issue", "i couldn't read the issue", "failed to fetch the issue",
+      "cannot fetch the issue", "unable to retrieve the issue", "couldn't access the issue",
+    ].some(phrase => combined.includes(phrase));
+  })();
+
   const blocked = (issue.dependencies ?? []).length > 0;
   const isPrimitive = !blocked && (issue.priority ?? 0) >= 0.7;
 
@@ -307,6 +322,12 @@ export function Card({ issue, workspaceColor, workspaceLabel, relatedSiblings, o
         className="text-sm text-slate-900 dark:text-slate-100 mt-1 line-clamp-2"
         onContextMenu={(e) => openCardMenu(e, [{ label: "Copy title", text: issue.title }])}
       >{issue.title}</div>
+
+      {planHasFetchWarning && (
+        <div className="mt-1 px-2 py-1 text-xs rounded bg-yellow-500/20 text-yellow-700 dark:text-yellow-300 border border-yellow-500/40">
+          ⚠ Planner could not fetch the GitHub issue — plan may be incomplete
+        </div>
+      )}
 
       <StatusRow
         activeSession={activeSession}

--- a/internal/harness/tools.go
+++ b/internal/harness/tools.go
@@ -12,11 +12,13 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	"prismconductor/internal/llm"
 	"prismconductor/internal/planio"
+	"prismconductor/internal/skills/validator"
 )
 
 // planFilePathRE matches a path under `.prismconductor/plans/` whose basename
@@ -238,6 +240,12 @@ func toolWrite(_ context.Context, e *env, raw json.RawMessage) (string, error) {
 	if planFilePathRE.MatchString(filepath.ToSlash(args.FilePath)) {
 		if err := planio.ValidatePlanJSON([]byte(args.Content)); err != nil {
 			return "", fmt.Errorf("plan rejected by validator (#71): %w. Fix the field(s) above and call Write again — do NOT proceed past this without a passing plan", err)
+		}
+		// Issue #232: content-relevance gate. Banned-phrase check is always
+		// enforced; token-overlap check runs only when gh issue view succeeds.
+		issueBody := fetchIssueBodyForValidation(e.Cwd, args.Content)
+		if err := validator.ValidatePlanContent([]byte(args.Content), 3, issueBody); err != nil {
+			return "", fmt.Errorf("plan rejected by content validator (#232): %w. Set ready_to_execute: false or ensure the issue body was fetched before calling Write", err)
 		}
 	}
 	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
@@ -530,4 +538,33 @@ func toolTodoWrite(_ context.Context, e *env, raw json.RawMessage) (string, erro
 		lines[i] = fmt.Sprintf("[%s] %s", t.Status, t.Content)
 	}
 	return fmt.Sprintf("todo list updated (%d items)\n%s", len(args.Todos), strings.Join(lines, "\n")), nil
+}
+
+// fetchIssueBodyForValidation attempts to fetch the GitHub issue title+body
+// corresponding to the issue_number in planJSON using `gh issue view`. Returns
+// the concatenated title and body on success, or an empty string on any error
+// so the caller can skip the overlap check rather than hard-failing.
+func fetchIssueBodyForValidation(cwd, planJSON string) string {
+	var p struct {
+		IssueNumber int `json:"issue_number"`
+	}
+	if err := json.Unmarshal([]byte(planJSON), &p); err != nil || p.IssueNumber <= 0 {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "issue", "view", strconv.Itoa(p.IssueNumber), "--json", "title,body")
+	cmd.Dir = cwd
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	var issue struct {
+		Title string `json:"title"`
+		Body  string `json:"body"`
+	}
+	if err := json.Unmarshal(out, &issue); err != nil {
+		return ""
+	}
+	return issue.Title + " " + issue.Body
 }

--- a/internal/skills/bundle/skills/conductor-plan.md
+++ b/internal/skills/bundle/skills/conductor-plan.md
@@ -21,6 +21,17 @@ If `--related-repos` is set: the listed paths are SIBLING repositories you may g
 ## Behavior
 
 1. Fetch the issue body via `gh issue view <number> --json title,body,labels`.
+
+   **BLOCKED on fetch failure (NON-NEGOTIABLE):** If `gh issue view` exits non-zero
+   for any reason (auth error, network failure, missing issue, `gh` not installed), you MUST:
+   - Print `BLOCKED: cannot fetch issue #<number>: <first line of error output>` on its own line.
+   - Exit immediately. Do **not** write any plan file.
+
+   Writing a plan without reading the issue body is not acceptable. The body contains
+   the requirements and context that make accurate planning possible. Do NOT set
+   `ready_to_execute: true` based on the issue title alone under any circumstances.
+   The harness validator enforces this: any plan with `ready_to_execute: true` that
+   contains phrases like "I couldn't fetch the issue" will be rejected at write time.
 2. Read `CLAUDE.md` and `.claude/rules/*.md` if present (silently skip if absent — see §15.8).
 3. Grep the repo for terms in the issue title and body that name files/symbols.
 4. Run `gh label list -R <owner>/<repo> --json name,color,description --limit 200` to see the

--- a/internal/skills/bundle/tests/conductor_plan_fetch_failure_test.go
+++ b/internal/skills/bundle/tests/conductor_plan_fetch_failure_test.go
@@ -1,0 +1,100 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"prismconductor/internal/skills/bundle"
+	"prismconductor/internal/skills/validator"
+)
+
+// TestConductorPlanSkillDocContainsBLOCKEDRule verifies that the bundled
+// conductor-plan.md skill doc includes the BLOCKED-on-fetch-failure rule
+// (issue #232). The skill doc is the authoritative instruction to the planner
+// model; this test is a canary that fires if someone edits it away.
+func TestConductorPlanSkillDocContainsBLOCKEDRule(t *testing.T) {
+	content, err := bundle.FS.ReadFile("skills/conductor-plan.md")
+	if err != nil {
+		t.Fatalf("cannot read bundled conductor-plan.md: %v", err)
+	}
+	text := string(content)
+
+	required := []string{
+		"BLOCKED on fetch failure",
+		"BLOCKED: cannot fetch issue",
+		"ready_to_execute: true",
+	}
+	for _, phrase := range required {
+		if !strings.Contains(text, phrase) {
+			t.Errorf("conductor-plan.md missing required phrase %q — the BLOCKED-on-fetch-failure rule may have been removed", phrase)
+		}
+	}
+}
+
+// TestBannedPhrasesListIsNonEmpty ensures the validator's banned-phrase list
+// has at least the core set of fetch-failure indicators.
+func TestBannedPhrasesListIsNonEmpty(t *testing.T) {
+	if len(validator.BannedPhrases) == 0 {
+		t.Fatal("validator.BannedPhrases is empty — no fetch-failure detection possible")
+	}
+	mustContain := []string{
+		"i couldn't fetch",
+		"failed to retrieve the issue",
+		"could not access the issue",
+	}
+	for _, phrase := range mustContain {
+		found := false
+		for _, bp := range validator.BannedPhrases {
+			if bp == phrase {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("validator.BannedPhrases is missing core phrase %q", phrase)
+		}
+	}
+}
+
+// TestFetchFailurePhraseDetectedInPlanMarkdown is an integration-style smoke
+// test: a plan whose plan_markdown contains a fetch-failure admission triggers
+// the content validator when ready_to_execute is true.
+func TestFetchFailurePhraseDetectedInPlanMarkdown(t *testing.T) {
+	planJSON := `{
+		"issue_number": 99,
+		"revision": 1,
+		"plan_markdown": "I couldn't fetch the issue body from GitHub due to auth error.",
+		"goal_summary": "Unknown.",
+		"executive_summary": "Unknown.",
+		"files_to_modify": [],
+		"dependencies_detected": [],
+		"questions": [],
+		"estimated_complexity": "S",
+		"ready_to_execute": true
+	}`
+	err := validator.ValidatePlanContent([]byte(planJSON), 0, "")
+	if err == nil {
+		t.Fatal("expected content validator to reject plan with banned phrase + ready_to_execute:true")
+	}
+}
+
+// TestFetchFailurePhraseAllowedWhenNotReady verifies that a plan with a
+// fetch-failure phrase but ready_to_execute: false passes the content
+// validator (the planner correctly declined to mark it ready).
+func TestFetchFailurePhraseAllowedWhenNotReady(t *testing.T) {
+	planJSON := `{
+		"issue_number": 99,
+		"revision": 1,
+		"plan_markdown": "I couldn't fetch the issue — please paste the body.",
+		"goal_summary": "",
+		"executive_summary": "",
+		"files_to_modify": [],
+		"dependencies_detected": [],
+		"questions": [],
+		"estimated_complexity": "S",
+		"ready_to_execute": false
+	}`
+	if err := validator.ValidatePlanContent([]byte(planJSON), 0, ""); err != nil {
+		t.Fatalf("expected plan with fetch-failure phrase but ready:false to pass, got: %v", err)
+	}
+}

--- a/internal/skills/validator/plan_validator.go
+++ b/internal/skills/validator/plan_validator.go
@@ -1,0 +1,111 @@
+// Package validator provides content-relevance checks for conductor plan files
+// (issue #232). These checks are layered on top of the structural validation
+// in internal/planio and enforce that the planner actually read the GitHub issue
+// before claiming the plan is ready to execute.
+package validator
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// BannedPhrases are lowercase substrings that indicate the planner failed to
+// fetch the GitHub issue body. A plan with ready_to_execute: true that
+// contains any of these phrases must be rejected.
+var BannedPhrases = []string{
+	"i couldn't fetch",
+	"i could not fetch",
+	"failed to retrieve the issue",
+	"could not access the issue",
+	"unable to fetch the issue",
+	"i was unable to read",
+	"i could not read the issue",
+	"i couldn't read the issue",
+	"failed to fetch the issue",
+	"cannot fetch the issue",
+	"unable to retrieve the issue",
+	"couldn't access the issue",
+}
+
+// ContainsBannedPhrase returns the first matching banned phrase and true when
+// the lowercased text matches any entry in BannedPhrases.
+func ContainsBannedPhrase(text string) (string, bool) {
+	lower := strings.ToLower(text)
+	for _, phrase := range BannedPhrases {
+		if strings.Contains(lower, phrase) {
+			return phrase, true
+		}
+	}
+	return "", false
+}
+
+// longTokens returns the set of unique lowercased words of length >= minLen
+// found in text, stripping punctuation.
+func longTokens(text string, minLen int) map[string]struct{} {
+	out := make(map[string]struct{})
+	for _, word := range strings.FieldsFunc(strings.ToLower(text), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}) {
+		if len(word) >= minLen {
+			out[word] = struct{}{}
+		}
+	}
+	return out
+}
+
+// CountTokenOverlap returns the number of distinct tokens of length >= minLen
+// that appear in both a and b.
+func CountTokenOverlap(a, b string, minLen int) int {
+	tokensA := longTokens(a, minLen)
+	tokensB := longTokens(b, minLen)
+	count := 0
+	for tok := range tokensA {
+		if _, ok := tokensB[tok]; ok {
+			count++
+		}
+	}
+	return count
+}
+
+// planContent is the subset of plan fields checked for content relevance.
+type planContent struct {
+	ReadyToExecute   bool   `json:"ready_to_execute"`
+	PlanMarkdown     string `json:"plan_markdown"`
+	GoalSummary      string `json:"goal_summary"`
+	ExecutiveSummary string `json:"executive_summary"`
+}
+
+// ValidatePlanContent checks a plan JSON document for content-relevance issues.
+//
+// It rejects any plan with ready_to_execute: true that contains a banned
+// fetch-failure phrase. When issueBody is non-empty and ready_to_execute is
+// true, it also requires that at least minOverlap distinct long tokens (length
+// >= 8) appear in both the plan and the issue body.
+//
+// Structural errors in planJSON are ignored — callers should run
+// planio.ValidatePlanJSON first.
+func ValidatePlanContent(planJSON []byte, minOverlap int, issueBody string) error {
+	var p planContent
+	if err := json.Unmarshal(planJSON, &p); err != nil {
+		return nil
+	}
+
+	combined := strings.Join([]string{p.PlanMarkdown, p.GoalSummary, p.ExecutiveSummary}, " ")
+
+	if phrase, found := ContainsBannedPhrase(combined); found {
+		if p.ReadyToExecute {
+			return fmt.Errorf("plan is marked ready_to_execute but contains fetch-failure marker %q — set ready_to_execute: false when the issue body could not be fetched", phrase)
+		}
+	}
+
+	if issueBody != "" && p.ReadyToExecute && minOverlap > 0 {
+		overlap := CountTokenOverlap(combined, issueBody, 8)
+		if overlap < minOverlap {
+			return fmt.Errorf("plan has insufficient token overlap with the issue body (%d of %d required distinct long tokens match) — verify the issue fetch succeeded before marking ready_to_execute: true", overlap, minOverlap)
+		}
+	}
+
+	return nil
+}

--- a/internal/skills/validator/tests/plan_content_relevance_test.go
+++ b/internal/skills/validator/tests/plan_content_relevance_test.go
@@ -1,0 +1,150 @@
+package tests
+
+import (
+	"testing"
+
+	"prismconductor/internal/skills/validator"
+)
+
+func TestContainsBannedPhrase(t *testing.T) {
+	cases := []struct {
+		text  string
+		found bool
+	}{
+		{"I couldn't fetch the issue from GitHub.", true},
+		{"I could not fetch the issue body.", true},
+		{"Failed to retrieve the issue.", true},
+		{"Could not access the issue.", true},
+		{"Unable to fetch the issue — auth error.", true},
+		{"I was unable to read the issue.", true},
+		{"I could not read the issue body.", true},
+		{"I couldn't read the issue.", true},
+		{"Failed to fetch the issue.", true},
+		{"Cannot fetch the issue.", true},
+		{"Unable to retrieve the issue.", true},
+		{"Couldn't access the issue.", true},
+		// Case-insensitive.
+		{"FAILED TO RETRIEVE THE ISSUE.", true},
+		// Clean plan text — no banned phrases.
+		{"Add a new endpoint to the API that returns user profiles.", false},
+		{"Fix the nil dereference in the auth middleware.", false},
+		{"Refactor the session pool to reduce memory usage.", false},
+	}
+
+	for _, tc := range cases {
+		phrase, found := validator.ContainsBannedPhrase(tc.text)
+		if found != tc.found {
+			t.Errorf("ContainsBannedPhrase(%q): got found=%v phrase=%q, want found=%v", tc.text, found, phrase, tc.found)
+		}
+	}
+}
+
+func TestCountTokenOverlap(t *testing.T) {
+	a := "authentication middleware refactoring session"
+	b := "refactoring the authentication layer in session handling"
+	overlap := validator.CountTokenOverlap(a, b, 8)
+	// "authentication", "refactoring", "middleware" (len<8? no: 10), "session" (7 < 8)
+	// tokens >=8: "authentication"(14), "refactoring"(11), "middleware"(10) from a
+	// tokens >=8: "refactoring"(11), "authentication"(14), "handling"(8) from b
+	// overlap: "authentication", "refactoring" = 2
+	if overlap < 2 {
+		t.Errorf("CountTokenOverlap: expected >= 2, got %d", overlap)
+	}
+
+	// No overlap at all.
+	zero := validator.CountTokenOverlap("apples oranges", "something completely different", 8)
+	if zero != 0 {
+		t.Errorf("CountTokenOverlap: expected 0 for disjoint texts, got %d", zero)
+	}
+}
+
+const validReadyPlan = `{
+	"issue_number": 42,
+	"revision": 1,
+	"plan_markdown": "Add a retry mechanism to the authentication middleware to handle transient database timeouts.",
+	"goal_summary": "Improve resilience of the authentication layer.",
+	"executive_summary": "Users will see fewer login failures during database hiccups.",
+	"files_to_modify": [],
+	"dependencies_detected": [],
+	"questions": [],
+	"estimated_complexity": "S",
+	"ready_to_execute": true
+}`
+
+const bannedPhraseReadyPlan = `{
+	"issue_number": 42,
+	"revision": 1,
+	"plan_markdown": "I couldn't fetch the issue body so I am guessing at the requirements.",
+	"goal_summary": "Unknown — I could not read the issue.",
+	"executive_summary": "Unknown outcome.",
+	"files_to_modify": [],
+	"dependencies_detected": [],
+	"questions": [],
+	"estimated_complexity": "S",
+	"ready_to_execute": true
+}`
+
+const bannedPhraseNotReadyPlan = `{
+	"issue_number": 42,
+	"revision": 1,
+	"plan_markdown": "I couldn't fetch the issue body — please paste the text.",
+	"goal_summary": "",
+	"executive_summary": "",
+	"files_to_modify": [],
+	"dependencies_detected": [],
+	"questions": [],
+	"estimated_complexity": "S",
+	"ready_to_execute": false
+}`
+
+func TestValidatePlanContent_CleanReadyPlan(t *testing.T) {
+	if err := validator.ValidatePlanContent([]byte(validReadyPlan), 0, ""); err != nil {
+		t.Fatalf("expected clean plan to pass, got: %v", err)
+	}
+}
+
+func TestValidatePlanContent_BannedPhraseReadyPlanRejected(t *testing.T) {
+	err := validator.ValidatePlanContent([]byte(bannedPhraseReadyPlan), 0, "")
+	if err == nil {
+		t.Fatal("expected rejection for banned phrase + ready_to_execute: true, got nil")
+	}
+}
+
+func TestValidatePlanContent_BannedPhraseNotReadyPlanAllowed(t *testing.T) {
+	// Banned phrases are only hard-rejected when ready_to_execute: true.
+	// When false, the plan can contain them (the planner is correctly
+	// signalling it couldn't fetch the issue and not marking it ready).
+	if err := validator.ValidatePlanContent([]byte(bannedPhraseNotReadyPlan), 0, ""); err != nil {
+		t.Fatalf("expected plan with banned phrase but ready_to_execute:false to pass, got: %v", err)
+	}
+}
+
+func TestValidatePlanContent_TokenOverlapSufficient(t *testing.T) {
+	issueBody := "authentication middleware refactoring transient database timeouts resilience"
+	if err := validator.ValidatePlanContent([]byte(validReadyPlan), 3, issueBody); err != nil {
+		t.Fatalf("expected sufficient overlap to pass, got: %v", err)
+	}
+}
+
+func TestValidatePlanContent_TokenOverlapInsufficient(t *testing.T) {
+	issueBody := "completely unrelated topic about something else entirely"
+	err := validator.ValidatePlanContent([]byte(validReadyPlan), 3, issueBody)
+	if err == nil {
+		t.Fatal("expected rejection for insufficient token overlap, got nil")
+	}
+}
+
+func TestValidatePlanContent_EmptyIssueBodySkipsOverlapCheck(t *testing.T) {
+	// When issueBody is empty (gh fetch failed), the overlap check is skipped.
+	if err := validator.ValidatePlanContent([]byte(validReadyPlan), 3, ""); err != nil {
+		t.Fatalf("expected empty issueBody to skip overlap check, got: %v", err)
+	}
+}
+
+func TestValidatePlanContent_MalformedJSONReturnsNil(t *testing.T) {
+	// Structural errors are caught by planio.ValidatePlanJSON; content
+	// validator returns nil so callers can surface the structural error.
+	if err := validator.ValidatePlanContent([]byte("{not json"), 0, ""); err != nil {
+		t.Fatalf("expected malformed JSON to return nil, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a BLOCKED-on-fetch-failure rule to `conductor-plan.md`: if `gh issue view` fails, the planner must emit `BLOCKED: cannot fetch issue #<num>: <reason>` and exit without writing any plan file
- New `internal/skills/validator` package with `ValidatePlanContent()` for banned-phrase detection and token-overlap checking; hooked into the harness Write tool as a content-relevance gate after structural validation
- Yellow warning banner in `Card.tsx` surfaces fetch-failure admissions in existing plans so users know when a plan may be off-topic

## Files modified

- `internal/skills/bundle/skills/conductor-plan.md` — BLOCKED-on-fetch-failure skill rule (NON-NEGOTIABLE section)
- `internal/skills/validator/plan_validator.go` — new package: `BannedPhrases`, `ContainsBannedPhrase`, `CountTokenOverlap`, `ValidatePlanContent`
- `internal/harness/tools.go` — calls `ValidatePlanContent` in Write tool after structural validation; `fetchIssueBodyForValidation` helper for best-effort gh fetch
- `frontend/src/components/Card.tsx` — `planHasFetchWarning` computed field + yellow banner JSX
- `internal/skills/bundle/tests/conductor_plan_fetch_failure_test.go` — verifies skill doc contains BLOCKED rule; smoke-tests banned-phrase detection
- `internal/skills/validator/tests/plan_content_relevance_test.go` — full unit coverage: banned phrases, token overlap, ready/not-ready branching, edge cases

## Verification

- **Lint:** `go vet prismconductor/internal/...` — pass
- **TypeScript:** `tsc --noEmit` — pass
- **Build:** `wails build` — pass (29.6s)
- **Smoke test:** `playwright test e2e/startup.spec.ts` — pass (`✓ app boots, React mounts, no console errors`)
- **Tests:** `go test ./internal/skills/... ./internal/harness/... ./internal/planio/...` — all pass (7 packages, 0 failures)
- **Commit tier:** Tier 1 (GitHub API signed commit `eb6ffd9`)

## Workspace

`Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-232`

Closes #232