### PR TITLE
fix(#247): conflict badges + REVIEW rollback + poller watchdog

### DIFF
--- a/app.go
+++ b/app.go
@@ -353,6 +353,9 @@ func (a *App) startup(ctx context.Context) {
 		// Issue #124: PR merge-conflict detection and resolution worker.
 		a.bus.Subscribe(a.handlePRConflictsDetected)
 		a.bus.Subscribe(a.handlePRConflictsResolved)
+
+		// Issue #247: poller watchdog toast.
+		a.bus.Subscribe(a.handlePollerWatchdogFired)
 	}
 
 	// Issue #17: answer-file watcher. Polls each enabled workspace's
@@ -499,6 +502,23 @@ func (a *App) handleSessionStateChange(sess types.Session, prev types.SessionSta
 		}
 		if err := a.store.SetIssueFailureReason(sess.WorkspaceID, sess.IssueNumber, reason); err != nil {
 			log.Printf("SetIssueFailureReason #%d: %v", sess.IssueNumber, err)
+		}
+
+		// When the execute session fails and the issue already has an open PR,
+		// roll the card back to REVIEW so it is not stranded in IN_PROGRESS.
+		// The user can inspect or re-open the PR from the REVIEW column (#247).
+		if iss, loadErr := a.store.LoadIssue(sess.WorkspaceID, sess.IssueNumber); loadErr == nil && iss.PRNumber != nil {
+			if mvErr := a.store.MoveIssueColumn(sess.WorkspaceID, sess.IssueNumber, types.ColReview); mvErr != nil {
+				log.Printf("handleSessionStateChange: rollback to REVIEW #%d: %v", sess.IssueNumber, mvErr)
+			} else {
+				a.emitToast("warning", toastWorkspaceName(a.wsReg, sess.WorkspaceID),
+					fmt.Sprintf("#%d execute/continue failed; card returned to REVIEW. Last error: %s", sess.IssueNumber, reason),
+					map[string]any{
+						"workspace_id": sess.WorkspaceID,
+						"issue_number": sess.IssueNumber,
+						"action":       "focus_card",
+					})
+			}
 		}
 
 		// Attempt to schedule an automatic retry for transient failures (#221).
@@ -3966,6 +3986,17 @@ func (a *App) handlePRConflictsResolved(e eventbus.Event) {
 				"issue_number": p.IssueNumber,
 				"action":       "focus_card",
 			})
+	}
+}
+
+// handlePollerWatchdogFired handles EvtPollerWatchdogFired (#247): emits a
+// warning toast when the GitHub poll loop has been restarted by the watchdog.
+func (a *App) handlePollerWatchdogFired(e eventbus.Event) {
+	if e.Type != eventbus.EvtPollerWatchdogFired {
+		return
+	}
+	if !a.notificationsSuppressed() {
+		a.emitToast("warning", "GitHub Poller", "GitHub poller was stuck — restarted", nil)
 	}
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -340,3 +340,89 @@ func TestRetryExecuteForApprovedPlan_RequiresRegistry(t *testing.T) {
 		t.Fatal("expected error when wsReg and store are nil")
 	}
 }
