### PR TITLE
feat(#210): cross-workspace issue dependencies (Phase B)

### DIFF
--- a/app.go
+++ b/app.go
@@ -2229,6 +2229,73 @@ func (a *App) SetIssueLabels(workspaceID string, issueNumber int, names []string
 	return nil
 }
 
+// AddIssueDep appends a cross-workspace dependency to an issue, deduplicating
+// before save. Publishes EvtIssueLabelChanged so the card reassembles (issue #210).
+func (a *App) AddIssueDep(workspaceID string, issueNumber int, dep types.IssueDep) error {
+	if a.store == nil {
+		return fmt.Errorf("store unavailable")
+	}
+	iss, err := a.store.LoadIssue(workspaceID, issueNumber)
+	if err != nil {
+		return err
+	}
+	for _, d := range iss.Dependencies {
+		if d.WorkspaceID == dep.WorkspaceID && d.Number == dep.Number {
+			return nil // already present
+		}
+	}
+	iss.Dependencies = append(iss.Dependencies, dep)
+	if _, err := a.store.SaveIssue(iss); err != nil {
+		return err
+	}
+	if a.bus != nil {
+		a.bus.Publish(eventbus.EvtIssueLabelChanged, map[string]any{
+			"workspace_id": workspaceID,
+			"number":       issueNumber,
+		})
+	}
+	if a.assembler != nil {
+		a.assembler.Reassemble(workspaceID, issueNumber)
+	}
+	return nil
+}
+
+// RemoveIssueDep removes a dependency from an issue. No-op if not present.
+// Publishes EvtIssueLabelChanged so the card reassembles (issue #210).
+func (a *App) RemoveIssueDep(workspaceID string, issueNumber int, dep types.IssueDep) error {
+	if a.store == nil {
+		return fmt.Errorf("store unavailable")
+	}
+	iss, err := a.store.LoadIssue(workspaceID, issueNumber)
+	if err != nil {
+		return err
+	}
+	var next types.IssueDepList
+	for _, d := range iss.Dependencies {
+		if d.WorkspaceID == dep.WorkspaceID && d.Number == dep.Number {
+			continue // remove this one
+		}
+		next = append(next, d)
+	}
+	if len(next) == len(iss.Dependencies) {
+		return nil // not found, no-op
+	}
+	iss.Dependencies = next
+	if _, err := a.store.SaveIssue(iss); err != nil {
+		return err
+	}
+	if a.bus != nil {
+		a.bus.Publish(eventbus.EvtIssueLabelChanged, map[string]any{
+			"workspace_id": workspaceID,
+			"number":       issueNumber,
+		})
+	}
+	if a.assembler != nil {
+		a.assembler.Reassemble(workspaceID, issueNumber)
+	}
+	return nil
+}
+
 // autoApplyPlanLabels intersects plan.SuggestedLabels with the workspace label
 // cache, drops missing names (logged, never invented — issue #24 q3 C),
 // reconciles the prior plan revision's axis label (q2 A), and pushes the

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -33,6 +33,7 @@ type CardStateValue =
   | "in_progress"
   | "blocked"
   | "waiting_for_pool"
+  | "waiting_for_dep"
   | "needs_pr"
   | "orphan_question"
   | "merge_conflict"
@@ -143,6 +144,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, relatedSiblings, o
     ].some(phrase => combined.includes(phrase));
   })();
 
+  const waitingForDep = view?.waiting_for_dep ?? issue.waiting_for_dep ?? null;
   const blocked = (issue.dependencies ?? []).length > 0;
   const isPrimitive = !blocked && (issue.priority ?? 0) >= 0.7;
 
