### PR TITLE
feat: unlock Event Diagnostics panel in release builds (#249)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,15 @@ The product spec lives in `PRISMCONDUCTOR_PLAN.md`. Treat it as the source of tr
 - `wails build` — full app bundle (~40s).
 - `PRISMCONDUCTOR_DATA_DIR=<path>` — overrides the conductor's data directory. Tests, smoke harnesses, and worker verification gates MUST set this to a temp dir; otherwise they can corrupt the user's real `~/Library/Application Support/PrismConductor/conductor.db`. CI enforces that no test code touches the prod path (see `.github/workflows/smoke.yml` and `.github/workflows/build.yml`).
 
+## Advanced / Diagnostics
+
+The Event Diagnostics panel (`EventDiagnostics` component) shows live event-bus ring buffers. It is always visible in `wails dev` (DEV builds). In release builds it is hidden by default and can be enabled two ways:
+
+- **Session-only (chord):** Press `Cmd+Opt+D` on macOS or `Ctrl+Alt+D` on Windows/Linux. The Diagnostics tab appears for the current session only and is gone after a restart.
+- **Persistent (Settings):** Open Settings → Advanced → enable "Show Diagnostics tab". This persists to `localStorage` under the key `prismconductor.showDiagnostics` and survives restarts.
+
+Intended for support engineers and power users diagnosing UI/backend state drift.
+
 ## Verification skills
 
 - **`/bug-hunter-state`** — scans the conductor's persistent state (SQLite DB, `workspaces.json`, transcripts dir, live process table) for 12 known broken-state patterns and writes a timestamped `{findings}` JSON + Markdown report to `.prismconductor/bug-hunter/`. Read-only; never mutates state. Invoke on demand or schedule with `/loop 24h /bug-hunter-state`. Reports land in `.prismconductor/bug-hunter/<RFC3339>.{json,md}`; `latest.json` always points to the most recent run.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,11 +31,13 @@ import { TitleSearch } from "./components/Header";
 import { PoolsHeader } from "./components/PoolsHeader";
 import { AgentTerminalDrawer } from "./components/AgentTerminalDrawer";
 import { useAgentTerminalStore } from "./stores/useAgentTerminalStore";
+import { useDiagnosticUnlock } from "./hooks/useDiagnosticUnlock";
 
 type PlanRef = { workspace_id: string; number: number };
 type PlanTarget = PlanRef | null;
 
 function App() {
+  useDiagnosticUnlock();
   const appendLine = useSessionStore((s) => s.appendLine);
   const setMeta = useSessionStore((s) => s.setMeta);
   const setActive = useSessionStore((s) => s.setActive);

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -7,8 +7,9 @@ import { LogsPanel } from "./LogsPanel";
 import { AppearancePanel } from "./AppearancePanel";
 import { CollectionsPanel } from "./CollectionsPanel";
 import { EventDiagnostics } from "./EventDiagnostics";
+import { useSettingsStore } from "../stores/useSettingsStore";
 
-type Tab = "workspaces" | "collections" | "pools" | "skills" | "notify" | "appearance" | "logs" | "diagnostics";
+type Tab = "workspaces" | "collections" | "pools" | "skills" | "notify" | "appearance" | "logs" | "advanced" | "diagnostics";
 
 export function Settings({
   open,
@@ -20,6 +21,12 @@ export function Settings({
   initialTab?: Tab;
 }) {
   const [tab, setTab] = useState<Tab>(initialTab ?? "workspaces");
+  const showDiagnostics = useSettingsStore((s) => s.showDiagnostics);
+  const diagnosticsUnlocked = useSettingsStore((s) => s.diagnosticsUnlocked);
+  const setShowDiagnostics = useSettingsStore((s) => s.setShowDiagnostics);
+
+  const diagnosticsVisible = import.meta.env.DEV || showDiagnostics || diagnosticsUnlocked;
+
   if (!open) return null;
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
@@ -39,7 +46,8 @@ export function Settings({
                 ["notify", "Notifications"],
                 ["appearance", "Appearance"],
                 ["logs", "Logs"],
-                ...(import.meta.env.DEV ? [["diagnostics", "Diagnostics"] as [Tab, string]] : []),
+                ["advanced", "Advanced"],
+                ...(diagnosticsVisible ? [["diagnostics", "Diagnostics"] as [Tab, string]] : []),
               ] as [Tab, string][]
             ).map(([k, label]) => (
               <button
@@ -62,7 +70,34 @@ export function Settings({
             {tab === "notify" && <NotifyPanel />}
             {tab === "appearance" && <AppearancePanel />}
             {tab === "logs" && <LogsPanel />}
-            {tab === "diagnostics" && import.meta.env.DEV && <EventDiagnostics />}
+            {tab === "advanced" && (
+              <div className="space-y-4">
+                <div>
+                  <div className="text-slate-300 text-sm font-medium mb-1">Diagnostics</div>
+                  <label className="flex items-center gap-3 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={showDiagnostics}
+                      onChange={(e) => setShowDiagnostics(e.target.checked)}
+                      className="accent-sky-500"
+                    />
+                    <span className="text-slate-400 text-sm">
+                      Show Diagnostics tab
+                    </span>
+                  </label>
+                  <p className="text-slate-500 text-xs mt-1">
+                    Exposes the Event Diagnostics panel for on-device debugging. Persists across restarts.
+                    You can also unlock it for the current session with{" "}
+                    <kbd className="px-1 py-0.5 bg-slate-800 rounded text-slate-300">
+                      {typeof navigator !== "undefined" && /Mac|Macintosh/.test(navigator.platform || navigator.userAgent)
+                        ? "⌘⌥D"
+                        : "Ctrl+Alt+D"}
+                    </kbd>.
+                  </p>
+                </div>
+              </div>
+            )}
+            {tab === "diagnostics" && diagnosticsVisible && <EventDiagnostics />}
           </div>
         </div>
       </div>

--- a/frontend/src/hooks/useDiagnosticUnlock.ts
+++ b/frontend/src/hooks/useDiagnosticUnlock.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+import { useSettingsStore } from "../stores/useSettingsStore";
+
+const isMac = /Mac|Macintosh|iPhone|iPad/.test(
+  typeof navigator !== "undefined" ? (navigator.platform || navigator.userAgent) : "",
+);
+
+export function useDiagnosticUnlock() {
+  const setDiagnosticsUnlocked = useSettingsStore((s) => s.setDiagnosticsUnlocked);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const modifierOk = isMac ? e.metaKey : e.ctrlKey;
+      if (modifierOk && e.altKey && e.key.toLowerCase() === "d") {
+        setDiagnosticsUnlocked(true);
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [setDiagnosticsUnlocked]);
+}

--- a/frontend/src/stores/useSettingsStore.test.ts
+++ b/frontend/src/stores/useSettingsStore.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Stub localStorage before importing the store.
+const storage: Record<string, string> = {};
+vi.stubGlobal("localStorage", {
+  getItem: (k: string) => storage[k] ?? null,
+  setItem: (k: string, v: string) => { storage[k] = v; },
+  removeItem: (k: string) => { delete storage[k]; },
+});
+
+import { useSettingsStore } from "./useSettingsStore";
+
+const DIAGNOSTICS_KEY = "prismconductor.showDiagnostics";
+
+beforeEach(() => {
+  for (const k of Object.keys(storage)) delete storage[k];
+  useSettingsStore.setState({ showDiagnostics: false, diagnosticsUnlocked: false });
+});
+
+describe("useSettingsStore", () => {
+  it("defaults to showDiagnostics=false and diagnosticsUnlocked=false", () => {
+    const { showDiagnostics, diagnosticsUnlocked } = useSettingsStore.getState();
+    expect(showDiagnostics).toBe(false);
+    expect(diagnosticsUnlocked).toBe(false);
+  });
+
+  it("setShowDiagnostics persists to localStorage", () => {
+    useSettingsStore.getState().setShowDiagnostics(true);
+    expect(useSettingsStore.getState().showDiagnostics).toBe(true);
+    expect(storage[DIAGNOSTICS_KEY]).toBe("true");
+  });
+
+  it("setShowDiagnostics false clears persisted value", () => {
+    storage[DIAGNOSTICS_KEY] = "true";
+    useSettingsStore.getState().setShowDiagnostics(false);
+    expect(useSettingsStore.getState().showDiagnostics).toBe(false);
+    expect(storage[DIAGNOSTICS_KEY]).toBe("false");
+  });
+
+  it("setDiagnosticsUnlocked sets session flag without persisting", () => {
+    useSettingsStore.getState().setDiagnosticsUnlocked(true);
+    expect(useSettingsStore.getState().diagnosticsUnlocked).toBe(true);
+    expect(storage[DIAGNOSTICS_KEY]).toBeUndefined();
+  });
+
+  it("setDiagnosticsUnlocked can be reset to false", () => {
+    useSettingsStore.setState({ diagnosticsUnlocked: true });
+    useSettingsStore.getState().setDiagnosticsUnlocked(false);
+    expect(useSettingsStore.getState().diagnosticsUnlocked).toBe(false);
+  });
+});

--- a/frontend/src/stores/useSettingsStore.ts
+++ b/frontend/src/stores/useSettingsStore.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+
+const DIAGNOSTICS_KEY = "prismconductor.showDiagnostics";
+
+function loadShowDiagnostics(): boolean {
+  try {
+    return localStorage.getItem(DIAGNOSTICS_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+type State = {
+  showDiagnostics: boolean;
+  diagnosticsUnlocked: boolean;
+  setShowDiagnostics: (val: boolean) => void;
+  setDiagnosticsUnlocked: (val: boolean) => void;
+};
+
+export const useSettingsStore = create<State>((set) => ({
+  showDiagnostics: loadShowDiagnostics(),
+  diagnosticsUnlocked: false,
+  setShowDiagnostics: (val) => {
+    try {
+      localStorage.setItem(DIAGNOSTICS_KEY, String(val));
+    } catch {
+      // ignore
+    }
+    set({ showDiagnostics: val });
+  },
+  setDiagnosticsUnlocked: (val) => set({ diagnosticsUnlocked: val }),
+}));


### PR DESCRIPTION
## Summary

- Adds a hidden keyboard chord (`Cmd+Opt+D` on macOS, `Ctrl+Alt+D` on Windows/Linux) that unlocks the Diagnostics tab for the current session only.
- Adds a persisted Settings → Advanced → "Show diagnostics tab" toggle so the panel survives restarts.
- DEV builds remain always-on and unchanged.

## Files modified

- `frontend/src/stores/useSettingsStore.ts` *(new)* — `showDiagnostics` (localStorage-persisted) + `diagnosticsUnlocked` (session-only) Zustand store
- `frontend/src/hooks/useDiagnosticUnlock.ts` *(new)* — keydown listener for platform-aware chord; mounted at App root
- `frontend/src/components/Settings.tsx` — Advanced tab with toggle; diagnostics gate replaced with `DEV || showDiagnostics || diagnosticsUnlocked`
- `frontend/src/App.tsx` — mounts `useDiagnosticUnlock` hook
- `CLAUDE.md` — documents unlock flows for support engineers

## Verification

| Gate | Command | Result |
|------|---------|--------|
| Lint / typecheck | `cd frontend && node_modules/.bin/tsc --noEmit` | ✅ pass |
| Build | `wails build` | ✅ pass (8.8 s) |
| Smoke test | `npx --prefix tests playwright test tests/e2e/startup.spec.ts` | ⚠ skipped in execute worker — no wails dev server running at localhost:34115 (environment limitation); CI workflow runs this under xvfb-run |
| Unit tests | `cd frontend && node_modules/.bin/vitest run` | ✅ 97 passed (12 files) — includes new `useSettingsStore.test.ts` |

Commit tier: **Tier 1** (GitHub API signed commit)

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-249

Closes #249