+
+// Issue #247: when an execute session fails after a PR has been opened,
+// handleSessionStateChange must move the card to REVIEW and emit a toast.
+func TestHandleSessionStateChange_RollsBackToReviewWhenPROpen(t *testing.T) {
+	s, err := store.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	const wsID = "ws1"
+	const issueNum = 77
+	prNum := 99
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID: wsID,
+		Number:      issueNum,
+		Title:       "issue with open PR",
+		State:       "open",
+		Column:      types.ColInProgress,
+		PRNumber:    &prNum,
+	}); err != nil {
+		t.Fatalf("SaveIssue: %v", err)
+	}
+
+	a := &App{store: s, bus: eventbus.New()}
+	failedSess := types.Session{
+		ID:            "sess-fail",
+		WorkspaceID:   wsID,
+		IssueNumber:   issueNum,
+		Mode:          types.ModeExecute,
+		State:         types.StateBlocked,
+		BlockedReason: "lint failed",
+	}
+	a.handleSessionStateChange(failedSess, types.StateRunning)
+
+	// Card must be rolled back to REVIEW.
+	iss, err := s.LoadIssue(wsID, issueNum)
+	if err != nil {
+		t.Fatalf("LoadIssue: %v", err)
+	}
+	if iss.Column != types.ColReview {
+		t.Errorf("column = %q, want %q", iss.Column, types.ColReview)
+	}
+}
+
+// Issue #247: when an execute session fails with NO open PR, the card must
+// NOT be rolled back to REVIEW (preserve existing behaviour).
+func TestHandleSessionStateChange_NoRollbackWhenNoPR(t *testing.T) {
+	s, err := store.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	const wsID = "ws1"
+	const issueNum = 88
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID: wsID,
+		Number:      issueNum,
+		Title:       "issue without PR",
+		State:       "open",
+		Column:      types.ColInProgress,
+	}); err != nil {
+		t.Fatalf("SaveIssue: %v", err)
+	}
+
+	a := &App{store: s, bus: eventbus.New()}
+	failedSess := types.Session{
+		ID:            "sess-fail-no-pr",
+		WorkspaceID:   wsID,
+		IssueNumber:   issueNum,
+		Mode:          types.ModeExecute,
+		State:         types.StateFailed,
+		BlockedReason: "build failed",
+	}
+	a.handleSessionStateChange(failedSess, types.StateRunning)
+
+	// Column must NOT have changed — no PR, no rollback.
+	iss, err := s.LoadIssue(wsID, issueNum)
+	if err != nil {
+		t.Fatalf("LoadIssue: %v", err)
+	}
+	if iss.Column != types.ColInProgress {
+		t.Errorf("column = %q, want %q (no rollback expected without PR)", iss.Column, types.ColInProgress)
+	}
+}

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -924,7 +924,7 @@ function StatusRow({
   }
 
   const showConflicts =
-    conflictsInfo && column === "review" && !activeSession && !pausedSession && !waitingForPool;
+    conflictsInfo && !activeSession && !pausedSession && !waitingForPool;
   if (showConflicts && conflictsInfo) {
     const fileCount = conflictsInfo.conflicting_files?.length ?? 0;
     return (
@@ -963,7 +963,7 @@ function StatusRow({
   }
 
   const showTestsFailing =
-    testsFailingInfo && column === "review" && !activeSession && !pausedSession && !waitingForPool;
+    testsFailingInfo && !activeSession && !pausedSession && !waitingForPool;
   if (showTestsFailing && testsFailingInfo) {
     const jobCount = testsFailingInfo.failing_jobs?.length ?? 0;
     const maxReached = testsFailingInfo.max_attempts_reached ?? false;

--- a/internal/cardstate/cardstate.go
+++ b/internal/cardstate/cardstate.go
@@ -132,8 +132,8 @@ type DeriveParams struct {
 //  7. Active session execute-mode → in_progress
 //  8. No active session + waiting_for_pool → waiting_for_pool
 //  9. No active session + needs_pr → needs_pr
-//  10. No active session + merge_conflict → merge_conflict
-//  11. No active session + tests_failing → tests_failing
+//  10. No active session + merge_conflict (PR open, any column) → merge_conflict
+//  11. No active session + tests_failing (PR open, any column) → tests_failing
 //  12. No active session + last_failure → blocked
 //  13. No active session + plan_failed → plan_failed
 //  14. Plan ready (not approved) → plan_ready
@@ -207,10 +207,10 @@ func DeriveCardState(p DeriveParams) (CardState, CardStateDetails) {
 			BlockedReason: p.NeedsPRInfo.Reason,
 		}
 	}
-	if p.HasConflicts && p.Column == types.ColReview {
+	if p.HasConflicts && p.PRNumber != nil {
 		return CardStateMergeConflict, CardStateDetails{Reason: "PR has merge conflicts with its base branch"}
 	}
-	if p.HasTestsFailing && p.Column == types.ColReview {
+	if p.HasTestsFailing && p.PRNumber != nil {
 		return CardStateTestsFailing, CardStateDetails{Reason: "PR check runs are failing"}
 	}
 	if p.LastFailure != nil {

--- a/internal/cardstate/cardstate_test.go
+++ b/internal/cardstate/cardstate_test.go
@@ -197,12 +197,22 @@ func TestDeriveCardState(t *testing.T) {
 			wantState: cardstate.CardStateMergeConflict,
 		},
 		{
-			name: "merge conflict NOT in review column → ignored",
+			name: "merge conflict NOT in review column, no PR → ignored",
 			params: cardstate.DeriveParams{
 				Column:       types.ColInProgress,
 				HasConflicts: true,
+				// PRNumber nil: conflict signal exists but no PR yet, so ignored.
 			},
 			wantState: cardstate.CardStateTodo,
+		},
+		{
+			name: "merge conflict with PR, NOT in review column → merge_conflict",
+			params: cardstate.DeriveParams{
+				Column:       types.ColInProgress,
+				PRNumber:     ptr(7),
+				HasConflicts: true,
+			},
+			wantState: cardstate.CardStateMergeConflict,
 		},
 		{
 			name: "tests failing in review column",
@@ -214,12 +224,22 @@ func TestDeriveCardState(t *testing.T) {
 			wantState: cardstate.CardStateTestsFailing,
 		},
 		{
-			name: "tests failing NOT in review column → ignored",
+			name: "tests failing NOT in review column, no PR → ignored",
 			params: cardstate.DeriveParams{
 				Column:          types.ColInProgress,
 				HasTestsFailing: true,
+				// PRNumber nil: test signal exists but no PR yet, so ignored.
 			},
 			wantState: cardstate.CardStateTodo,
+		},
+		{
+			name: "tests failing with PR, NOT in review column → tests_failing",
+			params: cardstate.DeriveParams{
+				Column:          types.ColInProgress,
+				PRNumber:        ptr(7),
+				HasTestsFailing: true,
+			},
+			wantState: cardstate.CardStateTestsFailing,
 		},
 		{
 			name: "last_failure (blocked reason) → blocked",

--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -67,6 +67,9 @@ const (
 	EvtRetryFired     EventType = "retry_fired"
 	EvtRetryCancelled EventType = "retry_cancelled"
 	EvtRetryExhausted EventType = "retry_exhausted"
+
+	// Issue #247: poller watchdog fired when the GitHub poll loop stalls.
+	EvtPollerWatchdogFired EventType = "poller_watchdog_fired"
 )
 
 type Event struct {

--- a/internal/github/poll.go
+++ b/internal/github/poll.go
@@ -96,6 +96,11 @@ type Poller struct {
 	// can filter out the conductor's own comments from the unread-badge signal.
 	ghUserOnce sync.Once
 	ghUser     string
+
+	// lastPollAt records the time the most recent fanOut completed. The watchdog
+	// goroutine uses it to detect a stalled loop (issue #247).
+	lastPollMu sync.Mutex
+	lastPollAt time.Time
 }
 
 // NewPoller constructs a Poller with sensible defaults.
@@ -164,6 +169,9 @@ func (p *Poller) Run(ctx context.Context) {
 	p.running = true
 	p.mu.Unlock()
 
+	// Watchdog: restarts a stalled poll loop (issue #247).
+	go p.runWatchdog(ctx)
+
 	// Initial fetch.
 	p.fanOut(ctx)
 
@@ -222,10 +230,55 @@ func (p *Poller) fanOut(ctx context.Context) {
 		}(ws)
 	}
 	wg.Wait()
+	now := time.Now()
+	p.lastPollMu.Lock()
+	p.lastPollAt = now
+	p.lastPollMu.Unlock()
 	if p.Bus != nil {
 		p.Bus.Publish(eventbus.EventType("github_poll_done"), map[string]any{
-			"at": time.Now(),
+			"at": now,
 		})
+	}
+}
+
+// LastPollAt returns the time the most recent fanOut completed, or zero if
+// no poll has completed yet. Safe for concurrent use.
+func (p *Poller) LastPollAt() time.Time {
+	p.lastPollMu.Lock()
+	defer p.lastPollMu.Unlock()
+	return p.lastPollAt
+}
+
+// runWatchdog monitors lastPollAt and pokes the poll loop if it goes quiet
+// for more than 3× the configured interval. Emits EvtPollerWatchdogFired
+// on the bus so the app layer can surface a toast (issue #247).
+// Returns when ctx is cancelled.
+func (p *Poller) runWatchdog(ctx context.Context) {
+	threshold := 3 * p.Interval
+	ticker := time.NewTicker(p.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.lastPollMu.Lock()
+			last := p.lastPollAt
+			p.lastPollMu.Unlock()
+			if last.IsZero() {
+				continue // no poll has completed yet; watchdog not armed
+			}
+			if time.Since(last) < threshold {
+				continue
+			}
+			log.Printf("github poller watchdog: no poll completed in %v — poking loop", time.Since(last).Round(time.Second))
+			p.PokeNow()
+			if p.Bus != nil {
+				p.Bus.Publish(eventbus.EvtPollerWatchdogFired, map[string]any{
+					"stale_seconds": int(time.Since(last).Seconds()),
+				})
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Part A**: `handleSessionStateChange` now rolls execute-failure cards back to REVIEW when the issue already has an open PR, so cards are never stranded in IN_PROGRESS after a continue-work failure
- **Part B**: `DeriveCardState` derives `merge_conflict` and `tests_failing` from `PRNumber != nil` (any column) instead of `Column == ColReview`, so conflicted PRs show the red glow and Resolve Conflicts button regardless of column
- **Part C**: Added `lastPollAt` tracking and a watchdog goroutine in `internal/github/poll.go` that pokes the poll loop if it stalls for >3× the interval and emits an `EvtPollerWatchdogFired` bus event; `app.go` subscribes and shows a warning toast

## Files modified

- `app.go` — REVIEW rollback in `handleSessionStateChange`, `handlePollerWatchdogFired` bus subscriber
- `app_test.go` — two new tests: rollback fires when PR open, no rollback when PR absent
- `internal/cardstate/cardstate.go` — `HasConflicts`/`HasTestsFailing` now gate on `PRNumber != nil`
- `internal/cardstate/cardstate_test.go` — new cases: conflict+PR in IN_PROGRESS → merge_conflict; tests_failing+PR in IN_PROGRESS → tests_failing
- `internal/eventbus/bus.go` — `EvtPollerWatchdogFired` event type
- `internal/github/poll.go` — `lastPollAt` field, `LastPollAt()` accessor, `runWatchdog()` goroutine
- `frontend/src/components/Card.tsx` — removed `column === "review"` gate from `showConflicts` and `showTestsFailing`

## Verification

| Gate | Command | Result |
|---|---|---|
| Lint (Go internal) | `go vet prismconductor/internal/...` | pass |
| Typecheck (TS) | `npx tsc --noEmit` (frontend) | pass |
| Build (frontend) | `npm run build` | pass |
| Smoke test | `npx playwright test tests/e2e/startup.spec.ts` | skipped locally — requires running `wails dev` + xvfb; CI `smoke.yml` gates this |
| Tests (Go) | `go test prismconductor prismconductor/internal/...` | pass (40 packages) |

**Commit tier**: Tier 1 (GitHub GraphQL `createCommitOnBranch` — signed by GitHub)

## Notes

- Q3 (last-poll timestamp in Settings UI) not implemented — was not in `files_to_modify`; `Poller.LastPollAt()` accessor is available for a follow-up
- Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-247

Closes #247