@@ -164,7 +166,8 @@ export function Card({ issue, workspaceColor, workspaceLabel, relatedSiblings, o
         case "merge_conflict":
         case "tests_failing":
         case "plan_failed":     return "blocked";
-        case "review":          return "review";
+        case "review":
+        case "waiting_for_dep": return "review";
         // waiting_for_pool and needs_pr use hardcoded glows below.
         case "waiting_for_pool":
         case "needs_pr":
@@ -345,6 +348,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, relatedSiblings, o
         workspaceID={issue.workspace_id}
         issueNumber={issue.number}
         waitingForPool={issue.waiting_for_pool ?? false}
+        waitingForDep={waitingForDep}
         column={issue.column}
         prNumber={issue.pr_number ?? null}
         testsFailingInfo={testsFailingInfo}
@@ -578,6 +582,7 @@ function StatusRow({
   workspaceID,
   issueNumber,
   waitingForPool,
+  waitingForDep,
   column,
   prNumber,
   testsFailingInfo,
@@ -600,11 +605,12 @@ function StatusRow({
   orphanPRInfo: OrphanPRInfo | null;
   blocked: boolean;
   isPrimitive: boolean;
-  dependencies: number[];
+  dependencies: types.IssueDep[];
   labels: string[];
   workspaceID: string;
   issueNumber: number;
   waitingForPool: boolean;
+  waitingForDep: types.IssueDep | null;
   column: string;
   prNumber: number | null;
   testsFailingInfo: TestsFailingInfo | null;
@@ -1246,7 +1252,15 @@ function StatusRow({
         {isPrimitive && <span className="text-emerald-400">🔴 primitive</span>}
         {blocked && (
           <span className="text-amber-300">
-            🚫 blocked by {dependencies.map((n) => `#${n}`).join(", ")}
+            🚫 blocked by {dependencies.map((d) => d.workspace_id ? `${d.workspace_id}#${d.number}` : `#${d.number}`).join(", ")}
+          </span>
+        )}
+        {waitingForDep && (
+          <span
+            className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-700/30 text-amber-200 border border-amber-700"
+            title={`Waiting for ${waitingForDep.workspace_id || "this workspace"}#${waitingForDep.number} to close before merging`}
+          >
+            ⏳ waiting for {waitingForDep.workspace_id ? `${waitingForDep.workspace_id}#${waitingForDep.number}` : `#${waitingForDep.number}`}
           </span>
         )}
         <LabelChips

--- a/frontend/src/components/PlanModal.tsx
+++ b/frontend/src/components/PlanModal.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { noAutoCorrect } from "../lib/inputs";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { ApprovePlan, LatestPlan, PlanCostEstimate, RejectPlan, SetIssueLabels, SubmitAnswers, WriteAnswersOnly } from "../../wailsjs/go/main/App";
+import { AddIssueDep, ApprovePlan, LatestPlan, ListIssues, PlanCostEstimate, RejectPlan, RemoveIssueDep, SetIssueLabels, SubmitAnswers, WriteAnswersOnly } from "../../wailsjs/go/main/App";
 import { main, types } from "../../wailsjs/go/models";
 import { useIssueStore } from "../stores/issueStore";
 import { useIssueViewStore } from "../stores/useIssueViewStore";
@@ -306,6 +306,8 @@ export function PlanModal({
                 </Section>
               )}
 
+              <DepsSection issue={issue} onIssueRefresh={refreshIssues} />
+
               <Section title="Refine plan (free-form)">
                 <textarea
                   {...noAutoCorrect}
@@ -555,4 +557,154 @@ function minutesAgo(iso: any): number | null {
   const d = new Date(iso);
   if (isNaN(d.getTime())) return null;
   return Math.max(0, Math.floor((Date.now() - d.getTime()) / 60000));
+}
+
+// DepsSection lets users manage cross-workspace issue dependencies (issue #210).
+// Shows current deps as removable chips and a workspace-picker + issue-search
+// form to add new ones.
+function DepsSection({
+  issue,
+  onIssueRefresh,
+}: {
+  issue: types.Issue;
+  onIssueRefresh: (wsID?: string) => Promise<void> | void;
+}) {
+  const workspaces = useWorkspaceStore((s) => s.workspaces);
+  const [adding, setAdding] = useState(false);
+  const [selWsID, setSelWsID] = useState("");
+  const [siblingIssues, setSiblingIssues] = useState<types.Issue[]>([]);
+  const [loadingIssues, setLoadingIssues] = useState(false);
+  const [selIssueNum, setSelIssueNum] = useState<number | "">("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // Only offer cross-workspace deps — sibling workspaces exclude the current one.
+  const siblings = workspaces.filter((w) => w.id !== issue.workspace_id && w.enabled);
+
+  useEffect(() => {
+    if (!selWsID) { setSiblingIssues([]); return; }
+    setLoadingIssues(true);
+    setSelIssueNum("");
+    ListIssues(selWsID)
+      .then((issues) => setSiblingIssues(issues ?? []))
+      .catch(() => setSiblingIssues([]))
+      .finally(() => setLoadingIssues(false));
+  }, [selWsID]);
+
+  async function addDep() {
+    if (!selWsID || !selIssueNum) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      await AddIssueDep(issue.workspace_id, issue.number, new types.IssueDep({ workspace_id: selWsID, number: selIssueNum }));
+      setAdding(false);
+      setSelWsID("");
+      setSelIssueNum("");
+      await onIssueRefresh(issue.workspace_id);
+    } catch (e: any) {
+      setErr(String(e?.message ?? e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removeDep(dep: types.IssueDep) {
+    setBusy(true);
+    setErr(null);
+    try {
+      await RemoveIssueDep(issue.workspace_id, issue.number, dep);
+      await onIssueRefresh(issue.workspace_id);
+    } catch (e: any) {
+      setErr(String(e?.message ?? e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const deps = issue.dependencies ?? [];
+  // Only show cross-workspace deps in this section; same-workspace deps shown on card.
+  const crossDeps = deps.filter((d) => d.workspace_id && d.workspace_id !== issue.workspace_id);
+
+  if (crossDeps.length === 0 && !adding && siblings.length === 0) return null;
+
+  return (
+    <Section title="Cross-workspace dependencies">
+      <div className="space-y-2">
+        {crossDeps.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {crossDeps.map((d) => (
+              <span
+                key={`${d.workspace_id}#${d.number}`}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-amber-900/30 border border-amber-700 text-amber-200"
+              >
+                {d.workspace_id}#{d.number}
+                <button
+                  type="button"
+                  onClick={() => removeDep(d)}
+                  disabled={busy}
+                  className="text-amber-400 hover:text-red-400 disabled:opacity-50 leading-none"
+                  title="Remove dependency"
+                >
+                  ✕
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+        {adding ? (
+          <div className="flex items-center gap-2 flex-wrap">
+            <select
+              value={selWsID}
+              onChange={(e) => setSelWsID(e.target.value)}
+              className="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-xs text-slate-200"
+            >
+              <option value="">Workspace…</option>
+              {siblings.map((w) => (
+                <option key={w.id} value={w.id}>{w.display_name || w.id}</option>
+              ))}
+            </select>
+            {selWsID && (
+              <select
+                value={selIssueNum}
+                onChange={(e) => setSelIssueNum(Number(e.target.value) || "")}
+                disabled={loadingIssues}
+                className="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-xs text-slate-200 max-w-[220px]"
+              >
+                <option value="">{loadingIssues ? "Loading…" : "Issue…"}</option>
+                {siblingIssues
+                  .filter((i) => i.state === "open" || i.state === "")
+                  .map((i) => (
+                    <option key={i.number} value={i.number}>#{i.number} — {i.title.slice(0, 60)}</option>
+                  ))}
+              </select>
+            )}
+            <button
+              type="button"
+              onClick={addDep}
+              disabled={busy || !selWsID || !selIssueNum}
+              className="px-2 py-0.5 rounded bg-emerald-700 hover:bg-emerald-600 disabled:opacity-50 text-xs"
+            >
+              Add
+            </button>
+            <button
+              type="button"
+              onClick={() => { setAdding(false); setSelWsID(""); setSelIssueNum(""); }}
+              className="text-xs text-slate-500 hover:text-slate-300"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : siblings.length > 0 ? (
+          <button
+            type="button"
+            onClick={() => setAdding(true)}
+            className="text-xs text-sky-400 hover:text-sky-300"
+          >
+            + Add cross-workspace dependency
+          </button>
+        ) : null}
+        {err && <div className="text-red-400 text-xs">{err}</div>}
+      </div>
+    </Section>
+  );
 }

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -17,6 +17,8 @@ export function AcknowledgeComment(arg1:string,arg2:number,arg3:number):Promise<
 
 export function ActivateGoal(arg1:string):Promise<void>;
 
+export function AddIssueDep(arg1:string,arg2:number,arg3:types.IssueDep):Promise<void>;
+
 export function AddManualIssue(arg1:string,arg2:number,arg3:string,arg4:string,arg5:Array<string>,arg6:string):Promise<types.Issue>;
 
 export function AddWorkspace(arg1:types.Workspace):Promise<void>;
@@ -178,6 +180,8 @@ export function RefreshIssuesNow():Promise<void>;
 export function RejectPlan(arg1:string,arg2:number):Promise<void>;
 
 export function RemoveIssue(arg1:string,arg2:number):Promise<void>;
+
+export function RemoveIssueDep(arg1:string,arg2:number,arg3:types.IssueDep):Promise<void>;
 
 export function RemoveWorkspace(arg1:string):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -10,6 +10,10 @@ export function ActivateGoal(arg1) {
   return window['go']['main']['App']['ActivateGoal'](arg1);
 }
 
+export function AddIssueDep(arg1, arg2, arg3) {
+  return window['go']['main']['App']['AddIssueDep'](arg1, arg2, arg3);
+}
+
 export function AddManualIssue(arg1, arg2, arg3, arg4, arg5, arg6) {
   return window['go']['main']['App']['AddManualIssue'](arg1, arg2, arg3, arg4, arg5, arg6);
 }
@@ -332,6 +336,10 @@ export function RejectPlan(arg1, arg2) {
 
 export function RemoveIssue(arg1, arg2) {
   return window['go']['main']['App']['RemoveIssue'](arg1, arg2);
+}
+
+export function RemoveIssueDep(arg1, arg2, arg3) {
+  return window['go']['main']['App']['RemoveIssueDep'](arg1, arg2, arg3);
 }
 
 export function RemoveWorkspace(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1004,6 +1004,7 @@ export namespace issueview {
 	    unread_comment_count: number;
 	    card_state?: string;
 	    card_state_details?: cardstate.CardStateDetails;
+	    waiting_for_dep?: types.IssueDep;
 	
 	    static createFrom(source: any = {}) {
 	        return new IssueView(source);
@@ -1028,6 +1029,7 @@ export namespace issueview {
 	        this.unread_comment_count = source["unread_comment_count"];
 	        this.card_state = source["card_state"];
 	        this.card_state_details = this.convertValues(source["card_state_details"], cardstate.CardStateDetails);
+	        this.waiting_for_dep = this.convertValues(source["waiting_for_dep"], types.IssueDep);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -1698,6 +1700,20 @@ export namespace types {
 		    return a;
 		}
 	}
+	export class IssueDep {
+	    workspace_id: string;
+	    number: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new IssueDep(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.workspace_id = source["workspace_id"];
+	        this.number = source["number"];
+	    }
+	}
 	export class Issue {
 	    number: number;
 	    workspace_id: string;
@@ -1710,7 +1726,7 @@ export namespace types {
 	    updated_at: any;
 	    goal_id?: string;
 	    priority: number;
-	    dependencies: number[];
+	    dependencies: IssueDep[];
 	    dep_rationale: string;
 	    column: string;
 	    plan?: Plan;
@@ -1723,6 +1739,7 @@ export namespace types {
 	    // Go type: time
 	    closed_at?: any;
 	    waiting_for_pool?: boolean;
+	    waiting_for_dep?: IssueDep;
 	    pipeline_step_id?: string;
 	    pipeline_loops?: Record<string, number>;
 	    pipeline_version?: number;
@@ -1749,7 +1766,7 @@ export namespace types {
 	        this.updated_at = this.convertValues(source["updated_at"], null);
 	        this.goal_id = source["goal_id"];
 	        this.priority = source["priority"];
-	        this.dependencies = source["dependencies"];
+	        this.dependencies = this.convertValues(source["dependencies"], IssueDep);
 	        this.dep_rationale = source["dep_rationale"];
 	        this.column = source["column"];
 	        this.plan = this.convertValues(source["plan"], Plan);
@@ -1760,6 +1777,7 @@ export namespace types {
 	        this.archived_at = this.convertValues(source["archived_at"], null);
 	        this.closed_at = this.convertValues(source["closed_at"], null);
 	        this.waiting_for_pool = source["waiting_for_pool"];
+	        this.waiting_for_dep = this.convertValues(source["waiting_for_dep"], IssueDep);
 	        this.pipeline_step_id = source["pipeline_step_id"];
 	        this.pipeline_loops = source["pipeline_loops"];
 	        this.pipeline_version = source["pipeline_version"];
@@ -1789,6 +1807,7 @@ export namespace types {
 		    return a;
 		}
 	}
+	
 	
 	export class Label {
 	    name: string;

--- a/internal/cardstate/apply_event.go
+++ b/internal/cardstate/apply_event.go
@@ -26,6 +26,12 @@ const (
 	EvtIssueClosed         EventKind = "issue_closed"
 	EvtPoolEnqueued        EventKind = "pool_enqueued"
 	EvtPoolDequeued        EventKind = "pool_dequeued"
+	// EvtDepWaiting fires when an unresolved cross-workspace dep is detected
+	// (issue #210). DepInfo carries the blocking dep identity.
+	EvtDepWaiting  EventKind = "dep_waiting"
+	// EvtDepResolved fires when all cross-workspace deps for an issue are
+	// satisfied and WaitingForDep is cleared (issue #210).
+	EvtDepResolved EventKind = "dep_resolved"
 )
 
 // Event is the input to ApplyEvent. It carries the kind plus any additional
@@ -37,6 +43,8 @@ type Event struct {
 	PRNumber     *int
 	PRURL        string
 	OccurredAt   time.Time
+	// DepInfo is populated for EvtDepWaiting events (issue #210).
+	DepInfo *types.IssueDep
 }
 
 // SideEffect is an explicit action that must be performed after a state
@@ -137,6 +145,10 @@ func ApplyEvent(
 		next.WaitingForPool = true
 	case EvtPoolDequeued:
 		next.WaitingForPool = false
+	case EvtDepWaiting:
+		next.WaitingForDep = ev.DepInfo
+	case EvtDepResolved:
+		next.WaitingForDep = nil
 	}
 
 	toState, details := DeriveCardState(next)

--- a/internal/cardstate/cardstate.go
+++ b/internal/cardstate/cardstate.go
@@ -5,7 +5,11 @@
 // (issue #30).
 package cardstate
 
-import "prismconductor/internal/types"
+import (
+	"fmt"
+
+	"prismconductor/internal/types"
+)
 
 // CardState is the canonical visual state of a board card. It is derived
 // entirely from backend data and emitted as part of IssueView so the frontend
@@ -46,6 +50,10 @@ const (
 	// CardStateRetryScheduled — execute failed with a retryable cause; the
 	// scheduler has queued an automatic re-spawn with exponential backoff (#221).
 	CardStateRetryScheduled CardState = "retry_scheduled"
+	// CardStateWaitingForDep — card is in REVIEW with a green PR but at least
+	// one cross-workspace dependency is still open (issue #210). Merge should
+	// be held until the dep resolves.
+	CardStateWaitingForDep CardState = "waiting_for_dep"
 )
 
 // PendingRetryInfo carries the retry schedule for a card in retry_scheduled
@@ -105,6 +113,10 @@ type DeriveParams struct {
 	// issue. Non-nil overrides the blocked state so the card shows a countdown
 	// instead of a permanent error badge (#221).
 	PendingRetry *PendingRetryInfo
+
+	// WaitingForDep is set when the issue has an unresolved cross-workspace
+	// dependency. Non-nil surfaces a waiting badge in REVIEW (issue #210).
+	WaitingForDep *types.IssueDep
 }
 
 // DeriveCardState maps DeriveParams to a single CardState + detail blob.
@@ -234,6 +246,11 @@ func DeriveCardState(p DeriveParams) (CardState, CardStateDetails) {
 	if p.Plan != nil && p.Plan.ReadyToExecute && p.Plan.ApprovedAt == nil {
 		if p.Column != types.ColReview && p.Column != types.ColDone {
 			return CardStatePlanReady, CardStateDetails{Reason: "plan ready for approval"}
+		}
+	}
+	if p.WaitingForDep != nil && p.Column == types.ColReview {
+		return CardStateWaitingForDep, CardStateDetails{
+			Reason: fmt.Sprintf("waiting for %s#%d to close before merging", p.WaitingForDep.WorkspaceID, p.WaitingForDep.Number),
 		}
 	}
 	if p.Column == types.ColReview && p.PRNumber != nil {

--- a/internal/github/poll.go
+++ b/internal/github/poll.go
@@ -25,6 +25,9 @@ type Store interface {
 	SaveLabels(workspaceID string, labels []types.Label) error
 	UpsertPRComment(c types.PRComment) (bool, error)
 	MostRecentFailedExecuteSession(workspaceID string, issueNumber int) (*types.Session, error)
+	// SetIssueWaitingForDep writes or clears the waiting_for_dep field
+	// on an issue JSON blob (issue #210).
+	SetIssueWaitingForDep(workspaceID string, issueNumber int, dep *types.IssueDep) error
 }
 
 // WorkspaceSource lets the poller pick up newly-added workspaces between ticks.
@@ -402,6 +405,14 @@ func (p *Poller) pollOne(ctx context.Context, ws types.Workspace) error {
 		}
 	}
 
+	// Cross-workspace dep check (issue #210): for issues with IssueDep entries
+	// referencing other workspaces, check if those deps are still open. If any
+	// are, set WaitingForDep on the issue to surface a UI badge. When all
+	// cross-workspace deps are satisfied, clear WaitingForDep. Bounded by the
+	// number of issues with cross-workspace deps (typically few), so API impact
+	// is negligible. Uses the current prev list since it includes all columns.
+	p.probeDepStatus(ws, prev)
+
 	// Piggy-back label fetch on the same tick. Failures are logged and don't
 	// abort the issue cycle (the cache stays stale until the next tick).
 	if labels, err := p.Client.ListLabels(ctx, ws); err != nil {
@@ -412,6 +423,72 @@ func (p *Poller) pollOne(ctx context.Context, ws types.Workspace) error {
 		p.Bus.Publish(eventbus.EvtLabelsUpdated, map[string]any{"workspace_id": ws.ID})
 	}
 	return nil
+}
+
+// probeDepStatus checks cross-workspace dependencies for issues in prev and
+// sets or clears WaitingForDep on each issue accordingly (issue #210).
+// Only examines issues that have at least one cross-workspace dep. Loads each
+// sibling workspace's issue list at most once per tick.
+func (p *Poller) probeDepStatus(ws types.Workspace, prev []types.Issue) {
+	siblingCache := map[string]map[int]bool{} // wsID → open issue numbers
+
+	for _, iss := range prev {
+		var firstBlocking *types.IssueDep
+		for i := range iss.Dependencies {
+			dep := &iss.Dependencies[i]
+			if dep.WorkspaceID == "" {
+				continue // same-workspace deps managed by orchestrator
+			}
+			// Load and cache sibling workspace open-issue set.
+			openNums, ok := siblingCache[dep.WorkspaceID]
+			if !ok {
+				openNums = map[int]bool{}
+				siblingIssues, err := p.Store.ListIssues(dep.WorkspaceID)
+				if err != nil {
+					log.Printf("dep probe: list issues %s: %v", dep.WorkspaceID, err)
+					siblingCache[dep.WorkspaceID] = openNums
+					continue
+				}
+				for _, si := range siblingIssues {
+					if si.State == "" || si.State == "open" {
+						openNums[si.Number] = true
+					}
+				}
+				siblingCache[dep.WorkspaceID] = openNums
+			}
+			if openNums[dep.Number] {
+				firstBlocking = dep
+				break
+			}
+		}
+
+		// Determine whether current WaitingForDep matches desired state.
+		switch {
+		case firstBlocking != nil && (iss.WaitingForDep == nil ||
+			iss.WaitingForDep.WorkspaceID != firstBlocking.WorkspaceID ||
+			iss.WaitingForDep.Number != firstBlocking.Number):
+			// Set or update WaitingForDep.
+			dep := *firstBlocking
+			if err := p.Store.SetIssueWaitingForDep(ws.ID, iss.Number, &dep); err != nil {
+				log.Printf("dep probe: set waiting_for_dep %s#%d: %v", ws.ID, iss.Number, err)
+			} else if p.Bus != nil {
+				p.Bus.Publish(eventbus.EvtIssueLabelChanged, map[string]any{
+					"workspace_id": ws.ID,
+					"number":       iss.Number,
+				})
+			}
+		case firstBlocking == nil && iss.WaitingForDep != nil:
+			// Clear WaitingForDep — all cross-workspace deps satisfied.
+			if err := p.Store.SetIssueWaitingForDep(ws.ID, iss.Number, nil); err != nil {
+				log.Printf("dep probe: clear waiting_for_dep %s#%d: %v", ws.ID, iss.Number, err)
+			} else if p.Bus != nil {
+				p.Bus.Publish(eventbus.EvtIssueLabelChanged, map[string]any{
+					"workspace_id": ws.ID,
+					"number":       iss.Number,
+				})
+			}
+		}
+	}
 }
 
 func (p *Poller) publish(t eventbus.EventType, ws types.Workspace, iss types.Issue) {

--- a/internal/issueview/assembler.go
+++ b/internal/issueview/assembler.go
@@ -454,6 +454,7 @@ func (a *Assembler) Assemble(workspaceID string, issueNumber int) (IssueView, er
 		HasOrphanQuestion: orphanQuestion != nil,
 		PlanFailed:        planFailed,
 		PendingRetry:      pendingRetry,
+		WaitingForDep:     iss.WaitingForDep,
 	})
 	var csDetailsPtr *cardstate.CardStateDetails
 	if cs != cardstate.CardStateTodo && cs != cardstate.CardStateDone {
@@ -478,6 +479,7 @@ func (a *Assembler) Assemble(workspaceID string, issueNumber int) (IssueView, er
 		UnreadCommentCount: unreadCommentCount,
 		CardState:          cs,
 		CardStateDetails:   csDetailsPtr,
+		WaitingForDep:      iss.WaitingForDep,
 	}, nil
 }
 

--- a/internal/issueview/issueview.go
+++ b/internal/issueview/issueview.go
@@ -105,6 +105,10 @@ type IssueView struct {
 	// blocked reason, session ID, failure cause, etc. Nil-safe: always check
 	// CardState first.
 	CardStateDetails *cardstate.CardStateDetails `json:"card_state_details,omitempty"`
+
+	// WaitingForDep is set when the issue has an unresolved cross-workspace
+	// dependency (issue #210). Non-nil → show a waiting badge on the card.
+	WaitingForDep *types.IssueDep `json:"waiting_for_dep,omitempty"`
 }
 
 // OrphanPRInfo is surfaced when an execute session pushed a branch but failed

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -209,10 +210,14 @@ func (o *Orchestrator) autoPull(reason string) {
 	// Order by priority desc, with blocked items last.
 	sortByOrchestratorPriority(candidates)
 
+	// Build a cross-workspace open-issue set for dep checking. Only loads
+	// workspace issues that candidates actually reference (issue #210).
+	crossWsOpen := buildCrossWsOpenSet(o.store, candidates)
+
 	// If all plan slots are taken, enqueue the next candidate so the drain can
 	// retry as soon as a slot frees (issue #40). Skip if nothing is queued.
 	if o.pool.FreePlanSlots() <= 0 {
-		next := pickNextUnblocked(candidates, all)
+		next := pickNextUnblocked(candidates, all, crossWsOpen)
 		if next != nil {
 			o.enqueuePending(next, types.RolePlan, "spawn:plan")
 		}
@@ -220,7 +225,7 @@ func (o *Orchestrator) autoPull(reason string) {
 	}
 
 	for o.pool.FreePlanSlots() > 0 {
-		next := pickNextUnblocked(candidates, all)
+		next := pickNextUnblocked(candidates, all, crossWsOpen)
 		if next == nil {
 			return
 		}
@@ -263,9 +268,9 @@ func (o *Orchestrator) autoPull(reason string) {
 }
 
 // pickNextUnblocked returns the first candidate currently in TODO with no
-// open dependencies, or nil. `all` is the full universe used to check whether
-// dependency issues are still open.
-func pickNextUnblocked(candidates []types.Issue, all []types.Issue) *types.Issue {
+// open dependencies, or nil. `all` is the full universe used to check
+// same-workspace deps; `crossWsOpen` covers cross-workspace deps (issue #210).
+func pickNextUnblocked(candidates []types.Issue, all []types.Issue, crossWsOpen map[string]bool) *types.Issue {
 	openSet := map[int]bool{}
 	for _, iss := range all {
 		if iss.State == "" || iss.State == "open" {
@@ -279,9 +284,16 @@ func pickNextUnblocked(candidates []types.Issue, all []types.Issue) *types.Issue
 		}
 		blocked := false
 		for _, dep := range c.Dependencies {
-			if openSet[dep] {
-				blocked = true
-				break
+			if dep.WorkspaceID == "" {
+				if openSet[dep.Number] {
+					blocked = true
+					break
+				}
+			} else {
+				if crossWsOpen[dep.WorkspaceID+"#"+strconv.Itoa(dep.Number)] {
+					blocked = true
+					break
+				}
 			}
 		}
 		if blocked {
@@ -290,6 +302,32 @@ func pickNextUnblocked(candidates []types.Issue, all []types.Issue) *types.Issue
 		return c
 	}
 	return nil
+}
+
+// buildCrossWsOpenSet loads issues from sibling workspaces referenced by
+// candidate deps and returns a "wsID#num" → true map for open issues.
+// Only loads each sibling workspace once (issue #210).
+func buildCrossWsOpenSet(st Store, candidates []types.Issue) map[string]bool {
+	seen := map[string]bool{}
+	result := map[string]bool{}
+	for _, c := range candidates {
+		for _, dep := range c.Dependencies {
+			if dep.WorkspaceID == "" || seen[dep.WorkspaceID] {
+				continue
+			}
+			seen[dep.WorkspaceID] = true
+			issues, err := st.ListIssues(dep.WorkspaceID)
+			if err != nil {
+				continue
+			}
+			for _, iss := range issues {
+				if iss.State == "" || iss.State == "open" {
+					result[dep.WorkspaceID+"#"+strconv.Itoa(iss.Number)] = true
+				}
+			}
+		}
+	}
+	return result
 }
 
 func sortByOrchestratorPriority(in []types.Issue) {
@@ -537,11 +575,25 @@ func (o *Orchestrator) applyResult(goal types.Goal, candidates []types.Issue, re
 		if p, ok := priority[iss.Number]; ok {
 			updated.Priority = p
 		}
+		// Preserve user-set cross-workspace deps; replace same-workspace deps
+		// with the LLM's output (issue #210).
+		var crossWsDeps types.IssueDepList
+		for _, d := range iss.Dependencies {
+			if d.WorkspaceID != "" {
+				crossWsDeps = append(crossWsDeps, d)
+			}
+		}
+		var sameWsDepsForCache []int
 		if e, ok := depEdges[iss.Number]; ok {
-			updated.Dependencies = e.DependsOn
+			sameDeps := make(types.IssueDepList, len(e.DependsOn))
+			for i, n := range e.DependsOn {
+				sameDeps[i] = types.IssueDep{Number: n}
+				sameWsDepsForCache = append(sameWsDepsForCache, n)
+			}
+			updated.Dependencies = append(crossWsDeps, sameDeps...)
 			updated.DepRationale = e.Rationale
 		} else {
-			updated.Dependencies = nil
+			updated.Dependencies = crossWsDeps
 			updated.DepRationale = ""
 		}
 		if _, err := o.store.SaveIssue(updated); err != nil {
@@ -551,7 +603,7 @@ func (o *Orchestrator) applyResult(goal types.Goal, candidates []types.Issue, re
 		hash := IssueBodyHash(iss)
 		entry := depCacheEntry{
 			IsPrimitive: primSet[iss.Number],
-			DependsOn:   updated.Dependencies,
+			DependsOn:   sameWsDepsForCache,
 			Rationale:   updated.DepRationale,
 		}
 		_ = o.store.DepCachePut(iss.WorkspaceID, iss.Number, goal.ID, hash, entry)
@@ -560,7 +612,8 @@ func (o *Orchestrator) applyResult(goal types.Goal, candidates []types.Issue, re
 }
 
 // recomputeBlocked re-evaluates each candidate's "blocked-by" status when an
-// issue closes — open dep numbers stay, closed dep numbers are pruned.
+// issue closes — prunes same-workspace closed deps. Cross-workspace deps are
+// managed by the GitHub poller via WaitingForDep (issue #210).
 func (o *Orchestrator) recomputeBlocked() error {
 	if o.store == nil {
 		return nil
@@ -579,10 +632,15 @@ func (o *Orchestrator) recomputeBlocked() error {
 		if len(iss.Dependencies) == 0 {
 			continue
 		}
-		var stillOpen []int
-		for _, n := range iss.Dependencies {
-			if openSet[n] {
-				stillOpen = append(stillOpen, n)
+		var stillOpen types.IssueDepList
+		for _, dep := range iss.Dependencies {
+			if dep.WorkspaceID != "" {
+				// Cross-workspace deps are never pruned here — the poller owns them.
+				stillOpen = append(stillOpen, dep)
+				continue
+			}
+			if openSet[dep.Number] {
+				stillOpen = append(stillOpen, dep)
 			}
 		}
 		if len(stillOpen) != len(iss.Dependencies) {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -179,6 +179,89 @@ func TestRunRank_NoOrchestratorPool_NoOps(t *testing.T) {
 	}
 }
 
+// multiWsStubStore routes ListIssues by workspace ID for cross-workspace tests.
+type multiWsStubStore struct {
+	stubStore
+	byWS map[string][]types.Issue
+}
+
+func (s *multiWsStubStore) ListIssues(wsID string) ([]types.Issue, error) {
+	s.listIssuesHits++
+	if v, ok := s.byWS[wsID]; ok {
+		return v, nil
+	}
+	return s.issues, nil
+}
+
+func TestPickNextUnblockedCrossWsDepOpen(t *testing.T) {
+	// Issue 1 in ws1 depends on issue 10 in ws2 (cross-workspace).
+	// ws2 issue 10 is still open → issue 1 must be blocked.
+	ws2Issues := []types.Issue{
+		{WorkspaceID: "ws2", Number: 10, State: "open"},
+	}
+	ws1Issues := []types.Issue{
+		{WorkspaceID: "ws1", Number: 1, State: "open", Column: types.ColTodo,
+			Dependencies: types.IssueDepList{{WorkspaceID: "ws2", Number: 10}}},
+	}
+	st := &multiWsStubStore{
+		byWS: map[string][]types.Issue{"ws2": ws2Issues, "ws1": ws1Issues},
+	}
+	st.issues = ws1Issues
+
+	crossWsOpen := buildCrossWsOpenSet(st, ws1Issues)
+	got := pickNextUnblocked(ws1Issues, ws1Issues, crossWsOpen)
+	if got != nil {
+		t.Errorf("expected nil (blocked on open cross-ws dep), got issue #%d", got.Number)
+	}
+}
+
+func TestPickNextUnblockedCrossWsDepClosed(t *testing.T) {
+	// Issue 1 in ws1 depends on issue 10 in ws2, but ws2 issue 10 is closed.
+	// → issue 1 is unblocked.
+	ws2Issues := []types.Issue{
+		{WorkspaceID: "ws2", Number: 10, State: "closed"},
+	}
+	ws1Issues := []types.Issue{
+		{WorkspaceID: "ws1", Number: 1, State: "open", Column: types.ColTodo,
+			Dependencies: types.IssueDepList{{WorkspaceID: "ws2", Number: 10}}},
+	}
+	st := &multiWsStubStore{
+		byWS: map[string][]types.Issue{"ws2": ws2Issues, "ws1": ws1Issues},
+	}
+	st.issues = ws1Issues
+
+	crossWsOpen := buildCrossWsOpenSet(st, ws1Issues)
+	got := pickNextUnblocked(ws1Issues, ws1Issues, crossWsOpen)
+	if got == nil {
+		t.Error("expected issue to be unblocked (cross-ws dep is closed), got nil")
+	}
+}
+
+func TestBuildCrossWsOpenSetDedupsLoads(t *testing.T) {
+	// Two candidates both reference ws2; buildCrossWsOpenSet should only call
+	// ListIssues("ws2") once.
+	ws2Issues := []types.Issue{
+		{WorkspaceID: "ws2", Number: 5, State: "open"},
+	}
+	ws1Issues := []types.Issue{
+		{WorkspaceID: "ws1", Number: 1, State: "open", Column: types.ColTodo,
+			Dependencies: types.IssueDepList{{WorkspaceID: "ws2", Number: 5}}},
+		{WorkspaceID: "ws1", Number: 2, State: "open", Column: types.ColTodo,
+			Dependencies: types.IssueDepList{{WorkspaceID: "ws2", Number: 5}}},
+	}
+	st := &multiWsStubStore{
+		byWS: map[string][]types.Issue{"ws2": ws2Issues, "ws1": ws1Issues},
+	}
+	st.issues = ws1Issues
+
+	buildCrossWsOpenSet(st, ws1Issues)
+	// ListIssues("ws1") is never called; ListIssues("ws2") called once.
+	// Total hits should be 1 (only "ws2").
+	if st.listIssuesHits != 1 {
+		t.Errorf("ListIssues hit %d times, want 1 (ws2 deduped)", st.listIssuesHits)
+	}
+}
+
 // TestRunRank_ResolverHit invokes the LLM only when the resolver returns a
 // non-nil client. Confirms the resolver is consulted on every call (not at
 // construction time).

--- a/internal/store/issues.go
+++ b/internal/store/issues.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -103,6 +104,13 @@ func (s *Store) SaveIssue(iss types.Issue) (bool, error) {
 			// the push succeeded. MarkPROpened is the only caller that clears it.
 			if prev.NeedsPRInfo != nil {
 				iss.NeedsPRInfo = prev.NeedsPRInfo
+			}
+			// Preserve WaitingForDep: set by the GitHub poller when a cross-
+			// workspace dep is still open; cleared by the same poller when the
+			// dep closes. A generic SaveIssue (e.g. from applyResult) must not
+			// clobber this conductor-managed field (issue #210).
+			if prev.WaitingForDep != nil {
+				iss.WaitingForDep = prev.WaitingForDep
 			}
 			// Preserve FailureReason: set by the conductor on execute failure;
 			// the GitHub poll has no opinion on it (#194).
@@ -900,5 +908,29 @@ func (s *Store) SetIssueFailureReason(workspaceID string, issueNumber int, reaso
 	_, err := s.DB.Exec(
 		`UPDATE issues SET json = json_set(json, '$.failure_reason', ?) WHERE workspace_id = ? AND number = ?`,
 		reason, workspaceID, issueNumber)
+	return err
+}
+
+// SetIssueWaitingForDep writes (or clears) the waiting_for_dep field in the
+// issue JSON blob. dep == nil clears the field. Uses json_set to bypass
+// SaveIssue's preservation logic, same pattern as SetIssueWaitingForPool.
+// Only the GitHub poller should call this (issue #210).
+func (s *Store) SetIssueWaitingForDep(workspaceID string, issueNumber int, dep *types.IssueDep) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	if dep == nil {
+		_, err := s.DB.Exec(
+			`UPDATE issues SET json = json_remove(json, '$.waiting_for_dep') WHERE workspace_id = ? AND number = ?`,
+			workspaceID, issueNumber)
+		return err
+	}
+	b, err := json.Marshal(dep)
+	if err != nil {
+		return err
+	}
+	_, err = s.DB.Exec(
+		`UPDATE issues SET json = json_set(json, '$.waiting_for_dep', json(?)) WHERE workspace_id = ? AND number = ?`,
+		string(b), workspaceID, issueNumber)
 	return err
 }

--- a/internal/store/issues_test.go
+++ b/internal/store/issues_test.go
@@ -978,3 +978,120 @@ func TestSetIssueWaitingForPool_SetsTrue(t *testing.T) {
 		t.Fatal("WaitingForPool should be true after SetIssueWaitingForPool(true)")
 	}
 }
+
+func TestSetIssueWaitingForDep_SetAndClear(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      200,
+		State:       "open",
+		Column:      types.ColReview,
+	}); err != nil {
+		t.Fatalf("SaveIssue: %v", err)
+	}
+
+	dep := &types.IssueDep{WorkspaceID: "infra", Number: 42}
+	if err := s.SetIssueWaitingForDep("ws1", 200, dep); err != nil {
+		t.Fatalf("SetIssueWaitingForDep(set): %v", err)
+	}
+
+	iss, err := s.LoadIssue("ws1", 200)
+	if err != nil {
+		t.Fatalf("LoadIssue after set: %v", err)
+	}
+	if iss.WaitingForDep == nil {
+		t.Fatal("WaitingForDep is nil after SetIssueWaitingForDep")
+	}
+	if iss.WaitingForDep.WorkspaceID != "infra" || iss.WaitingForDep.Number != 42 {
+		t.Errorf("WaitingForDep = %+v, want {infra 42}", iss.WaitingForDep)
+	}
+
+	// Clear it.
+	if err := s.SetIssueWaitingForDep("ws1", 200, nil); err != nil {
+		t.Fatalf("SetIssueWaitingForDep(clear): %v", err)
+	}
+
+	iss, err = s.LoadIssue("ws1", 200)
+	if err != nil {
+		t.Fatalf("LoadIssue after clear: %v", err)
+	}
+	if iss.WaitingForDep != nil {
+		t.Errorf("WaitingForDep = %+v after clear, want nil", iss.WaitingForDep)
+	}
+}
+
+func TestSaveIssuePreservesWaitingForDep(t *testing.T) {
+	s := newTestStore(t)
+	dep := &types.IssueDep{WorkspaceID: "svc", Number: 7}
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID:   "ws1",
+		Number:        201,
+		State:         "open",
+		Column:        types.ColReview,
+		WaitingForDep: dep,
+	}); err != nil {
+		t.Fatalf("SaveIssue: %v", err)
+	}
+
+	// Simulate a GitHub poll tick: SaveIssue with no WaitingForDep set on the
+	// incoming issue (as the poller only calls SetIssueWaitingForDep, not SaveIssue).
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID: "ws1",
+		Number:      201,
+		State:       "open",
+		Column:      types.ColReview,
+		Title:       "updated title",
+	}); err != nil {
+		t.Fatalf("SaveIssue (poll tick): %v", err)
+	}
+
+	iss, err := s.LoadIssue("ws1", 201)
+	if err != nil {
+		t.Fatalf("LoadIssue: %v", err)
+	}
+	if iss.WaitingForDep == nil {
+		t.Fatal("WaitingForDep was cleared by SaveIssue — preservation rule missing")
+	}
+	if iss.WaitingForDep.WorkspaceID != "svc" || iss.WaitingForDep.Number != 7 {
+		t.Errorf("WaitingForDep = %+v, want {svc 7}", iss.WaitingForDep)
+	}
+}
+
+func TestSaveIssuePreservesCrossWsDeps(t *testing.T) {
+	s := newTestStore(t)
+	crossDep := types.IssueDep{WorkspaceID: "infra", Number: 99}
+	sameDep := types.IssueDep{WorkspaceID: "", Number: 3}
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID:  "ws1",
+		Number:       202,
+		State:        "open",
+		Column:       types.ColTodo,
+		Dependencies: types.IssueDepList{crossDep, sameDep},
+	}); err != nil {
+		t.Fatalf("SaveIssue: %v", err)
+	}
+
+	iss, err := s.LoadIssue("ws1", 202)
+	if err != nil {
+		t.Fatalf("LoadIssue: %v", err)
+	}
+	if len(iss.Dependencies) != 2 {
+		t.Fatalf("Dependencies len = %d, want 2", len(iss.Dependencies))
+	}
+
+	var hasCross, hasSame bool
+	for _, d := range iss.Dependencies {
+		if d.WorkspaceID == "infra" && d.Number == 99 {
+			hasCross = true
+		}
+		if d.WorkspaceID == "" && d.Number == 3 {
+			hasSame = true
+		}
+	}
+	if !hasCross {
+		t.Error("cross-workspace dep missing after round-trip")
+	}
+	if !hasSame {
+		t.Error("same-workspace dep missing after round-trip")
+	}
+}

--- a/internal/types/issuedep_test.go
+++ b/internal/types/issuedep_test.go
@@ -1,0 +1,123 @@
+package types
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestIssueDepListUnmarshalLegacyInts(t *testing.T) {
+	raw := []byte(`[1, 2, 3]`)
+	var got IssueDepList
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal legacy ints: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	for i, want := range []int{1, 2, 3} {
+		if got[i].WorkspaceID != "" {
+			t.Errorf("[%d].WorkspaceID = %q, want empty", i, got[i].WorkspaceID)
+		}
+		if got[i].Number != want {
+			t.Errorf("[%d].Number = %d, want %d", i, got[i].Number, want)
+		}
+	}
+}
+
+func TestIssueDepListUnmarshalNewShape(t *testing.T) {
+	raw := []byte(`[{"workspace_id":"infra","number":5},{"workspace_id":"","number":2}]`)
+	var got IssueDepList
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal new shape: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].WorkspaceID != "infra" || got[0].Number != 5 {
+		t.Errorf("[0] = %+v, want {infra 5}", got[0])
+	}
+	if got[1].WorkspaceID != "" || got[1].Number != 2 {
+		t.Errorf("[1] = %+v, want { 2}", got[1])
+	}
+}
+
+func TestIssueDepListMarshalShape(t *testing.T) {
+	deps := IssueDepList{
+		{WorkspaceID: "infra", Number: 7},
+		{WorkspaceID: "", Number: 3},
+	}
+	b, err := json.Marshal(deps)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Unmarshal back and verify round-trip.
+	var got IssueDepList
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("round-trip unmarshal: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("round-trip len = %d, want 2", len(got))
+	}
+	if got[0] != deps[0] || got[1] != deps[1] {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", got, deps)
+	}
+}
+
+func TestIssueDepListUnmarshalEmpty(t *testing.T) {
+	raw := []byte(`[]`)
+	var got IssueDepList
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal empty: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("len = %d, want 0", len(got))
+	}
+}
+
+func TestIssueDepListUnmarshalNull(t *testing.T) {
+	raw := []byte(`null`)
+	var got IssueDepList
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal null: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil IssueDepList for JSON null, got %+v", got)
+	}
+}
+
+func TestIssueWaitingForDepField(t *testing.T) {
+	iss := Issue{
+		WorkspaceID: "ws1",
+		Number:      1,
+		Title:       "test",
+		State:       "open",
+		WaitingForDep: &IssueDep{WorkspaceID: "infra", Number: 42},
+	}
+	b, err := json.Marshal(iss)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got Issue
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.WaitingForDep == nil {
+		t.Fatal("WaitingForDep lost after round-trip")
+	}
+	if got.WaitingForDep.WorkspaceID != "infra" || got.WaitingForDep.Number != 42 {
+		t.Errorf("WaitingForDep = %+v, want {infra 42}", got.WaitingForDep)
+	}
+}
+
+func TestIssueWaitingForDepOmitsWhenNil(t *testing.T) {
+	iss := Issue{WorkspaceID: "ws1", Number: 1, Title: "test", State: "open"}
+	b, err := json.Marshal(iss)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	if strings.Contains(s, "waiting_for_dep") {
+		t.Errorf("expected waiting_for_dep to be omitted when nil; got %s", s)
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -2,6 +2,7 @@
 package types
 
 import (
+	"encoding/json"
 	"errors"
 	"time"
 )
@@ -348,6 +349,41 @@ const (
 	GoalAbandoned GoalStatus = "abandoned"
 )
 
+// --- IssueDep (§6.3, issue #210) ---
+
+// IssueDep identifies a dependency on a GitHub issue, optionally in another
+// workspace. WorkspaceID == "" means same workspace (legacy same-workspace
+// behavior). WorkspaceID is the short workspace key (e.g. "infra", "app").
+type IssueDep struct {
+	WorkspaceID string `json:"workspace_id"`
+	Number      int    `json:"number"`
+}
+
+// IssueDepList is a slice of IssueDep that unmarshals transparently from the
+// legacy []int format (same-workspace deps written before issue #210) as well
+// as the new []IssueDep format.
+type IssueDepList []IssueDep
+
+func (d *IssueDepList) UnmarshalJSON(b []byte) error {
+	// New canonical format: [{workspace_id,number}…]
+	var deps []IssueDep
+	if err := json.Unmarshal(b, &deps); err == nil {
+		*d = deps
+		return nil
+	}
+	// Legacy format: [1, 2, 3] — treat as same-workspace deps.
+	var ints []int
+	if err := json.Unmarshal(b, &ints); err != nil {
+		return err
+	}
+	out := make(IssueDepList, len(ints))
+	for i, n := range ints {
+		out[i] = IssueDep{Number: n}
+	}
+	*d = out
+	return nil
+}
+
 // --- Issue (§6.3) ---
 
 type Issue struct {
@@ -360,10 +396,10 @@ type Issue struct {
 	URL         string    `json:"url"`
 	UpdatedAt   time.Time `json:"updated_at"`
 
-	GoalID       *string     `json:"goal_id,omitempty"`
-	Priority     float64     `json:"priority"`
-	Dependencies []int       `json:"dependencies"`
-	DepRationale string      `json:"dep_rationale"`
+	GoalID       *string      `json:"goal_id,omitempty"`
+	Priority     float64      `json:"priority"`
+	Dependencies IssueDepList `json:"dependencies"`
+	DepRationale string       `json:"dep_rationale"`
 	Column       BoardColumn `json:"column"`
 	Plan         *Plan       `json:"plan,omitempty"`
 	SessionID    *string     `json:"session_id,omitempty"`
@@ -375,6 +411,12 @@ type Issue struct {
 	// WaitingForPool is set true when a spawn attempt was queued because no
 	// pool had free capacity (issue #40). Cleared on successful drain.
 	WaitingForPool bool `json:"waiting_for_pool,omitempty"`
+
+	// WaitingForDep is set to the first unresolved cross-workspace dependency
+	// for this issue. Non-nil when the issue is in REVIEW but a referenced
+	// dep in another workspace is still open (issue #210). Cleared by the
+	// GitHub poller when the dep closes/merges.
+	WaitingForDep *IssueDep `json:"waiting_for_dep,omitempty"`
 
 	// Pipeline tracking fields (issue #146). Stamped at first pipeline-step
 	// spawn so in-flight cards continue on the saved pipeline version.


### PR DESCRIPTION
## Summary

- Extends `Issue.Dependencies` from `[]int` to a cross-workspace `IssueDep` type (`WorkspaceID string`, `Number int`) with backward-compat `UnmarshalJSON` (legacy `[]int` rows deserialize transparently; new canonical shape written on save).
- GitHub poller sets `WaitingForDep` on REVIEW issues blocked on an unresolved cross-workspace dep; orchestrator's `autoPull`/`pickNextUnblocked` skips them.
- New `CardStateWaitingForDep` state and amber waiting badge in Card's `StatusRow`.
- `PlanModal.tsx` `DepsSection` UI: workspace picker + issue dropdown for adding/removing cross-workspace deps; `AddIssueDep` / `RemoveIssueDep` Wails bindings.

## Files modified

- `internal/types/types.go` — `IssueDep`, `IssueDepList` (with `UnmarshalJSON`), `Issue.WaitingForDep`
- `internal/store/issues.go` — `SetIssueWaitingForDep`, `WaitingForDep` preservation in `SaveIssue`
- `internal/orchestrator/orchestrator.go` — `buildCrossWsOpenSet`, `pickNextUnblocked` cross-ws blocking, `applyResult` dep preservation
- `internal/github/poll.go` — `probeDepStatus` per-poll dep check, `SetIssueWaitingForDep` in Store interface
- `internal/cardstate/cardstate.go` — `CardStateWaitingForDep` state, `WaitingForDep` in `DeriveParams`
- `internal/cardstate/apply_event.go` — `EvtDepWaiting` / `EvtDepResolved` events
- `internal/issueview/issueview.go` + `assembler.go` — `WaitingForDep` in view/assemble
- `app.go` — `AddIssueDep`, `RemoveIssueDep` Wails handlers
- `frontend/wailsjs/go/models.ts` — `IssueDep` class, `Issue.dependencies: IssueDep[]`, `Issue.waiting_for_dep`
- `frontend/wailsjs/go/main/App.js` + `App.d.ts` — new binding stubs
- `frontend/src/components/Card.tsx` — `"waiting_for_dep"` card state, amber waiting badge
- `frontend/src/components/PlanModal.tsx` — `DepsSection` UI component
- `internal/types/issuedep_test.go` — new: JSON round-trip tests for `IssueDepList`
- `internal/orchestrator/orchestrator_test.go` — cross-ws dep blocking tests
- `internal/store/issues_test.go` — `SetIssueWaitingForDep` set/clear, `SaveIssue` preservation, dep round-trip

## Verification

| Gate | Command | Result |
|------|---------|--------|
| Go vet | `go vet prismconductor/internal/...` | pass |
| TypeScript | `npx tsc --noEmit` (frontend) | pass |
| Build | `wails build` | pass (45s) |
| Smoke test | `playwright test tests/e2e/startup.spec.ts` | skipped — `wails dev` watcher loop triggered by freshly-installed `node_modules` in worktree; `wails build` passed cleanly |
| Go tests | `go test prismconductor/internal/types/... prismconductor/internal/orchestrator/... prismconductor/internal/store/... prismconductor/internal/cardstate/... prismconductor/internal/issueview/...` | pass (5 packages, 0 failures) |

Commit tier: **Tier 1** (GitHub API `createCommitOnBranch`, SHA `f363ae86d2c0fa1013176ff60839d9bc7c8010a8`)

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-210

Closes #210