### PR TITLE
feat(providers): add Provider entity for centralized LLM credentials (#268)

### DIFF
--- a/app.go
+++ b/app.go
@@ -180,6 +180,9 @@ func (a *App) startup(ctx context.Context) {
 		if err := a.migrateOrchestratorPool(); err != nil {
 			log.Printf("migrate orchestrator pool: %v", err)
 		}
+		// Issue #268: one-shot migration to group pool credentials into Provider
+		// entities. Idempotent; emits a toast when providers are created.
+		a.migratePoolsToProviders()
 		if n, err := a.store.ReconcilePoolPriorities(); err != nil {
 			log.Printf("reconcile pool priorities: %v", err)
 		} else if n > 0 {
@@ -2674,6 +2677,60 @@ func (a *App) ProbeProviderModels(provider types.Provider, endpoint, apiKey stri
 	}
 	pool := types.Pool{Provider: provider, Endpoint: endpoint, APIKey: apiKey}
 	return prov.ListModels(a.ctx, pool)
+}
+
+// --- Provider entities (issue #268) ---
+
+// ListProviderEntities returns every saved provider credential row.
+func (a *App) ListProviderEntities() ([]types.ProviderEntity, error) {
+	if a.store == nil {
+		return nil, fmt.Errorf("store unavailable")
+	}
+	return a.store.ListProviderEntities()
+}
+
+// SaveProviderEntity upserts a provider row. An empty ID triggers a new UUID.
+func (a *App) SaveProviderEntity(p types.ProviderEntity) error {
+	if a.store == nil {
+		return fmt.Errorf("store unavailable")
+	}
+	if p.ID == "" {
+		p.ID = uuid.NewString()
+	}
+	if p.CreatedAt.IsZero() {
+		p.CreatedAt = time.Now()
+	}
+	return a.store.SaveProviderEntity(p)
+}
+
+// DeleteProviderEntity removes a provider row. Returns an error if any pool
+// still references this provider (issue #268 q2).
+func (a *App) DeleteProviderEntity(id string) error {
+	if a.store == nil {
+		return fmt.Errorf("store unavailable")
+	}
+	return a.store.DeleteProviderEntity(id)
+}
+
+// migratePoolsToProviders is the one-shot startup migration (issue #268 q3).
+// Groups existing pools by (kind, endpoint, api_key), creates Provider rows,
+// and emits a toast with the counts. Idempotent: pools with provider_id set
+// are skipped.
+func (a *App) migratePoolsToProviders() {
+	if a.store == nil {
+		return
+	}
+	created, updated, err := a.store.MigratePoolsToProviders()
+	if err != nil {
+		log.Printf("migratePoolsToProviders: %v", err)
+		return
+	}
+	if created > 0 {
+		a.emitToast("info", "Providers", fmt.Sprintf(
+			"Auto-created %d provider(s) from %d pool credential(s).",
+			created, updated,
+		), nil)
+	}
 }
 
 // migrateClaudePoolFromLegacy seeds one Claude pool the first time the pools

--- a/frontend/src/components/PoolEditModal.tsx
+++ b/frontend/src/components/PoolEditModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   CreatePool,
+  ListProviderEntities,
   ListWorkspaces,
   SavePool,
 } from "../../wailsjs/go/main/App";
@@ -61,6 +62,10 @@ export function PoolEditModal({
   const [scope, setScope] = useState<Scope>(((initial?.scope as Scope) || "shared") as Scope);
   const [scopeWorkspaceID, setScopeWorkspaceID] = useState<string>(initial?.workspace_id ?? "");
   const [workspaces, setWorkspaces] = useState<types.Workspace[]>([]);
+  const [providerEntities, setProviderEntities] = useState<types.ProviderEntity[]>([]);
+  const [selectedProviderEntityID, setSelectedProviderEntityID] = useState<string>(
+    initial?.provider_id ?? "",
+  );
   const [providerKind, setProviderKind] = useState<string>(
     initial?.provider ?? fallbackProvider,
   );
@@ -120,7 +125,19 @@ export function PoolEditModal({
 
   useEffect(() => {
     ListWorkspaces().then((ws) => setWorkspaces(ws ?? [])).catch(() => {});
+    ListProviderEntities().then((pv) => setProviderEntities(pv ?? [])).catch(() => {});
   }, []);
+
+  function applyProviderEntity(id: string) {
+    setSelectedProviderEntityID(id);
+    if (!id) return;
+    const entity = providerEntities.find((e) => e.id === id);
+    if (!entity) return;
+    setProviderKind(entity.kind);
+    setEndpoint(entity.endpoint);
+    setApiKey(entity.api_key ?? "");
+    setTestResult(null);
+  }
 
   useEffect(() => {
     if (initial) return;
@@ -183,6 +200,7 @@ export function PoolEditModal({
       const pool = types.Pool.createFrom({
         id: initial?.id ?? "",
         name: finalName,
+        provider_id: selectedProviderEntityID || undefined,
         provider: providerKind,
         endpoint: endpoint.trim(),
         model: model.trim(),
@@ -277,6 +295,27 @@ export function PoolEditModal({
               </div>
             )}
           </div>
+
+          {providerEntities.length > 0 && (
+            <div>
+              <div className="text-xs text-slate-500 mb-1">Saved provider (optional)</div>
+              <select
+                value={selectedProviderEntityID}
+                onChange={(e) => applyProviderEntity(e.target.value)}
+                className="w-full bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-100"
+              >
+                <option value="">— enter inline —</option>
+                {providerEntities.map((e) => (
+                  <option key={e.id} value={e.id}>
+                    {e.name}
+                  </option>
+                ))}
+              </select>
+              <div className="text-[11px] text-slate-500 mt-1">
+                Pick a saved provider to auto-fill credentials, or leave blank to enter inline.
+              </div>
+            </div>
+          )}
 
           <div>
             <div className="text-xs text-slate-500 mb-1">Provider</div>

--- a/frontend/src/components/PoolsPanel.tsx
+++ b/frontend/src/components/PoolsPanel.tsx
@@ -457,14 +457,18 @@ function PoolRow({
             ${spendToday.toFixed(2)}/day
           </div>
         )}
-        <label className="flex items-center gap-1 text-xs">
-          <input
-            type="checkbox"
-            checked={row.pool.enabled}
-            onChange={(e) => onToggleEnabled(row.pool, e.target.checked)}
-          />
-          enabled
-        </label>
+        <button
+          onClick={() => onToggleEnabled(row.pool, !row.pool.enabled)}
+          className={
+            "text-xs px-2 py-0.5 rounded-full border transition-colors " +
+            (row.pool.enabled
+              ? "bg-emerald-900/50 border-emerald-700 text-emerald-300 hover:bg-emerald-900"
+              : "bg-slate-800 border-slate-700 text-slate-500 hover:text-slate-300")
+          }
+          title={row.pool.enabled ? "Click to disable" : "Click to enable"}
+        >
+          {row.pool.enabled ? "enabled" : "disabled"}
+        </button>
         <button
           className="text-xs text-slate-300 hover:text-slate-100 px-2 py-1 border border-slate-700 rounded"
           onClick={onEdit}

--- a/frontend/src/components/ProvidersPanel.tsx
+++ b/frontend/src/components/ProvidersPanel.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useState } from "react";
+import {
+  DeleteProviderEntity,
+  ListProviderEntities,
+  ListProviders,
+  SaveProviderEntity,
+} from "../../wailsjs/go/main/App";
+import { main, types } from "../../wailsjs/go/models";
+import { noAutoCorrect } from "../lib/inputs";
+
+export function ProvidersPanel() {
+  const [providers, setProviders] = useState<types.ProviderEntity[]>([]);
+  const [driverKinds, setDriverKinds] = useState<main.ProviderInfo[]>([]);
+  const [editing, setEditing] = useState<types.ProviderEntity | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [deleteErr, setDeleteErr] = useState<Record<string, string>>({});
+
+  async function refresh() {
+    try {
+      const [pv, dk] = await Promise.all([ListProviderEntities(), ListProviders()]);
+      setProviders(pv ?? []);
+      setDriverKinds(dk ?? []);
+    } catch (err) {
+      console.error("ProvidersPanel refresh", err);
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const driverByKind = new Map(driverKinds.map((d) => [d.kind, d]));
+
+  async function onDelete(p: types.ProviderEntity) {
+    setDeleteErr((s) => ({ ...s, [p.id]: "" }));
+    try {
+      await DeleteProviderEntity(p.id);
+      await refresh();
+    } catch (err: any) {
+      const msg = String(err?.message ?? err ?? "");
+      const friendly = msg.includes("referenced by") ? msg : (msg || "Delete failed.");
+      setDeleteErr((s) => ({ ...s, [p.id]: friendly }));
+    }
+  }
+
+  return (
+    <div className="space-y-3 text-sm">
+      {providers.length === 0 && (
+        <div className="text-slate-500">
+          No provider credentials saved. Add one to share credentials across pools.
+        </div>
+      )}
+
+      {providers.map((p) => {
+        const driver = driverByKind.get(p.kind);
+        return (
+          <div key={p.id} className="border border-slate-800 rounded p-2 bg-slate-950/40">
+            <div className="flex items-center gap-2">
+              <div className="flex-1 min-w-0">
+                <div className="text-slate-100 font-mono text-xs flex items-center gap-2">
+                  <span>{p.name}</span>
+                  <span className="text-slate-500">({driver?.display_name ?? p.kind})</span>
+                </div>
+                <div className="text-slate-500 text-xs">
+                  {p.endpoint || driver?.default_endpoint || "—"}
+                  {p.api_key ? " · key set" : ""}
+                </div>
+              </div>
+              <button
+                className="text-xs text-slate-300 hover:text-slate-100 px-2 py-1 border border-slate-700 rounded"
+                onClick={() => setEditing(p)}
+              >
+                Edit
+              </button>
+              <button
+                className="text-xs text-rose-300 hover:text-rose-200 px-2 py-1 border border-rose-900 rounded"
+                onClick={() => onDelete(p)}
+              >
+                Remove
+              </button>
+            </div>
+            {deleteErr[p.id] && (
+              <div className="mt-1 text-xs text-rose-300">{deleteErr[p.id]}</div>
+            )}
+          </div>
+        );
+      })}
+
+      <button
+        className="text-xs text-slate-200 hover:text-slate-50 px-3 py-1 border border-slate-700 rounded"
+        onClick={() => setAdding(true)}
+      >
+        + Add provider
+      </button>
+
+      {(editing || adding) && (
+        <ProviderEditModal
+          driverKinds={driverKinds}
+          initial={editing}
+          onClose={() => {
+            setEditing(null);
+            setAdding(false);
+          }}
+          onSaved={async () => {
+            setEditing(null);
+            setAdding(false);
+            await refresh();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function ProviderEditModal({
+  driverKinds,
+  initial,
+  onClose,
+  onSaved,
+}: {
+  driverKinds: main.ProviderInfo[];
+  initial: types.ProviderEntity | null;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const fallbackKind = driverKinds[0]?.kind ?? "claude";
+  const [kind, setKind] = useState<string>(initial?.kind ?? fallbackKind);
+  const [name, setName] = useState<string>(initial?.name ?? "");
+  const [endpoint, setEndpoint] = useState<string>(initial?.endpoint ?? "");
+  const [apiKey, setApiKey] = useState<string>(initial?.api_key ?? "");
+  const [busy, setBusy] = useState(false);
+  const [saveErr, setSaveErr] = useState<string>("");
+
+  const driver = driverKinds.find((d) => d.kind === kind);
+
+  async function onSave() {
+    setBusy(true);
+    setSaveErr("");
+    try {
+      const finalName = name.trim() || `${kind}-default`;
+      const entity = types.ProviderEntity.createFrom({
+        id: initial?.id ?? "",
+        name: finalName,
+        kind,
+        endpoint: endpoint.trim(),
+        api_key: apiKey,
+        created_at: initial?.created_at ?? new Date().toISOString(),
+      });
+      await SaveProviderEntity(entity);
+      onSaved();
+    } catch (err: any) {
+      setSaveErr(String(err?.message ?? err ?? "save failed"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[60]">
+      <div className="w-[480px] bg-slate-900 border border-slate-700 rounded-lg p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="text-slate-200 font-medium">
+            {initial ? "Edit provider" : "Add provider"}
+          </div>
+          <button onClick={onClose} className="text-slate-400 hover:text-slate-200">✕</button>
+        </div>
+
+        <div className="space-y-3 text-sm">
+          <div>
+            <div className="text-xs text-slate-500 mb-1">Kind</div>
+            <select
+              value={kind}
+              onChange={(e) => setKind(e.target.value)}
+              className="w-full bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-100"
+            >
+              {driverKinds.map((d) => (
+                <option key={d.kind} value={d.kind}>
+                  {d.display_name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {driver && kind !== "claude" && (
+            <div>
+              <div className="text-xs text-slate-500 mb-1">Endpoint URL</div>
+              <input
+                {...noAutoCorrect}
+                value={endpoint}
+                onChange={(e) => setEndpoint(e.target.value)}
+                placeholder={driver.default_endpoint}
+                className="w-full bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-100 font-mono text-xs"
+              />
+            </div>
+          )}
+
+          {driver?.needs_api_key && (
+            <div>
+              <div className="text-xs text-slate-500 mb-1">API key (optional)</div>
+              <input
+                {...noAutoCorrect}
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder="leave empty to use the provider's environment variable"
+                className="w-full bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-100 font-mono text-xs"
+              />
+            </div>
+          )}
+
+          <div>
+            <div className="text-xs text-slate-500 mb-1">Name</div>
+            <input
+              {...noAutoCorrect}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={`${kind}-default`}
+              className="w-full bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-100 font-mono text-xs"
+            />
+          </div>
+
+          {saveErr && <div className="text-xs text-rose-300">{saveErr}</div>}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 pt-2 border-t border-slate-800">
+          <button
+            onClick={onClose}
+            className="text-xs px-3 py-1 text-slate-400 hover:text-slate-200"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onSave}
+            disabled={busy}
+            className="text-xs px-3 py-1 bg-slate-700 hover:bg-slate-600 text-slate-100 rounded disabled:opacity-50"
+          >
+            {busy ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { WorkspacesPanel } from "./WorkspacesPanel";
 import { BundledSkillsViewer } from "./BundledSkillsViewer";
 import { PoolsPanel } from "./PoolsPanel";
+import { ProvidersPanel } from "./ProvidersPanel";
 import { NotifyPanel } from "./NotifyPanel";
 import { LogsPanel } from "./LogsPanel";
 import { AppearancePanel } from "./AppearancePanel";
@@ -9,7 +10,7 @@ import { CollectionsPanel } from "./CollectionsPanel";
 import { EventDiagnostics } from "./EventDiagnostics";
 import { useSettingsStore } from "../stores/useSettingsStore";
 
-type Tab = "workspaces" | "collections" | "pools" | "skills" | "notify" | "appearance" | "logs" | "advanced" | "diagnostics";
+type Tab = "workspaces" | "collections" | "providers" | "pools" | "skills" | "notify" | "appearance" | "logs" | "advanced" | "diagnostics";
 
 export function Settings({
   open,
@@ -41,6 +42,7 @@ export function Settings({
               [
                 ["workspaces", "Workspaces"],
                 ["collections", "Collections"],
+                ["providers", "Providers"],
                 ["pools", "Pools"],
                 ["skills", "Bundled skills"],
                 ["notify", "Notifications"],
@@ -65,6 +67,7 @@ export function Settings({
           <div className="flex-1 p-4 overflow-y-auto">
             {tab === "workspaces" && <WorkspacesPanel />}
             {tab === "collections" && <CollectionsPanel />}
+            {tab === "providers" && <ProvidersPanel />}
             {tab === "pools" && <PoolsPanel />}
             {tab === "skills" && <BundledSkillsViewer />}
             {tab === "notify" && <NotifyPanel />}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -57,6 +57,8 @@ export function DeleteLabel(arg1:string,arg2:string):Promise<void>;
 
 export function DeletePool(arg1:string):Promise<void>;
 
+export function DeleteProviderEntity(arg1:string):Promise<void>;
+
 export function DeployRemoteWorker(arg1:string,arg2:string,arg3:string):Promise<main.RemoteDeployResult>;
 
 export function DiagnoseIssue(arg1:string,arg2:number):Promise<diagnose.IssueDiagnosis>;
@@ -145,6 +147,8 @@ export function ListPlans(arg1:string,arg2:number):Promise<Array<types.Plan>>;
 
 export function ListPools():Promise<Array<workerpool.PoolStatus>>;
 
+export function ListProviderEntities():Promise<Array<types.ProviderEntity>>;
+
 export function ListProviders():Promise<Array<main.ProviderInfo>>;
 
 export function ListSessions():Promise<Array<types.Session>>;
@@ -224,6 +228,8 @@ export function RunOrchestrator():Promise<void>;
 export function SaveGoal(arg1:types.Goal):Promise<void>;
 
 export function SavePool(arg1:types.Pool):Promise<void>;
+
+export function SaveProviderEntity(arg1:types.ProviderEntity):Promise<void>;
 
 export function SaveWorkspacePipeline(arg1:string,arg2:types.WorkspacePipeline):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -90,6 +90,10 @@ export function DeletePool(arg1) {
   return window['go']['main']['App']['DeletePool'](arg1);
 }
 
+export function DeleteProviderEntity(arg1) {
+  return window['go']['main']['App']['DeleteProviderEntity'](arg1);
+}
+
 export function DeployRemoteWorker(arg1, arg2, arg3) {
   return window['go']['main']['App']['DeployRemoteWorker'](arg1, arg2, arg3);
 }
@@ -266,6 +270,10 @@ export function ListPools() {
   return window['go']['main']['App']['ListPools']();
 }
 
+export function ListProviderEntities() {
+  return window['go']['main']['App']['ListProviderEntities']();
+}
+
 export function ListProviders() {
   return window['go']['main']['App']['ListProviders']();
 }
@@ -424,6 +432,10 @@ export function SaveGoal(arg1) {
 
 export function SavePool(arg1) {
   return window['go']['main']['App']['SavePool'](arg1);
+}
+
+export function SaveProviderEntity(arg1) {
+  return window['go']['main']['App']['SaveProviderEntity'](arg1);
 }
 
 export function SaveWorkspacePipeline(arg1, arg2) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -2004,6 +2004,7 @@ export namespace types {
 	export class Pool {
 	    id: string;
 	    name: string;
+	    provider_id?: string;
 	    provider: string;
 	    endpoint: string;
 	    model: string;
@@ -2030,6 +2031,7 @@ export namespace types {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
 	        this.name = source["name"];
+	        this.provider_id = source["provider_id"];
 	        this.provider = source["provider"];
 	        this.endpoint = source["endpoint"];
 	        this.model = source["model"];
@@ -2092,6 +2094,47 @@ export namespace types {
 	        this.used = source["used"];
 	        this.resets_at = this.convertValues(source["resets_at"], null);
 	        this.captured_at = this.convertValues(source["captured_at"], null);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class ProviderEntity {
+	    id: string;
+	    name: string;
+	    kind: string;
+	    endpoint: string;
+	    api_key?: string;
+	    // Go type: time
+	    created_at: any;
+	
+	    static createFrom(source: any = {}) {
+	        return new ProviderEntity(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
+	        this.name = source["name"];
+	        this.kind = source["kind"];
+	        this.endpoint = source["endpoint"];
+	        this.api_key = source["api_key"];
+	        this.created_at = this.convertValues(source["created_at"], null);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -1,5 +1,16 @@
 package migrations
 
+import (
+	"database/sql"
+	"strings"
+)
+
+// isAlreadyExists returns true when the SQLite error text indicates the column
+// or table already exists (ALTER TABLE on an existing column).
+func isAlreadyExists(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "duplicate column name")
+}
+
 // all is the ordered list of every migration this binary knows about.
 // IDs must be lexicographically ordered (YYYYMMDD_NN_description).
 // Never remove or reorder entries; only append.
@@ -61,6 +72,38 @@ CREATE TABLE IF NOT EXISTS cross_workspace_deps (
 );
 CREATE INDEX IF NOT EXISTS idx_cwd_dep
     ON cross_workspace_deps (dep_workspace_id, dep_issue_number);`,
+	},
+	{
+		ID:          "20260511_00_add_providers",
+		Description: "issue #268: centralized provider credential entities; nullable provider_id FK on pools",
+		SQL: `
+CREATE TABLE IF NOT EXISTS providers (
+    id         TEXT    PRIMARY KEY,
+    name       TEXT    NOT NULL,
+    kind       TEXT    NOT NULL,
+    endpoint   TEXT    NOT NULL DEFAULT '',
+    api_key    TEXT    NOT NULL DEFAULT '',
+    created_at INTEGER NOT NULL
+);`,
+		Up: func(tx *sql.Tx) error {
+			// The pools table is created by legacy migrate(), which runs before
+			// the versioned migration framework on existing DBs. On a bare DB
+			// (e.g. migration-framework tests) the table may not exist yet; in
+			// that case the ALTER TABLE is a no-op and the legacy path will add
+			// the column via its own idempotent ALTER TABLE on first open.
+			var tblCount int
+			if err := tx.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='pools'`).Scan(&tblCount); err != nil {
+				return err
+			}
+			if tblCount == 0 {
+				return nil
+			}
+			_, err := tx.Exec(`ALTER TABLE pools ADD COLUMN provider_id TEXT`)
+			if err != nil && !isAlreadyExists(err) {
+				return err
+			}
+			return nil
+		},
 	},
 }
 

--- a/internal/store/pools.go
+++ b/internal/store/pools.go
@@ -44,7 +44,7 @@ func (s *Store) ListPools() ([]types.Pool, error) {
 		return nil, errors.New("store unavailable")
 	}
 	rows, err := s.DB.Query(`
-SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id
+SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id, COALESCE(provider_id,'')
 FROM pools
 ORDER BY priority ASC, created_at ASC, id ASC`)
 	if err != nil {
@@ -68,7 +68,7 @@ func (s *Store) ListPoolsByRole(role types.Role) ([]types.Pool, error) {
 		return nil, errors.New("store unavailable")
 	}
 	rows, err := s.DB.Query(`
-SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id
+SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id, COALESCE(provider_id,'')
 FROM pools
 WHERE role = ?
 ORDER BY priority ASC, created_at ASC, id ASC`, string(role))
@@ -93,7 +93,7 @@ func (s *Store) GetPool(id string) (types.Pool, error) {
 		return types.Pool{}, errors.New("store unavailable")
 	}
 	row := s.DB.QueryRow(`
-SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id
+SELECT id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id, COALESCE(provider_id,'')
 FROM pools WHERE id = ?`, id)
 	return scanPool(row)
 }
@@ -138,8 +138,8 @@ func (s *Store) SavePool(p types.Pool) error {
 		scope = string(types.PoolScopeShared)
 	}
 	_, err = s.DB.Exec(`
-INSERT INTO pools (id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO pools (id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id, provider_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
     name = excluded.name,
     provider = excluded.provider,
@@ -156,10 +156,11 @@ ON CONFLICT(id) DO UPDATE SET
     bash_timeout_ms = excluded.bash_timeout_ms,
     output_cap = excluded.output_cap,
     scope = excluded.scope,
-    workspace_id = excluded.workspace_id`,
+    workspace_id = excluded.workspace_id,
+    provider_id = excluded.provider_id`,
 		p.ID, p.Name, string(p.Provider), p.Endpoint, p.Model,
 		p.Capacity, enabled, p.APIKey, string(p.Role), p.CreatedAt.Unix(), p.Priority, p.Temperature,
-		p.MaxTurns, p.MaxInputTokens, bashTimeoutMs, p.OutputCap, scope, p.WorkspaceID)
+		p.MaxTurns, p.MaxInputTokens, bashTimeoutMs, p.OutputCap, scope, p.WorkspaceID, nullableString(p.ProviderID))
 	return err
 }
 
@@ -220,11 +221,11 @@ func (s *Store) CreatePool(p types.Pool) error {
 		scope = string(types.PoolScopeShared)
 	}
 	_, err = tx.Exec(`
-INSERT INTO pools (id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+INSERT INTO pools (id, name, provider, endpoint, model, capacity, enabled, api_key, role, created_at, priority, temperature, max_turns, max_input_tokens, bash_timeout_ms, output_cap, scope, workspace_id, provider_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		p.ID, p.Name, string(p.Provider), p.Endpoint, p.Model,
 		p.Capacity, enabled, p.APIKey, string(p.Role), p.CreatedAt.Unix(), p.Priority, p.Temperature,
-		p.MaxTurns, p.MaxInputTokens, bashTimeoutMs, p.OutputCap, scope, p.WorkspaceID)
+		p.MaxTurns, p.MaxInputTokens, bashTimeoutMs, p.OutputCap, scope, p.WorkspaceID, nullableString(p.ProviderID))
 	if err != nil {
 		return err
 	}
@@ -345,15 +346,16 @@ func scanPool(r rowScanner) (types.Pool, error) {
 	var createdAt int64
 	var temperature sql.NullFloat64
 	var maxTurns, maxInputTokens, bashTimeoutMs, outputCap sql.NullInt64
-	var scope, workspaceID string
+	var scope, workspaceID, providerID string
 	if err := r.Scan(&p.ID, &p.Name, &provider, &p.Endpoint, &p.Model,
 		&p.Capacity, &enabled, &p.APIKey, &role, &createdAt, &p.Priority, &temperature,
-		&maxTurns, &maxInputTokens, &bashTimeoutMs, &outputCap, &scope, &workspaceID); err != nil {
+		&maxTurns, &maxInputTokens, &bashTimeoutMs, &outputCap, &scope, &workspaceID, &providerID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return types.Pool{}, fmt.Errorf("pool not found")
 		}
 		return types.Pool{}, err
 	}
+	p.ProviderID = providerID
 	p.Provider = types.Provider(provider)
 	p.Role = types.Role(role)
 	if p.Role == "" {
@@ -387,3 +389,4 @@ func scanPool(r rowScanner) (types.Pool, error) {
 	p.WorkspaceID = workspaceID
 	return p, nil
 }
+

--- a/internal/store/providers.go
+++ b/internal/store/providers.go
@@ -1,0 +1,219 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"prismconductor/internal/types"
+)
+
+// ErrProviderNotFound is returned when a provider row does not exist.
+var ErrProviderNotFound = errors.New("provider not found")
+
+// ErrProviderReferenced is returned by DeleteProviderEntity when one or more
+// pools still reference the provider (q2: block deletion when referenced).
+type ErrProviderReferenced struct {
+	ProviderID string
+	PoolIDs    []string
+}
+
+func (e ErrProviderReferenced) Error() string {
+	return fmt.Sprintf("provider %q is referenced by %d pool(s): %s",
+		e.ProviderID, len(e.PoolIDs), strings.Join(e.PoolIDs, ", "))
+}
+
+// ListProviderEntities returns every provider row, oldest first.
+func (s *Store) ListProviderEntities() ([]types.ProviderEntity, error) {
+	if s == nil || s.DB == nil {
+		return nil, errors.New("store unavailable")
+	}
+	rows, err := s.DB.Query(
+		`SELECT id, name, kind, endpoint, api_key, created_at FROM providers ORDER BY created_at ASC, id ASC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []types.ProviderEntity
+	for rows.Next() {
+		p, err := scanProvider(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// GetProviderEntity returns one provider by ID.
+func (s *Store) GetProviderEntity(id string) (types.ProviderEntity, error) {
+	if s == nil || s.DB == nil {
+		return types.ProviderEntity{}, errors.New("store unavailable")
+	}
+	row := s.DB.QueryRow(
+		`SELECT id, name, kind, endpoint, api_key, created_at FROM providers WHERE id = ?`, id)
+	p, err := scanProvider(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return types.ProviderEntity{}, ErrProviderNotFound
+		}
+		return types.ProviderEntity{}, err
+	}
+	return p, nil
+}
+
+// SaveProviderEntity upserts a provider row. Caller must set ID before calling.
+func (s *Store) SaveProviderEntity(p types.ProviderEntity) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	if p.ID == "" {
+		return errors.New("provider ID required")
+	}
+	if p.CreatedAt.IsZero() {
+		p.CreatedAt = time.Now()
+	}
+	_, err := s.DB.Exec(`
+INSERT INTO providers (id, name, kind, endpoint, api_key, created_at)
+VALUES (?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+    name      = excluded.name,
+    kind      = excluded.kind,
+    endpoint  = excluded.endpoint,
+    api_key   = excluded.api_key`,
+		p.ID, p.Name, string(p.Kind), p.Endpoint, p.APIKey, p.CreatedAt.Unix())
+	return err
+}
+
+// DeleteProviderEntity removes a provider row. Returns ErrProviderReferenced
+// when one or more pools still reference this provider (q2: block deletion).
+func (s *Store) DeleteProviderEntity(id string) error {
+	if s == nil || s.DB == nil {
+		return errors.New("store unavailable")
+	}
+	rows, err := s.DB.Query(`SELECT id FROM pools WHERE provider_id = ?`, id)
+	if err != nil {
+		return err
+	}
+	var poolIDs []string
+	for rows.Next() {
+		var pid string
+		if err := rows.Scan(&pid); err != nil {
+			rows.Close()
+			return err
+		}
+		poolIDs = append(poolIDs, pid)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if len(poolIDs) > 0 {
+		return ErrProviderReferenced{ProviderID: id, PoolIDs: poolIDs}
+	}
+	_, err = s.DB.Exec(`DELETE FROM providers WHERE id = ?`, id)
+	return err
+}
+
+// MigratePoolsToProviders is a one-shot startup migration (issue #268, q3).
+// It groups all pools that have no provider_id by (kind, endpoint, api_key),
+// creates one ProviderEntity per unique group named "{kind}-default", and sets
+// each pool's provider_id to point at its group. Returns (created, updated, err).
+// Idempotent: pools already bearing a provider_id are skipped.
+func (s *Store) MigratePoolsToProviders() (created, updated int, err error) {
+	if s == nil || s.DB == nil {
+		return 0, 0, errors.New("store unavailable")
+	}
+
+	// Fetch pools without a provider_id.
+	rows, err := s.DB.Query(`SELECT id, provider, endpoint, api_key FROM pools WHERE provider_id IS NULL OR provider_id = ''`)
+	if err != nil {
+		return 0, 0, err
+	}
+	type poolRow struct {
+		id       string
+		provider string
+		endpoint string
+		apiKey   string
+	}
+	var unmigrated []poolRow
+	for rows.Next() {
+		var r poolRow
+		if err := rows.Scan(&r.id, &r.provider, &r.endpoint, &r.apiKey); err != nil {
+			rows.Close()
+			return 0, 0, err
+		}
+		unmigrated = append(unmigrated, r)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, 0, err
+	}
+	if len(unmigrated) == 0 {
+		return 0, 0, nil
+	}
+
+	type groupKey struct{ kind, endpoint, apiKey string }
+	groups := make(map[groupKey]string) // key → provider entity ID
+
+	tx, err := s.DB.Begin()
+	if err != nil {
+		return 0, 0, err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	now := time.Now().Unix()
+	for _, r := range unmigrated {
+		k := groupKey{kind: strings.ToLower(r.provider), endpoint: r.endpoint, apiKey: r.apiKey}
+		provID, seen := groups[k]
+		if !seen {
+			// Determine a unique name. Count existing providers with this kind prefix.
+			var count int
+			_ = tx.QueryRow(
+				`SELECT COUNT(*) FROM providers WHERE name LIKE ?`,
+				k.kind+"-%",
+			).Scan(&count)
+			name := fmt.Sprintf("%s-default", k.kind)
+			if count > 0 {
+				name = fmt.Sprintf("%s-default-%d", k.kind, count+1)
+			}
+			provID = uuid.New().String()
+			if _, err := tx.Exec(
+				`INSERT INTO providers (id, name, kind, endpoint, api_key, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+				provID, name, k.kind, k.endpoint, k.apiKey, now,
+			); err != nil {
+				return 0, 0, err
+			}
+			groups[k] = provID
+			created++
+		}
+		if _, err := tx.Exec(`UPDATE pools SET provider_id = ? WHERE id = ?`, provID, r.id); err != nil {
+			return 0, 0, err
+		}
+		updated++
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, 0, err
+	}
+	return created, updated, nil
+}
+
+type providerScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanProvider(r providerScanner) (types.ProviderEntity, error) {
+	var p types.ProviderEntity
+	var kind string
+	var createdAt int64
+	if err := r.Scan(&p.ID, &p.Name, &kind, &p.Endpoint, &p.APIKey, &createdAt); err != nil {
+		return types.ProviderEntity{}, err
+	}
+	p.Kind = types.Provider(kind)
+	p.CreatedAt = time.Unix(createdAt, 0)
+	return p, nil
+}

--- a/internal/store/providers_test.go
+++ b/internal/store/providers_test.go
@@ -1,0 +1,159 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"prismconductor/internal/types"
+)
+
+func TestProviderEntityCRUD(t *testing.T) {
+	s := openTempStore(t)
+
+	// Empty list on fresh DB.
+	pvs, err := s.ListProviderEntities()
+	if err != nil {
+		t.Fatalf("ListProviderEntities empty: %v", err)
+	}
+	if len(pvs) != 0 {
+		t.Fatalf("expected 0 providers, got %d", len(pvs))
+	}
+
+	p := types.ProviderEntity{
+		ID:        "prov-1",
+		Name:      "openai-default",
+		Kind:      types.ProviderOpenAI,
+		Endpoint:  "https://api.openai.com/v1",
+		APIKey:    "sk-test",
+		CreatedAt: time.Unix(1700000000, 0),
+	}
+	if err := s.SaveProviderEntity(p); err != nil {
+		t.Fatalf("SaveProviderEntity: %v", err)
+	}
+
+	got, err := s.GetProviderEntity(p.ID)
+	if err != nil {
+		t.Fatalf("GetProviderEntity: %v", err)
+	}
+	if got.Name != p.Name || got.Kind != p.Kind || got.Endpoint != p.Endpoint || got.APIKey != p.APIKey {
+		t.Fatalf("GetProviderEntity round-trip mismatch: %+v", got)
+	}
+	if !got.CreatedAt.Equal(time.Unix(1700000000, 0)) {
+		t.Errorf("CreatedAt = %v, want %v", got.CreatedAt, time.Unix(1700000000, 0))
+	}
+
+	// Upsert: change name.
+	p.Name = "openai-renamed"
+	if err := s.SaveProviderEntity(p); err != nil {
+		t.Fatalf("SaveProviderEntity upsert: %v", err)
+	}
+	got2, _ := s.GetProviderEntity(p.ID)
+	if got2.Name != "openai-renamed" {
+		t.Errorf("after upsert Name = %q, want %q", got2.Name, "openai-renamed")
+	}
+
+	// Delete succeeds when not referenced.
+	if err := s.DeleteProviderEntity(p.ID); err != nil {
+		t.Fatalf("DeleteProviderEntity: %v", err)
+	}
+	pvs2, _ := s.ListProviderEntities()
+	if len(pvs2) != 0 {
+		t.Errorf("expected empty after delete, got %d", len(pvs2))
+	}
+}
+
+func TestDeleteProviderEntityBlocked(t *testing.T) {
+	s := openTempStore(t)
+
+	prov := types.ProviderEntity{
+		ID:        "prov-block",
+		Name:      "claude-default",
+		Kind:      types.ProviderClaude,
+		CreatedAt: time.Now(),
+	}
+	if err := s.SaveProviderEntity(prov); err != nil {
+		t.Fatalf("SaveProviderEntity: %v", err)
+	}
+
+	pool := types.Pool{
+		ID:         "pool-1",
+		Name:       "test-pool",
+		Provider:   types.ProviderClaude,
+		Model:      "claude-opus-4-7",
+		Capacity:   1,
+		Enabled:    true,
+		CreatedAt:  time.Now(),
+		ProviderID: prov.ID,
+	}
+	if err := s.SavePool(pool); err != nil {
+		t.Fatalf("SavePool: %v", err)
+	}
+
+	err := s.DeleteProviderEntity(prov.ID)
+	if err == nil {
+		t.Fatal("expected error when deleting referenced provider, got nil")
+	}
+	ref, ok := err.(ErrProviderReferenced)
+	if !ok {
+		t.Fatalf("expected ErrProviderReferenced, got %T: %v", err, err)
+	}
+	if len(ref.PoolIDs) != 1 || ref.PoolIDs[0] != pool.ID {
+		t.Errorf("ErrProviderReferenced.PoolIDs = %v, want [%s]", ref.PoolIDs, pool.ID)
+	}
+}
+
+func TestMigratePoolsToProviders(t *testing.T) {
+	s := openTempStore(t)
+
+	// Insert two pools with identical credentials and one with different creds.
+	pools := []types.Pool{
+		{ID: "p1", Name: "a", Provider: types.ProviderOpenAI, Endpoint: "http://ep1", APIKey: "k1", Model: "m", Capacity: 1, CreatedAt: time.Now()},
+		{ID: "p2", Name: "b", Provider: types.ProviderOpenAI, Endpoint: "http://ep1", APIKey: "k1", Model: "m", Capacity: 1, CreatedAt: time.Now()},
+		{ID: "p3", Name: "c", Provider: types.ProviderOllama, Endpoint: "http://ep2", APIKey: "", Model: "m", Capacity: 1, CreatedAt: time.Now()},
+	}
+	for _, p := range pools {
+		if err := s.SavePool(p); err != nil {
+			t.Fatalf("SavePool %s: %v", p.ID, err)
+		}
+	}
+
+	created, updated, err := s.MigratePoolsToProviders()
+	if err != nil {
+		t.Fatalf("MigratePoolsToProviders: %v", err)
+	}
+	// 2 unique groups → 2 providers, 3 pools updated.
+	if created != 2 {
+		t.Errorf("created = %d, want 2", created)
+	}
+	if updated != 3 {
+		t.Errorf("updated = %d, want 3", updated)
+	}
+
+	provs, _ := s.ListProviderEntities()
+	if len(provs) != 2 {
+		t.Errorf("ListProviderEntities = %d, want 2", len(provs))
+	}
+
+	// Idempotent: running again must be a no-op.
+	created2, updated2, err2 := s.MigratePoolsToProviders()
+	if err2 != nil {
+		t.Fatalf("second run: %v", err2)
+	}
+	if created2 != 0 || updated2 != 0 {
+		t.Errorf("second run not idempotent: created=%d updated=%d", created2, updated2)
+	}
+
+	// p1 and p2 must share the same provider_id.
+	pp1, _ := s.GetPool("p1")
+	pp2, _ := s.GetPool("p2")
+	pp3, _ := s.GetPool("p3")
+	if pp1.ProviderID == "" || pp2.ProviderID == "" || pp3.ProviderID == "" {
+		t.Errorf("expected all pools to have provider_id set: p1=%q p2=%q p3=%q", pp1.ProviderID, pp2.ProviderID, pp3.ProviderID)
+	}
+	if pp1.ProviderID != pp2.ProviderID {
+		t.Errorf("p1 and p2 should share provider_id: p1=%q p2=%q", pp1.ProviderID, pp2.ProviderID)
+	}
+	if pp1.ProviderID == pp3.ProviderID {
+		t.Errorf("p1 and p3 should have different provider_id: both=%q", pp1.ProviderID)
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -311,6 +311,13 @@ CREATE TABLE IF NOT EXISTS pools (
 	}
 	// Issue #159: PR comment surface — persisted per (workspace, issue, comment_id).
 	// conversation = issue thread comments; review = PR inline diff comments.
+	// Issue #268: nullable provider_id FK on pools; providers table created by
+	// the versioned migration framework (20260511_00_add_providers).
+	if _, err := s.DB.Exec(`ALTER TABLE pools ADD COLUMN provider_id TEXT`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column name") {
+			return err
+		}
+	}
 	if _, err := s.DB.Exec(`CREATE TABLE IF NOT EXISTS pr_comments (
     id           INTEGER PRIMARY KEY AUTOINCREMENT,
     workspace_id TEXT NOT NULL,

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -228,13 +228,27 @@ type ConventionHints struct {
 	PackageManager string `json:"package_manager"`
 }
 
+// --- ProviderEntity (issue #268: centralized LLM credentials) ---
+
+// ProviderEntity is a persisted set of LLM credentials shared across pools.
+// Distinct from the Provider enum (which names a driver kind like "claude").
+type ProviderEntity struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Kind      Provider  `json:"kind"`
+	Endpoint  string    `json:"endpoint"`
+	APIKey    string    `json:"api_key,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
 // --- Pool (heterogeneous worker fleets, §6.6 / issue #27, role added in #39) ---
 
 type Pool struct {
-	ID        string    `json:"id"`
-	Name      string    `json:"name"`
-	Provider  Provider  `json:"provider"`
-	Endpoint  string    `json:"endpoint"`
+	ID         string    `json:"id"`
+	Name       string    `json:"name"`
+	ProviderID string    `json:"provider_id,omitempty"`
+	Provider   Provider  `json:"provider"`
+	Endpoint   string    `json:"endpoint"`
 	Model     string    `json:"model"`
 	Capacity  int       `json:"capacity"`
 	Enabled   bool      `json:"enabled"`


### PR DESCRIPTION
## Summary

- Adds a first-class `ProviderEntity` (DB table + Go struct) so LLM credentials (endpoint + API key) can be entered once and shared across many pools
- Auto-migration on startup groups existing pools by credentials into named provider rows and emits a toast with counts
- Pools list Enabled/Disabled control changed from checkbox to pill-style toggle (visual, behavior unchanged)

## Files modified

- `internal/types/types.go` — add `ProviderEntity` struct, `Pool.ProviderID` field
- `internal/store/migrations/registry.go` — `20260511_00_add_providers` migration (creates `providers` table, adds nullable `provider_id` FK to `pools`)
- `internal/store/sqlite.go` — idempotent legacy `ALTER TABLE pools ADD COLUMN provider_id` in `migrate()`
- `internal/store/providers.go` _(new)_ — `ListProviderEntities`, `GetProviderEntity`, `SaveProviderEntity`, `DeleteProviderEntity`, `MigratePoolsToProviders`
- `internal/store/providers_test.go` _(new)_ — 3 tests: CRUD, deletion block, idempotent migration
- `internal/store/pools.go` — include `provider_id` in all queries and scan
- `app.go` — `ListProviderEntities`, `SaveProviderEntity`, `DeleteProviderEntity` Wails bindings; `migratePoolsToProviders` startup hook
- `frontend/wailsjs/go/models.ts` — add `types.ProviderEntity` class, add `provider_id` field to `types.Pool`
- `frontend/wailsjs/go/main/App.js` / `App.d.ts` — add bindings for 3 new methods
- `frontend/src/components/ProvidersPanel.tsx` _(new)_ — list/add/edit/delete UI with inline `ProviderEditModal`
- `frontend/src/components/Settings.tsx` — add "Providers" tab between Collections and Pools
- `frontend/src/components/PoolsPanel.tsx` — replace checkbox with pill toggle (enabled=green, disabled=grey)
- `frontend/src/components/PoolEditModal.tsx` — optional saved-provider picker that pre-fills provider kind, endpoint, and API key

## Verification

| Step | Command | Result |
|---|---|---|
| Lint (Go) | `go vet ./internal/...` | ✅ pass |
| Lint (TS) | `npx tsc --noEmit` | ✅ pass |
| Build | `wails build` | ✅ pass (10.5s) |
| Smoke test | `tests/e2e/startup.spec.ts` | ⚠ skipped — `@playwright/test` not installed in worktree (pre-existing worktree constraint) |
| Tests | `go test prismconductor/internal/...` | ✅ all pass |

**Commit tier:** Tier 2b (unsigned local commit — signed commits not required on main)

## Design notes

- Migration is idempotent: pools already bearing a `provider_id` are skipped on second run
- Provider deletion is blocked with `ErrProviderReferenced` when any pool references the provider (q2 answer: yes)
- Auto-created provider names follow `{kind}-default` convention (q1 answer)
- Legacy inline `provider`/`endpoint`/`api_key` columns are retained on `Pool` for this release (backward-compat window)

**Workspace mode:** per-execute worktree at `/Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-268`

Closes #268