### PR TITLE
feat(pools): auto-derive model list per pool from provider (#28)

### DIFF
--- a/frontend/src/components/ModelSelect.tsx
+++ b/frontend/src/components/ModelSelect.tsx
@@ -1,0 +1,70 @@
+import { noAutoCorrect } from "../lib/inputs";
+import { useModelsStore } from "../stores/modelsStore";
+
+type Props = {
+  provider: string;
+  endpoint: string;
+  apiKey: string;
+  value: string;
+  onChange: (v: string) => void;
+};
+
+export function ModelSelect({ provider, endpoint, apiKey, value, onChange }: Props) {
+  const entry = useModelsStore((s) => s.getEntry(provider, endpoint));
+  const { invalidate, fetch } = useModelsStore();
+
+  const models = entry?.models ?? [];
+  const loading = entry?.loading ?? false;
+  const error = entry?.error ?? null;
+
+  async function handleRefresh() {
+    invalidate(provider, endpoint);
+    try {
+      await fetch(provider, endpoint, apiKey);
+    } catch {
+      // error stored in the cache entry
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      {models.length > 0 ? (
+        <select
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="flex-1 bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-100"
+        >
+          <option value="">— pick a model —</option>
+          {models.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          {...noAutoCorrect}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={loading ? "Loading models…" : "model id (free text)"}
+          disabled={loading}
+          className="flex-1 bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-100 font-mono text-xs disabled:opacity-60"
+        />
+      )}
+      <button
+        type="button"
+        disabled={loading}
+        onClick={handleRefresh}
+        title="Refresh model list"
+        className="shrink-0 text-slate-400 hover:text-slate-200 disabled:opacity-50 px-1 text-sm"
+      >
+        {loading ? "…" : "↻"}
+      </button>
+      {!loading && error && (
+        <span className="text-xs text-amber-400" title={error}>
+          ⚠
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/PoolEditModal.tsx
+++ b/frontend/src/components/PoolEditModal.tsx
@@ -2,11 +2,12 @@ import { useEffect, useMemo, useState } from "react";
 import {
   CreatePool,
   ListWorkspaces,
-  ProbeProviderModels,
   SavePool,
 } from "../../wailsjs/go/main/App";
 import { main, types } from "../../wailsjs/go/models";
 import { noAutoCorrect } from "../lib/inputs";
+import { ModelSelect } from "./ModelSelect";
+import { useModelsStore } from "../stores/modelsStore";
 
 type Role = "plan" | "work" | "orchestrator";
 type Scope = "shared" | "workspace";
@@ -82,8 +83,6 @@ export function PoolEditModal({
   const [outputCapKBStr, setOutputCapKBStr] = useState<string>(
     initial?.output_cap != null ? String(Math.round((initial.output_cap as number) / 1024)) : "",
   );
-  const [models, setModels] = useState<string[]>([]);
-  const [probing, setProbing] = useState(false);
   const [testResult, setTestResult] = useState<{ ok: boolean; msg: string } | null>(null);
   const [busy, setBusy] = useState(false);
   const [saveErr, setSaveErr] = useState<string>("");
@@ -92,6 +91,12 @@ export function PoolEditModal({
     () => providers.find((p) => p.kind === providerKind),
     [providers, providerKind],
   );
+
+  const resolvedEndpoint = endpoint || (providerInfo?.default_endpoint ?? "");
+  const fetchModels = useModelsStore((s) => s.fetch);
+  const invalidateModels = useModelsStore((s) => s.invalidate);
+  const modelEntry = useModelsStore((s) => s.getEntry(providerKind, resolvedEndpoint));
+  const probing = modelEntry?.loading ?? false;
 
   // Disable Save when picking role=orchestrator while another enabled
   // orchestrator pool already exists (and isn't the row we're editing).
@@ -124,29 +129,16 @@ export function PoolEditModal({
     }
   }, [model, providerKind]);
 
-  async function probe(): Promise<string[]> {
-    if (!providerInfo) return [];
-    setProbing(true);
-    try {
-      const list = await ProbeProviderModels(
-        providerKind,
-        endpoint || providerInfo.default_endpoint,
-        apiKey,
-      );
-      setModels(list ?? []);
-      return list ?? [];
-    } catch (err) {
-      setModels([]);
-      throw err;
-    } finally {
-      setProbing(false);
-    }
-  }
+  // Auto-probe when provider changes.
+  useEffect(() => {
+    if (!providerInfo) return;
+    fetchModels(providerKind, resolvedEndpoint, apiKey).catch(() => {});
+  }, [providerKind]);
 
   async function onEndpointBlur() {
     if (!providerInfo) return;
     try {
-      await probe();
+      await fetchModels(providerKind, resolvedEndpoint, apiKey);
     } catch {
       // Silent — UI keeps the model field as free-text.
     }
@@ -155,7 +147,8 @@ export function PoolEditModal({
   async function onTestConnection() {
     setTestResult(null);
     try {
-      const list = await probe();
+      invalidateModels(providerKind, resolvedEndpoint);
+      const list = await fetchModels(providerKind, resolvedEndpoint, apiKey);
       const sample = list.slice(0, 3).join(", ");
       setTestResult({
         ok: true,
@@ -286,7 +279,6 @@ export function PoolEditModal({
               value={providerKind}
               onChange={(e) => {
                 setProviderKind(e.target.value);
-                setModels([]);
                 setTestResult(null);
                 const info = providers.find((p) => p.kind === e.target.value);
                 if (info && !initial) setEndpoint(info.default_endpoint);
@@ -331,28 +323,13 @@ export function PoolEditModal({
 
           <div>
             <div className="text-xs text-slate-500 mb-1">Model</div>
-            {models.length > 0 ? (
-              <select
-                value={model}
-                onChange={(e) => setModel(e.target.value)}
-                className="w-full bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-100"
-              >
-                <option value="">— pick a model —</option>
-                {models.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                  </option>
-                ))}
-              </select>
-            ) : (
-              <input
-                {...noAutoCorrect}
-                value={model}
-                onChange={(e) => setModel(e.target.value)}
-                placeholder="model id (free text)"
-                className="w-full bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-100 font-mono text-xs"
-              />
-            )}
+            <ModelSelect
+              provider={providerKind}
+              endpoint={resolvedEndpoint}
+              apiKey={apiKey}
+              value={model}
+              onChange={setModel}
+            />
           </div>
 
           <div className="flex items-center gap-2">

--- a/frontend/src/stores/modelsStore.test.ts
+++ b/frontend/src/stores/modelsStore.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../../wailsjs/go/main/App", () => ({
+  ProbeProviderModels: vi.fn(),
+}));
+
+import { useModelsStore } from "./modelsStore";
+import { ProbeProviderModels } from "../../wailsjs/go/main/App";
+
+beforeEach(() => {
+  useModelsStore.setState({ cache: {} });
+  vi.clearAllMocks();
+});
+
+describe("useModelsStore", () => {
+  it("getEntry returns null when not cached", () => {
+    const entry = useModelsStore.getState().getEntry("ollama", "http://localhost:11434");
+    expect(entry).toBeNull();
+  });
+
+  it("fetch calls ProbeProviderModels and caches the result", async () => {
+    (ProbeProviderModels as ReturnType<typeof vi.fn>).mockResolvedValueOnce(["model-a", "model-b"]);
+    const result = await useModelsStore.getState().fetch("ollama", "http://localhost:11434", "");
+    expect(result).toEqual(["model-a", "model-b"]);
+    expect(ProbeProviderModels).toHaveBeenCalledWith("ollama", "http://localhost:11434", "");
+    const entry = useModelsStore.getState().getEntry("ollama", "http://localhost:11434");
+    expect(entry).not.toBeNull();
+    expect(entry?.models).toEqual(["model-a", "model-b"]);
+    expect(entry?.error).toBeNull();
+    expect(entry?.loading).toBe(false);
+  });
+
+  it("fetch returns cached result within TTL without calling ProbeProviderModels again", async () => {
+    (ProbeProviderModels as ReturnType<typeof vi.fn>).mockResolvedValue(["model-a"]);
+    await useModelsStore.getState().fetch("ollama", "http://localhost:11434", "");
+    vi.clearAllMocks();
+    const result = await useModelsStore.getState().fetch("ollama", "http://localhost:11434", "");
+    expect(result).toEqual(["model-a"]);
+    expect(ProbeProviderModels).not.toHaveBeenCalled();
+  });
+
+  it("fetch bypasses cache after TTL expires", async () => {
+    vi.useFakeTimers();
+    (ProbeProviderModels as ReturnType<typeof vi.fn>).mockResolvedValue(["model-a"]);
+    await useModelsStore.getState().fetch("ollama", "http://localhost:11434", "");
+
+    // Advance time past TTL (5 minutes)
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    (ProbeProviderModels as ReturnType<typeof vi.fn>).mockResolvedValue(["model-b"]);
+    const result = await useModelsStore.getState().fetch("ollama", "http://localhost:11434", "");
+    expect(result).toEqual(["model-b"]);
+    expect(ProbeProviderModels).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("fetch stores error in cache entry on failure and rethrows", async () => {
+    (ProbeProviderModels as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("connection refused"));
+    await expect(
+      useModelsStore.getState().fetch("ollama", "http://localhost:11434", "")
+    ).rejects.toThrow("connection refused");
+
+    const entry = useModelsStore.getState().getEntry("ollama", "http://localhost:11434");
+    expect(entry).not.toBeNull();
+    expect(entry?.error).toBe("connection refused");
+    expect(entry?.loading).toBe(false);
+    expect(entry?.models).toEqual([]);
+  });
+
+  it("fetch preserves previous models in cache entry on failure", async () => {
+    (ProbeProviderModels as ReturnType<typeof vi.fn>).mockResolvedValueOnce(["model-a"]);
+    await useModelsStore.getState().fetch("ollama", "http://localhost:11434", "");
+
+    // Force cache expiry
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    (ProbeProviderModels as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("timeout"));
+    await expect(
+      useModelsStore.getState().fetch("ollama", "http://localhost:11434", "")
+    ).rejects.toThrow("timeout");
+
+    const entry = useModelsStore.getState().getEntry("ollama", "http://localhost:11434");
+    // Previous models preserved in cache entry on error
+    expect(entry?.models).toEqual(["model-a"]);
+    expect(entry?.error).toBe("timeout");
+    vi.useRealTimers();
+  });
+
+  it("invalidate removes the cache entry", async () => {
+    (ProbeProviderModels as ReturnType<typeof vi.fn>).mockResolvedValueOnce(["model-a"]);
+    await useModelsStore.getState().fetch("ollama", "http://localhost:11434", "");
+    expect(useModelsStore.getState().getEntry("ollama", "http://localhost:11434")).not.toBeNull();
+
+    useModelsStore.getState().invalidate("ollama", "http://localhost:11434");
+    expect(useModelsStore.getState().getEntry("ollama", "http://localhost:11434")).toBeNull();
+  });
+
+  it("invalidate does not affect other cache entries", async () => {
+    (ProbeProviderModels as ReturnType<typeof vi.fn>).mockResolvedValue(["model-a"]);
+    await useModelsStore.getState().fetch("ollama", "http://localhost:11434", "");
+    await useModelsStore.getState().fetch("openai", "https://api.openai.com", "sk-key");
+
+    useModelsStore.getState().invalidate("ollama", "http://localhost:11434");
+
+    expect(useModelsStore.getState().getEntry("ollama", "http://localhost:11434")).toBeNull();
+    expect(useModelsStore.getState().getEntry("openai", "https://api.openai.com")).not.toBeNull();
+  });
+
+  it("sets loading=true during fetch before resolving", async () => {
+    let resolveProbe!: (v: string[]) => void;
+    (ProbeProviderModels as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      new Promise<string[]>((resolve) => { resolveProbe = resolve; })
+    );
+
+    const fetchPromise = useModelsStore.getState().fetch("ollama", "http://localhost:11434", "");
+    const entry = useModelsStore.getState().getEntry("ollama", "http://localhost:11434");
+    expect(entry?.loading).toBe(true);
+
+    resolveProbe(["model-x"]);
+    await fetchPromise;
+    const afterEntry = useModelsStore.getState().getEntry("ollama", "http://localhost:11434");
+    expect(afterEntry?.loading).toBe(false);
+  });
+
+  it("cache is keyed by provider:endpoint so different combinations are independent", async () => {
+    (ProbeProviderModels as ReturnType<typeof vi.fn>).mockResolvedValueOnce(["ollama-model"]);
+    await useModelsStore.getState().fetch("ollama", "http://localhost:11434", "");
+    (ProbeProviderModels as ReturnType<typeof vi.fn>).mockResolvedValueOnce(["openai-model"]);
+    await useModelsStore.getState().fetch("openai", "https://api.openai.com", "key");
+
+    expect(useModelsStore.getState().getEntry("ollama", "http://localhost:11434")?.models).toEqual(["ollama-model"]);
+    expect(useModelsStore.getState().getEntry("openai", "https://api.openai.com")?.models).toEqual(["openai-model"]);
+  });
+});

--- a/frontend/src/stores/modelsStore.ts
+++ b/frontend/src/stores/modelsStore.ts
@@ -1,0 +1,81 @@
+import { create } from "zustand";
+import { ProbeProviderModels } from "../../wailsjs/go/main/App";
+
+const TTL_MS = 5 * 60 * 1000;
+
+export type CacheEntry = {
+  models: string[];
+  fetchedAt: number;
+  loading: boolean;
+  error: string | null;
+};
+
+type State = {
+  cache: Record<string, CacheEntry>;
+  getEntry: (provider: string, endpoint: string) => CacheEntry | null;
+  fetch: (provider: string, endpoint: string, apiKey: string) => Promise<string[]>;
+  invalidate: (provider: string, endpoint: string) => void;
+};
+
+function key(provider: string, endpoint: string): string {
+  return `${provider}:${endpoint}`;
+}
+
+export const useModelsStore = create<State>((set, get) => ({
+  cache: {},
+
+  getEntry: (provider, endpoint) => get().cache[key(provider, endpoint)] ?? null,
+
+  invalidate: (provider, endpoint) => {
+    const k = key(provider, endpoint);
+    set((s) => {
+      const next = { ...s.cache };
+      delete next[k];
+      return { cache: next };
+    });
+  },
+
+  fetch: async (provider, endpoint, apiKey) => {
+    const k = key(provider, endpoint);
+    const existing = get().cache[k];
+    if (existing && !existing.loading && Date.now() - existing.fetchedAt < TTL_MS) {
+      return existing.models;
+    }
+    set((s) => ({
+      cache: {
+        ...s.cache,
+        [k]: {
+          models: existing?.models ?? [],
+          fetchedAt: existing?.fetchedAt ?? 0,
+          loading: true,
+          error: null,
+        },
+      },
+    }));
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const list = (await ProbeProviderModels(provider as any, endpoint, apiKey)) ?? [];
+      set((s) => ({
+        cache: {
+          ...s.cache,
+          [k]: { models: list, fetchedAt: Date.now(), loading: false, error: null },
+        },
+      }));
+      return list;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      set((s) => ({
+        cache: {
+          ...s.cache,
+          [k]: {
+            models: existing?.models ?? [],
+            fetchedAt: existing?.fetchedAt ?? 0,
+            loading: false,
+            error: msg,
+          },
+        },
+      }));
+      throw err;
+    }
+  },
+}));

--- a/internal/llm/listmodels_test.go
+++ b/internal/llm/listmodels_test.go
@@ -1,0 +1,287 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sort"
+	"testing"
+
+	"prismconductor/internal/types"
+)
+
+// TestOllamaListModels verifies that /api/tags JSON is parsed, model names
+// are extracted, and the returned slice is sorted alphabetically.
+func TestOllamaListModels(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tags" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"models": []map[string]any{
+				{"name": "llama3:latest"},
+				{"name": "mistral:7b"},
+				{"name": "codellama:13b"},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	p := ollamaProvider{client: &http.Client{}}
+	pool := types.Pool{Endpoint: ts.URL}
+	got, err := p.ListModels(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("ListModels error: %v", err)
+	}
+	want := []string{"codellama:13b", "llama3:latest", "mistral:7b"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	if !sort.StringsAreSorted(got) {
+		t.Fatalf("result not sorted: %v", got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %s, want %s", i, got[i], want[i])
+		}
+	}
+}
+
+// TestOllamaListModelsEmpty verifies that an empty models array produces an
+// empty (not nil) slice with no error.
+func TestOllamaListModelsEmpty(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"models": []any{}})
+	}))
+	defer ts.Close()
+
+	p := ollamaProvider{client: &http.Client{}}
+	got, err := p.ListModels(context.Background(), types.Pool{Endpoint: ts.URL})
+	if err != nil {
+		t.Fatalf("ListModels error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %v", got)
+	}
+}
+
+// TestOpenAIListModels verifies the /v1/models OpenAI envelope is parsed and
+// model IDs are returned sorted.
+func TestOpenAIListModels(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"id": "gpt-4o"},
+				{"id": "gpt-4o-mini"},
+				{"id": "gpt-3.5-turbo"},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	p := openaiProvider{client: &http.Client{}}
+	got, err := p.ListModels(context.Background(), types.Pool{Endpoint: ts.URL, APIKey: "test-key"})
+	if err != nil {
+		t.Fatalf("ListModels error: %v", err)
+	}
+	want := []string{"gpt-3.5-turbo", "gpt-4o", "gpt-4o-mini"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	if !sort.StringsAreSorted(got) {
+		t.Fatalf("result not sorted: %v", got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %s, want %s", i, got[i], want[i])
+		}
+	}
+}
+
+// TestOpenAIListModelsUsesEnvKey verifies that when no API key is stored in
+// the pool, the OPENAI_API_KEY environment variable is forwarded as the Bearer
+// token.
+func TestOpenAIListModelsUsesEnvKey(t *testing.T) {
+	const envKey = "sk-test-env-key"
+	t.Setenv("OPENAI_API_KEY", envKey)
+
+	var gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"id": "gpt-4o"}},
+		})
+	}))
+	defer ts.Close()
+
+	p := openaiProvider{client: &http.Client{}}
+	_, err := p.ListModels(context.Background(), types.Pool{Endpoint: ts.URL, APIKey: ""})
+	if err != nil {
+		t.Fatalf("ListModels error: %v", err)
+	}
+	want := "Bearer " + envKey
+	if gotAuth != want {
+		t.Fatalf("Authorization header = %q, want %q", gotAuth, want)
+	}
+
+	// Restore env so tests don't leak state.
+	os.Unsetenv("OPENAI_API_KEY")
+}
+
+// TestLiteLLMListModelsPrefers_model_info verifies that the /model/info
+// LiteLLM-native endpoint is preferred and model_name fields are used.
+func TestLiteLLMListModelsPrefers_model_info(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/model/info":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
+					{"model_name": "gpt-4o-alias"},
+					{"model_name": "claude-3-alias"},
+				},
+			})
+		default:
+			http.Error(w, "should not be called", http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	p := litellmProvider{client: &http.Client{}}
+	got, err := p.ListModels(context.Background(), types.Pool{Endpoint: ts.URL})
+	if err != nil {
+		t.Fatalf("ListModels error: %v", err)
+	}
+	want := []string{"claude-3-alias", "gpt-4o-alias"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %s, want %s", i, got[i], want[i])
+		}
+	}
+}
+
+// TestLiteLLMListModelsFallsBackToV1Models verifies that when /model/info
+// fails (error or empty), the fallback to /v1/models is used.
+func TestLiteLLMListModelsFallsBackToV1Models(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/model/info":
+			http.Error(w, "not found", http.StatusNotFound)
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
+					{"id": "mixtral-8x7b"},
+					{"id": "llama-3-70b"},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	p := litellmProvider{client: &http.Client{}}
+	got, err := p.ListModels(context.Background(), types.Pool{Endpoint: ts.URL})
+	if err != nil {
+		t.Fatalf("ListModels fallback error: %v", err)
+	}
+	want := []string{"llama-3-70b", "mixtral-8x7b"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %s, want %s", i, got[i], want[i])
+		}
+	}
+}
+
+// TestLMStudioListModelsNativeAPI verifies the /api/v0/models native endpoint
+// is used and only models with state="loaded" (or empty state) are included.
+func TestLMStudioListModelsNativeAPI(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v0/models":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
+					{"id": "qwen2.5-coder-7b", "state": "loaded"},
+					{"id": "llama-3.2-1b", "state": "loaded"},
+					{"id": "phi-4", "state": "not-loaded"},
+					{"id": "gemma-2-2b", "state": ""},
+				},
+			})
+		default:
+			http.Error(w, "fallback should not be hit", http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	p := lmstudioProvider{client: &http.Client{}}
+	got, err := p.ListModels(context.Background(), types.Pool{Endpoint: ts.URL})
+	if err != nil {
+		t.Fatalf("ListModels error: %v", err)
+	}
+	// "phi-4" (state=not-loaded) must be excluded; empty-state entries included.
+	want := []string{"gemma-2-2b", "llama-3.2-1b", "qwen2.5-coder-7b"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %s, want %s", i, got[i], want[i])
+		}
+	}
+}
+
+// TestLMStudioListModelsFallback verifies that when /api/v0/models returns an
+// HTTP error, the provider falls back to /v1/models.
+func TestLMStudioListModelsFallback(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v0/models":
+			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
+					{"id": "meta-llama-3.1-8b-instruct"},
+					{"id": "deepseek-r1-distill-qwen-7b"},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	p := lmstudioProvider{client: &http.Client{}}
+	got, err := p.ListModels(context.Background(), types.Pool{Endpoint: ts.URL})
+	if err != nil {
+		t.Fatalf("ListModels fallback error: %v", err)
+	}
+	want := []string{"deepseek-r1-distill-qwen-7b", "meta-llama-3.1-8b-instruct"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %s, want %s", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `modelsStore` (Zustand, TTL=5 min, keyed by `provider:endpoint`) so model lists are cached across modal opens and re-probes only when stale
- Adds `ModelSelect` component: shows a `<select>` dropdown when models are available, falls back to free-text input otherwise, includes a ↻ refresh button and an amber error hint
- Refactors `PoolEditModal` to use the store + `ModelSelect` (removes local `models`/`probing` state, auto-probes on provider change, `Test connection` forces a fresh invalidate-then-fetch)

## Files modified

| File | Change |
|------|--------|
| `frontend/src/stores/modelsStore.ts` | **new** — Zustand cache store |
| `frontend/src/stores/modelsStore.test.ts` | **new** — 9 vitest tests (TTL hit/miss, error, invalidate, loading state) |
| `frontend/src/components/ModelSelect.tsx` | **new** — reusable dropdown/free-text component |
| `frontend/src/components/PoolEditModal.tsx` | modified — use store + `ModelSelect`, auto-probe on provider change |
| `internal/llm/listmodels_test.go` | **new** — 8 Go tests (Ollama, OpenAI, LiteLLM, LMStudio) with `httptest.NewServer` |

## Verification

| Gate | Command | Result |
|------|---------|--------|
| Lint | `go vet prismconductor/internal/...` | ✅ pass |
| Build | `wails build` (from repo root) | ✅ pass (8.4s) |
| Smoke test | `tests/e2e/startup.spec.ts` | ⚠ skipped — spec not present in this repo |
| Go tests | `go test prismconductor/internal/... -count=1` | ✅ pass (all packages) |
| TypeScript | `npx tsc --noEmit` | ✅ pass |
| Frontend tests | `npx vitest run` | ✅ 14 files, 112 tests pass |

Commit tier: **Tier 1** (GitHub API `createCommitOnBranch`, signed by GitHub)

Workspace mode: per-execute worktree at `/Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-28`

Closes #28