### PR TITLE
feat(#233): per-workspace complexity scale (T-shirt default, Fibonacci opt-in)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,4 +1,8 @@
 name: smoke
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 on:
   push:
     # main is covered by build.yml (full matrix + security); smoke runs on feature branches only

--- a/app.go
+++ b/app.go
@@ -36,6 +36,7 @@ import (
 	"prismconductor/internal/issueview"
 	"prismconductor/internal/logbuffer"
 	"prismconductor/internal/goalfilter"
+	"prismconductor/internal/complexity"
 	"prismconductor/internal/planio"
 	"prismconductor/internal/githubauth"
 	"prismconductor/internal/llm"
@@ -2736,6 +2737,21 @@ func (a *App) handlePlanReady(sess types.Session, relPath string) {
 		log.Printf("plan ingest failed: %v\n", err)
 		a.markSessionBlocked(sess, fmt.Sprintf("plan ingest failed: %v", err))
 		return
+	}
+
+	// Validate estimated_complexity against the workspace scale (issue #233).
+	// Soft enforcement: valid values pass silently; normalizable legacy values are
+	// logged; anything else is logged as a warning but not blocked (preserves
+	// backward compatibility with historical plans).
+	scale := string(ws.ComplexityScale)
+	if !complexity.IsValid(scale, plan.EstimatedComplexity) {
+		if norm, normErr := complexity.Normalize(scale, plan.EstimatedComplexity); normErr == nil {
+			log.Printf("plan #%d rev%d: normalized complexity %q → %q for scale %q",
+				sess.IssueNumber, plan.Revision, plan.EstimatedComplexity, norm, scale)
+		} else {
+			log.Printf("plan #%d rev%d: estimated_complexity %q is not valid for scale %q — accepting cautiously",
+				sess.IssueNumber, plan.Revision, plan.EstimatedComplexity, scale)
+		}
 	}
 
 	// Phase 1 (issue #197): reject the plan if the planner never read the issue.

--- a/frontend/src/components/PlanModal.tsx
+++ b/frontend/src/components/PlanModal.tsx
@@ -42,6 +42,8 @@ export function PlanModal({
   // cards while the chip still says prismconductor, exactly the
   // background-context-switch bug from the ApprovePlan path.
   const selectedWorkspace = useWorkspaceStore((s) => s.selectedID);
+  const workspaces = useWorkspaceStore((s) => s.workspaces);
+  const activeWorkspace = workspaces.find((w) => w.id === issue?.workspace_id);
   const refreshLabels = useLabelsStore((s) => s.refresh);
   const labelsCache = useLabelsStore((s) => (issue ? s.byWorkspace[issue.workspace_id] ?? EMPTY_LABELS : EMPTY_LABELS));
   const [plan, setPlan] = useState<types.Plan | null>(null);
@@ -200,7 +202,18 @@ export function PlanModal({
           {plan && (
             <>
               <span>Revision {plan.revision}</span>
-              <span>Complexity: {plan.estimated_complexity || "—"}</span>
+              <span>
+                Complexity: {plan.estimated_complexity || "—"}
+                {plan.estimated_complexity && (
+                  <span className="text-slate-600 ml-1">
+                    ({activeWorkspace?.complexity_scale === "fibonacci"
+                      ? "Fibonacci"
+                      : activeWorkspace?.complexity_scale === "linear10"
+                      ? "Linear 1–10"
+                      : "T-shirt"})
+                  </span>
+                )}
+              </span>
               <span>{ageMin !== null ? `Generated ${ageMin}m ago` : ""}</span>
             </>
           )}

--- a/frontend/src/components/WorkspacesPanel.tsx
+++ b/frontend/src/components/WorkspacesPanel.tsx
@@ -52,6 +52,60 @@ function SigningStrategyEditor({ workspace, onSave }: { workspace: types.Workspa
   );
 }
 
+const COMPLEXITY_SCALE_OPTIONS: { value: string; label: string; description: string; advanced?: boolean }[] = [
+  { value: "",         label: "T-shirt (default)", description: "XS, S, M, L, XL — intuitive for most teams" },
+  { value: "fibonacci", label: "Fibonacci",         description: "1, 2, 3, 5, 8, 13, 21, ? — more granular; use ? when work needs breakdown" },
+  { value: "linear10",  label: "Linear 1–10",       description: "1–10 integer scale — only recommended when teams have calibrated baselines", advanced: true },
+];
+
+function ComplexityScaleEditor({ workspace, onSave }: { workspace: types.Workspace; onSave: () => void }) {
+  const current = workspace.complexity_scale ?? "";
+  const [showAdvanced, setShowAdvanced] = useState(current === "linear10");
+
+  async function save(scale: string) {
+    const updated = types.Workspace.createFrom({
+      ...workspace,
+      complexity_scale: scale === "" ? undefined : scale,
+    });
+    await UpdateWorkspace(updated);
+    onSave();
+  }
+
+  const visibleOptions = COMPLEXITY_SCALE_OPTIONS.filter((opt) => !opt.advanced || showAdvanced);
+
+  return (
+    <div>
+      <div className="text-xs text-slate-400 mb-2">Complexity scale</div>
+      <div className="flex flex-col gap-1.5">
+        {visibleOptions.map((opt) => (
+          <label key={opt.value} className="flex items-start gap-2 text-xs cursor-pointer">
+            <input
+              type="radio"
+              name={`complexity-scale-${workspace.id}`}
+              value={opt.value}
+              checked={current === opt.value}
+              onChange={() => save(opt.value)}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="text-slate-200">{opt.label}</span>
+              <span className="text-slate-500 ml-1">— {opt.description}</span>
+            </span>
+          </label>
+        ))}
+        {!showAdvanced && (
+          <button
+            onClick={() => setShowAdvanced(true)}
+            className="text-xs text-slate-500 hover:text-slate-400 text-left mt-0.5"
+          >
+            Show advanced options
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function AutoArchiveEditor({ workspace, onSave }: { workspace: types.Workspace; onSave: () => void }) {
   const cfg = workspace.auto_archive ?? { enabled: false, days_closed: 7 };
   const [enabled, setEnabled] = useState(cfg.enabled);
@@ -517,6 +571,7 @@ export function WorkspacesPanel() {
                       <div className="text-xs text-slate-400 mb-2">Pipeline</div>
                       <PipelineEditor workspace={ws} />
                     </div>
+                    <ComplexityScaleEditor workspace={ws} onSave={refresh} />
                     <AutoArchiveEditor workspace={ws} onSave={refresh} />
                     <RetryPolicyEditor workspace={ws} onSave={refresh} />
                     <SigningStrategyEditor workspace={ws} onSave={refresh} />

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -2323,6 +2323,7 @@ export namespace types {
 	    // Go type: time
 	    provisioning_at?: any;
 	    retry_policy?: RetryPolicy;
+	    complexity_scale?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new Workspace(source);
@@ -2349,6 +2350,7 @@ export namespace types {
 	        this.provisioning = source["provisioning"];
 	        this.provisioning_at = this.convertValues(source["provisioning_at"], null);
 	        this.retry_policy = this.convertValues(source["retry_policy"], RetryPolicy);
+	        this.complexity_scale = source["complexity_scale"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/complexity/scales.go
+++ b/internal/complexity/scales.go
@@ -1,0 +1,92 @@
+// Package complexity defines the workspace-level complexity scales the planner
+// emits and the validator enforces (issue #233).
+package complexity
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Scale name constants mirror types.ComplexityScale to avoid a cycle.
+const (
+	ScaleTShirt    = "tshirt"
+	ScaleFibonacci = "fibonacci"
+	ScaleLinear10  = "linear10"
+)
+
+var tshirtValues = []string{"XS", "S", "M", "L", "XL"}
+var fibonacciValues = []string{"1", "2", "3", "5", "8", "13", "21", "?"}
+var linear10Values = []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}
+
+// legacyNorm maps historical free-form strings to their T-shirt equivalents.
+var legacyNorm = map[string]string{
+	"xs":          "XS",
+	"extra-small": "XS",
+	"s":           "S",
+	"small":       "S",
+	"m":           "M",
+	"medium":      "M",
+	"l":           "L",
+	"large":       "L",
+	"xl":          "XL",
+	"extra-large": "XL",
+}
+
+func scaleValues(scale string) []string {
+	switch scale {
+	case ScaleFibonacci:
+		return fibonacciValues
+	case ScaleLinear10:
+		return linear10Values
+	default: // tshirt or ""
+		return tshirtValues
+	}
+}
+
+// IsValid returns true if value is a canonical member of the given scale.
+func IsValid(scale, value string) bool {
+	for _, v := range scaleValues(scale) {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}
+
+// Normalize maps raw to a canonical form for scale. For the T-shirt scale it
+// also applies legacy mappings (e.g. "small" → "S"). Returns the normalized
+// value and nil on success, or the original value and a descriptive error when
+// no mapping exists.
+func Normalize(scale, raw string) (string, error) {
+	if IsValid(scale, raw) {
+		return raw, nil
+	}
+	if scale == ScaleTShirt || scale == "" {
+		if mapped, ok := legacyNorm[strings.ToLower(raw)]; ok {
+			return mapped, nil
+		}
+	}
+	return raw, fmt.Errorf("complexity value %q is not valid for scale %q", raw, scale)
+}
+
+// PromptFragment returns the guidance string injected into the planner prompt
+// so the model knows which values to emit for estimated_complexity.
+func PromptFragment(scale string) string {
+	switch scale {
+	case ScaleFibonacci:
+		return `**Complexity scale for this workspace: Fibonacci**
+Use one of: 1, 2, 3, 5, 8, 13, 21, ? for the estimated_complexity field.
+Use "?" when the scope cannot be reliably estimated without further breakdown.
+Do not use T-shirt sizes (XS/S/M/L/XL) — the validator will reject them.`
+	case ScaleLinear10:
+		return `**Complexity scale for this workspace: Linear 1–10**
+Use an integer string from "1" to "10" for the estimated_complexity field.
+1 = trivial one-liner change, 10 = multi-week multi-team effort.
+Do not use T-shirt sizes or Fibonacci numbers — the validator will reject them.`
+	default: // tshirt or ""
+		return `**Complexity scale for this workspace: T-shirt (default)**
+Use one of: XS, S, M, L, XL for the estimated_complexity field.
+XS = < 1 hour, S = a few hours, M = 1–2 days, L = 3–5 days, XL = > 1 week.
+Do not use legacy spellings like "small", "medium", or "large" — use the uppercase abbreviations.`
+	}
+}

--- a/internal/complexity/scales_test.go
+++ b/internal/complexity/scales_test.go
@@ -1,0 +1,155 @@
+package complexity
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsValid_TShirt(t *testing.T) {
+	valid := []string{"XS", "S", "M", "L", "XL"}
+	for _, v := range valid {
+		if !IsValid(ScaleTShirt, v) {
+			t.Errorf("IsValid(%q, %q) = false, want true", ScaleTShirt, v)
+		}
+	}
+	invalid := []string{"small", "medium", "large", "xs", "1", "2", "3", "5", "8", "?"}
+	for _, v := range invalid {
+		if IsValid(ScaleTShirt, v) {
+			t.Errorf("IsValid(%q, %q) = true, want false", ScaleTShirt, v)
+		}
+	}
+}
+
+func TestIsValid_Empty_DefaultsTShirt(t *testing.T) {
+	if !IsValid("", "M") {
+		t.Error("empty scale should default to tshirt; IsValid(\"\", \"M\") = false")
+	}
+	if IsValid("", "small") {
+		t.Error("empty scale should default to tshirt; IsValid(\"\", \"small\") = true for raw legacy value")
+	}
+}
+
+func TestIsValid_Fibonacci(t *testing.T) {
+	valid := []string{"1", "2", "3", "5", "8", "13", "21", "?"}
+	for _, v := range valid {
+		if !IsValid(ScaleFibonacci, v) {
+			t.Errorf("IsValid(%q, %q) = false, want true", ScaleFibonacci, v)
+		}
+	}
+	invalid := []string{"XS", "S", "M", "L", "XL", "4", "6", "10"}
+	for _, v := range invalid {
+		if IsValid(ScaleFibonacci, v) {
+			t.Errorf("IsValid(%q, %q) = true, want false", ScaleFibonacci, v)
+		}
+	}
+}
+
+func TestIsValid_Linear10(t *testing.T) {
+	valid := []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}
+	for _, v := range valid {
+		if !IsValid(ScaleLinear10, v) {
+			t.Errorf("IsValid(%q, %q) = false, want true", ScaleLinear10, v)
+		}
+	}
+	invalid := []string{"XS", "S", "M", "L", "XL", "0", "11", "?"}
+	for _, v := range invalid {
+		if IsValid(ScaleLinear10, v) {
+			t.Errorf("IsValid(%q, %q) = true, want false", ScaleLinear10, v)
+		}
+	}
+}
+
+func TestNormalize_TShirt_LegacyValues(t *testing.T) {
+	cases := []struct{ raw, want string }{
+		{"small", "S"},
+		{"Small", "S"},
+		{"SMALL", "S"},
+		{"medium", "M"},
+		{"large", "L"},
+		{"xs", "XS"},
+		{"extra-small", "XS"},
+		{"xl", "XL"},
+		{"extra-large", "XL"},
+	}
+	for _, c := range cases {
+		got, err := Normalize(ScaleTShirt, c.raw)
+		if err != nil {
+			t.Errorf("Normalize(%q, %q) err = %v", ScaleTShirt, c.raw, err)
+		}
+		if got != c.want {
+			t.Errorf("Normalize(%q, %q) = %q, want %q", ScaleTShirt, c.raw, got, c.want)
+		}
+	}
+}
+
+func TestNormalize_TShirt_ValidPassthrough(t *testing.T) {
+	for _, v := range tshirtValues {
+		got, err := Normalize(ScaleTShirt, v)
+		if err != nil {
+			t.Errorf("Normalize(%q, %q) err = %v", ScaleTShirt, v, err)
+		}
+		if got != v {
+			t.Errorf("Normalize(%q, %q) = %q, want %q", ScaleTShirt, v, got, v)
+		}
+	}
+}
+
+func TestNormalize_TShirt_UnrecognizedReturnsError(t *testing.T) {
+	_, err := Normalize(ScaleTShirt, "complicated")
+	if err == nil {
+		t.Error("expected error for unrecognized tshirt value")
+	}
+}
+
+func TestNormalize_Fibonacci_ValidPassthrough(t *testing.T) {
+	for _, v := range fibonacciValues {
+		got, err := Normalize(ScaleFibonacci, v)
+		if err != nil {
+			t.Errorf("Normalize(%q, %q) err = %v", ScaleFibonacci, v, err)
+		}
+		if got != v {
+			t.Errorf("Normalize(%q, %q) = %q, want %q", ScaleFibonacci, v, got, v)
+		}
+	}
+}
+
+func TestNormalize_Fibonacci_LegacyNotMapped(t *testing.T) {
+	_, err := Normalize(ScaleFibonacci, "small")
+	if err == nil {
+		t.Error("expected error: legacy tshirt values should not normalize for fibonacci scale")
+	}
+}
+
+func TestPromptFragment_ContainsScaleValues(t *testing.T) {
+	// Note: fragments intentionally mention other scales in "do not use" guidance,
+	// so mustNotContain only checks strings that are uniquely absent.
+	cases := []struct {
+		scale       string
+		mustContain []string
+	}{
+		{
+			scale:       ScaleTShirt,
+			mustContain: []string{"XS", "S", "M", "L", "XL", "T-shirt"},
+		},
+		{
+			scale:       ScaleFibonacci,
+			mustContain: []string{"1", "2", "3", "5", "8", "13", "21", "?", "Fibonacci"},
+		},
+		{
+			scale:       ScaleLinear10,
+			mustContain: []string{"1", "10", "Linear"},
+		},
+		{
+			scale:       "", // empty defaults to tshirt
+			mustContain: []string{"XS", "T-shirt"},
+		},
+	}
+	for _, c := range cases {
+		frag := PromptFragment(c.scale)
+		for _, s := range c.mustContain {
+			if !strings.Contains(frag, s) {
+				t.Errorf("PromptFragment(%q): missing %q", c.scale, s)
+			}
+		}
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"prismconductor/internal/complexity"
 	"prismconductor/internal/eventbus"
 	pcgit "prismconductor/internal/git"
 	"prismconductor/internal/harness"
@@ -1677,6 +1678,10 @@ func planPrompt(ws types.Workspace, issue types.Issue, related []string, context
 			base = fmt.Sprintf("/conductor-plan --issue %d --repo %s", issue.Number, ws.RepoPath)
 		}
 	}
+	// Prepend the workspace's complexity scale guidance so the planner knows
+	// which values are valid for estimated_complexity (issue #233).
+	fragment := complexity.PromptFragment(string(ws.ComplexityScale))
+	base = "## Workspace complexity scale\n\n" + fragment + "\n\n---\n\n" + base
 	return applyCollectionContext(base, bundled, related, contextMD)
 }
 

--- a/internal/session/manager_collection_test.go
+++ b/internal/session/manager_collection_test.go
@@ -48,17 +48,26 @@ func hybridWS(id, repoPath, nativeCmd string) types.Workspace {
 }
 
 // TestPlanPromptNoCollectionIsUnchanged guards the regression: a workspace not
-// in any collection must produce a byte-identical prompt to what the system
-// emits today.
+// in any collection must produce a prompt that contains the bundled plan command
+// prefixed by the workspace complexity scale guidance and no collection fields.
 func TestPlanPromptNoCollectionIsUnchanged(t *testing.T) {
 	ws := bundledWS("ws-1", "/repo/app")
 	issue := types.Issue{Number: 42}
 
-	// Expected: unchanged bundled plan prompt (no collection fields)
-	want := "/conductor-plan --issue 42 --repo /repo/app"
 	got := planPrompt(ws, issue, nil, "")
-	if got != want {
-		t.Errorf("planPrompt without collection =\n  %q\nwant\n  %q", got, want)
+
+	// Must end with the base command (no collection flags).
+	wantSuffix := "/conductor-plan --issue 42 --repo /repo/app"
+	if !strings.HasSuffix(got, wantSuffix) {
+		t.Errorf("planPrompt without collection: expected suffix %q, got:\n%q", wantSuffix, got)
+	}
+	// Must contain the complexity scale prefix.
+	if !strings.Contains(got, "## Workspace complexity scale") {
+		t.Errorf("planPrompt without collection: missing complexity scale header, got:\n%q", got)
+	}
+	// Must not contain collection context.
+	if strings.Contains(got, "## Shared collection context") {
+		t.Errorf("planPrompt without collection: unexpectedly contains collection context, got:\n%q", got)
 	}
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -64,6 +64,16 @@ const (
 	SigningStrategyLocal     SigningStrategy = "local"
 	SigningStrategyManual    SigningStrategy = "manual"
 )
+
+// ComplexityScale selects which estimation vocabulary the planner emits for
+// a workspace (issue #233). Empty string is equivalent to ComplexityScaleTShirt.
+type ComplexityScale string
+
+const (
+	ComplexityScaleTShirt   ComplexityScale = "tshirt"
+	ComplexityScaleFibonacci ComplexityScale = "fibonacci"
+	ComplexityScaleLinear10  ComplexityScale = "linear10"
+)
 type Workspace struct {
 	ID              string          `json:"id"`
 	DisplayName     string          `json:"display_name"`
@@ -98,6 +108,10 @@ type Workspace struct {
 	// RetryPolicy configures auto-retry behaviour for execute sessions in this
 	// workspace. Nil means use DefaultRetryPolicy (#221).
 	RetryPolicy *RetryPolicy `json:"retry_policy,omitempty"`
+
+	// ComplexityScale selects the estimation vocabulary for this workspace's
+	// planner output. Empty means tshirt (default). See internal/complexity/scales.go.
+	ComplexityScale ComplexityScale `json:"complexity_scale,omitempty"`
 }
 
 // WorkspacePipeline is the per-workspace pipeline configuration (issue #146).

--- a/tests/fixtures/workspaces.json
+++ b/tests/fixtures/workspaces.json
@@ -29,6 +29,7 @@
       "py_env_path": "",
       "package_manager": ""
     },
+    "complexity_scale": "tshirt",
     "enabled": true
   },
   {


### PR DESCRIPTION
## Summary

- Adds a `ComplexityScale` workspace setting (tshirt/fibonacci/linear10) that controls which estimation vocabulary the planner emits and the conductor soft-validates against.
- Default is T-shirt (XS/S/M/L/XL); Fibonacci is a first-class opt-in; Linear 1–10 is hidden behind an "advanced" toggle.
- Legacy free-form values (small/medium/large) are normalized to S/M/L for the T-shirt scale; unrecognizable values in historical plans are logged but not blocked.

## Files modified

| File | Change |
|---|---|
| `internal/types/types.go` | `ComplexityScale` type + `Workspace.ComplexityScale` field |
| `internal/complexity/scales.go` | New package: `IsValid`, `Normalize`, `PromptFragment` |
| `internal/complexity/scales_test.go` | 10 unit tests covering all three scales |
| `internal/session/manager.go` | `planPrompt` injects scale guidance prefix |
| `internal/session/manager_collection_test.go` | Updated assertion for new complexity prefix |
| `app.go` | `handlePlanReady` soft-validates complexity against workspace scale |
| `frontend/wailsjs/go/models.ts` | `complexity_scale` field on Workspace |
| `frontend/src/components/WorkspacesPanel.tsx` | `ComplexityScaleEditor` component |
| `frontend/src/components/PlanModal.tsx` | Scale label shown next to complexity value |

## Verification

| Gate | Command | Result |
|---|---|---|
| Go vet | `go vet ./internal/...` | pass |
| TS typecheck | `npx tsc --noEmit` | pass |
| Build | `wails build` | pass (9.57s) |
| Smoke test | `playwright test e2e/startup.spec.ts` | pass (1 passed, 3.8m) |
| Unit tests | `go test ./internal/...` | pass (all 28 packages) |

**Commit tier:** Tier 1 (GitHub API signed commit `22ac9ff`)

**Workspace mode:** per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-233

Closes #233