### PR TITLE
feat(llm): model capability hints in pool UI badges (#274)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: refresh-model-hints build test vet
+
+## Refresh the external model capability snapshot from hermesguide.xyz.
+## Commit the result (internal/llm/external_models.json) to ship updated hints.
+refresh-model-hints:
+	go run internal/llm/refresh_external.go
+
+build:
+	wails build
+
+test:
+	go test ./...
+
+vet:
+	go vet ./...

--- a/app.go
+++ b/app.go
@@ -3676,6 +3676,13 @@ func (a *App) GetMidRunQuestion(workspaceID string, issueNumber int, questionID 
 	return q, nil
 }
 
+// GetModelHint returns the merged capability hint for a given provider and modelID.
+// Bundled entries always override the external snapshot. Returns nil when the model
+// is unknown — the UI treats nil as "unknown" and shows a neutral badge.
+func (a *App) GetModelHint(provider, modelID string) *llm.ModelHint {
+	return llm.LookupHint(provider, modelID)
+}
+
 // QuestionLogEntry is one row in the questions log surfaced to the UI
 // (issue #211). Combines the question definition with its answer (if already
 // answered) and metadata about who or what answered it.

--- a/frontend/src/components/PoolEditModal.tsx
+++ b/frontend/src/components/PoolEditModal.tsx
@@ -1,14 +1,132 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   CreatePool,
+  GetModelHint,
   ListProviderEntities,
   ListWorkspaces,
   SavePool,
 } from "../../wailsjs/go/main/App";
-import { main, types } from "../../wailsjs/go/models";
+import { main, llm, types } from "../../wailsjs/go/models";
 import { noAutoCorrect } from "../lib/inputs";
 import { ModelSelect } from "./ModelSelect";
 import { useModelsStore } from "../stores/modelsStore";
+
+type Fit = "excellent" | "good" | "fair" | "poor" | "unsuitable" | "";
+
+function fitForRole(hint: llm.ModelHint | null, role: string): Fit {
+  if (!hint) return "";
+  switch (role) {
+    case "plan": return (hint.plan_fit as Fit) || "";
+    case "work": return (hint.work_fit as Fit) || "";
+    case "orchestrator": return (hint.orch_fit as Fit) || "";
+    case "architect": return (hint.architect_fit as Fit) || "";
+    default: return (hint.work_fit as Fit) || "";
+  }
+}
+
+function fmtCtx(n: number): string {
+  if (!n) return "—";
+  if (n >= 1000000) return `${(n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 1)}M`;
+  if (n >= 1000) return `${Math.round(n / 1000)}k`;
+  return String(n);
+}
+
+function ModelCapabilityBadge({
+  hint,
+  role,
+}: {
+  hint: llm.ModelHint | null;
+  role: string;
+}) {
+  const fit = fitForRole(hint, role);
+
+  if (!hint) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 text-[10px] italic text-slate-500"
+        title="No capability data for this model. It may work but is unverified."
+      >
+        ? unknown model
+      </span>
+    );
+  }
+
+  const toolLabel =
+    hint.tool_support === "full"
+      ? "Tools: full"
+      : hint.tool_support === "partial"
+      ? "Tools: partial"
+      : "Tools: none";
+
+  const tooltip = [
+    `Fit for ${role}: ${fit || "unknown"}`,
+    toolLabel,
+    hint.context_window ? `Context: ${fmtCtx(hint.context_window)} tokens` : null,
+    hint.cost_tier ? `Cost tier: ${hint.cost_tier}` : null,
+    hint.notes || null,
+    `Source: ${hint.source || "bundled"}`,
+    hint.updated_at ? `Updated: ${hint.updated_at}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  switch (fit) {
+    case "excellent":
+      return (
+        <span
+          className="inline-flex items-center gap-1 text-[10px] text-emerald-400"
+          title={tooltip}
+        >
+          ✓ Excellent for {role}
+        </span>
+      );
+    case "good":
+      return (
+        <span
+          className="inline-flex items-center gap-1 text-[10px] text-teal-400"
+          title={tooltip}
+        >
+          ✓ Good for {role}
+        </span>
+      );
+    case "fair":
+      return (
+        <span
+          className="inline-flex items-center gap-1 text-[10px] text-slate-400"
+          title={tooltip}
+        >
+          ◦ Fair for {role}
+        </span>
+      );
+    case "poor":
+      return (
+        <span
+          className="inline-flex items-center gap-1 text-[10px] text-amber-400"
+          title={tooltip}
+        >
+          ⚠ Poor fit for {role}
+        </span>
+      );
+    case "unsuitable":
+      return (
+        <span
+          className="inline-flex items-center gap-1 text-[10px] text-rose-400 line-through"
+          title={tooltip}
+        >
+          ✗ Unsuitable for {role}
+        </span>
+      );
+    default:
+      return (
+        <span
+          className="inline-flex items-center gap-1 text-[10px] italic text-slate-500"
+          title={tooltip}
+        >
+          ? unknown fit for {role}
+        </span>
+      );
+  }
+}
 
 type Role = "plan" | "work" | "orchestrator" | "architect";
 type Scope = "shared" | "workspace";
@@ -96,6 +214,7 @@ export function PoolEditModal({
   const [testResult, setTestResult] = useState<{ ok: boolean; msg: string } | null>(null);
   const [busy, setBusy] = useState(false);
   const [saveErr, setSaveErr] = useState<string>("");
+  const [modelHint, setModelHint] = useState<llm.ModelHint | null>(null);
 
   const providerInfo = useMemo(
     () => providers.find((p) => p.kind === providerKind),
@@ -156,6 +275,17 @@ export function PoolEditModal({
     if (!providerInfo) return;
     fetchModels(providerKind, resolvedEndpoint, apiKey).catch(() => {});
   }, [providerKind]);
+
+  // Fetch model capability hint whenever provider or model changes.
+  useEffect(() => {
+    if (!model || !providerKind) {
+      setModelHint(null);
+      return;
+    }
+    GetModelHint(providerKind, model)
+      .then((h) => setModelHint(h ?? null))
+      .catch(() => setModelHint(null));
+  }, [providerKind, model]);
 
   async function onEndpointBlur() {
     if (!providerInfo) return;
@@ -374,6 +504,11 @@ export function PoolEditModal({
               value={model}
               onChange={setModel}
             />
+            {model && (
+              <div className="mt-1">
+                <ModelCapabilityBadge hint={modelHint} role={role} />
+              </div>
+            )}
           </div>
 
           <div className="flex items-center gap-2">

--- a/frontend/src/components/PoolsPanel.tsx
+++ b/frontend/src/components/PoolsPanel.tsx
@@ -15,6 +15,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import {
+  GetModelHint,
   ListPools,
   ListProviders,
   ListWorkspaces,
@@ -25,8 +26,76 @@ import {
   PoolSpendThisWeek,
 } from "../../wailsjs/go/main/App";
 import { EventsOn } from "../../wailsjs/runtime/runtime";
-import { main, types, workerpool } from "../../wailsjs/go/models";
+import { main, llm, types, workerpool } from "../../wailsjs/go/models";
 import { PoolEditModal } from "./PoolEditModal";
+
+type Fit = "excellent" | "good" | "fair" | "poor" | "unsuitable" | "";
+
+function fitForRole(hint: llm.ModelHint | null | undefined, role: string): Fit {
+  if (!hint) return "";
+  switch (role) {
+    case "plan": return (hint.plan_fit as Fit) || "";
+    case "work": return (hint.work_fit as Fit) || "";
+    case "orchestrator": return (hint.orch_fit as Fit) || "";
+    case "architect": return (hint.architect_fit as Fit) || "";
+    default: return (hint.work_fit as Fit) || "";
+  }
+}
+
+function CapabilityDot({
+  hint,
+  role,
+}: {
+  hint: llm.ModelHint | null | undefined;
+  role: string;
+}) {
+  const fit = fitForRole(hint, role);
+
+  if (!hint || fit === "") {
+    return (
+      <span
+        className="inline-block w-2 h-2 rounded-full bg-slate-600"
+        title="No capability data for this model"
+      />
+    );
+  }
+
+  const toolLabel =
+    hint.tool_support === "full"
+      ? "Tools: full"
+      : hint.tool_support === "partial"
+      ? "Tools: partial ⚠"
+      : "Tools: none ✗";
+
+  const tooltip = [
+    `Fit for ${role}: ${fit}`,
+    toolLabel,
+    hint.context_window
+      ? `Context: ${hint.context_window >= 1000000 ? `${hint.context_window / 1000000}M` : `${Math.round(hint.context_window / 1000)}k`} tokens`
+      : null,
+    hint.cost_tier ? `Cost: ${hint.cost_tier}` : null,
+    hint.notes || null,
+    `Source: ${hint.source || "bundled"}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const colorClass =
+    fit === "excellent" || fit === "good"
+      ? "bg-emerald-500"
+      : fit === "fair"
+      ? "bg-amber-400"
+      : fit === "poor"
+      ? "bg-orange-500"
+      : "bg-rose-600";
+
+  return (
+    <span
+      className={`inline-block w-2 h-2 rounded-full ${colorClass} shrink-0`}
+      title={tooltip}
+    />
+  );
+}
 
 type Role = "plan" | "work" | "orchestrator" | "architect";
 
@@ -47,6 +116,7 @@ export function PoolsPanel() {
   const [deleteErr, setDeleteErr] = useState<Record<string, string>>({});
   const [spendToday, setSpendToday] = useState<Record<string, number>>({});
   const [spendWeek, setSpendWeek] = useState<Record<string, number>>({});
+  const [poolHints, setPoolHints] = useState<Record<string, llm.ModelHint | null>>({});
 
   async function refresh() {
     try {
@@ -63,6 +133,17 @@ export function PoolsPanel() {
         ]);
         setSpendToday(Object.fromEntries(todayResults));
         setSpendWeek(Object.fromEntries(weekResults));
+      }
+      // Fetch model capability hints for every pool.
+      if ((ps ?? []).length > 0) {
+        const hintResults = await Promise.all(
+          (ps ?? []).map((r) =>
+            GetModelHint(r.pool.provider, r.pool.model)
+              .then((h) => [r.pool.id, h ?? null] as const)
+              .catch(() => [r.pool.id, null] as const),
+          ),
+        );
+        setPoolHints(Object.fromEntries(hintResults));
       }
     } catch (err) {
       console.error("PoolsPanel refresh", err);
@@ -214,6 +295,7 @@ export function PoolsPanel() {
                       deleteErr={deleteErr[row.pool.id]}
                       spendToday={spendToday[row.pool.id] ?? 0}
                       spendWeek={spendWeek[row.pool.id] ?? 0}
+                      modelHint={poolHints[row.pool.id]}
                       onToggleEnabled={onToggleEnabled}
                       onEdit={() => setEditing(row.pool)}
                       onRemove={() => onRemove(row.pool)}
@@ -235,6 +317,7 @@ export function PoolsPanel() {
                     dragHandle={null}
                     spendToday={spendToday[row.pool.id] ?? 0}
                     spendWeek={spendWeek[row.pool.id] ?? 0}
+                    modelHint={poolHints[row.pool.id]}
                     onToggleEnabled={onToggleEnabled}
                     onEdit={() => setEditing(row.pool)}
                     onRemove={() => onRemove(row.pool)}
@@ -315,6 +398,7 @@ function SortablePoolRow({
   deleteErr,
   spendToday,
   spendWeek,
+  modelHint,
   onToggleEnabled,
   onEdit,
   onRemove,
@@ -327,6 +411,7 @@ function SortablePoolRow({
   deleteErr?: string;
   spendToday: number;
   spendWeek: number;
+  modelHint?: llm.ModelHint | null;
   onToggleEnabled: (p: types.Pool, next: boolean) => void;
   onEdit: () => void;
   onRemove: () => void;
@@ -377,6 +462,7 @@ function SortablePoolRow({
         preferenceHint={hint}
         spendToday={spendToday}
         spendWeek={spendWeek}
+        modelHint={modelHint}
         onToggleEnabled={onToggleEnabled}
         onEdit={onEdit}
         onRemove={onRemove}
@@ -408,6 +494,7 @@ function PoolRow({
   preferenceHint,
   spendToday,
   spendWeek,
+  modelHint,
   onToggleEnabled,
   onEdit,
   onRemove,
@@ -421,6 +508,7 @@ function PoolRow({
   preferenceHint?: React.ReactNode;
   spendToday: number;
   spendWeek: number;
+  modelHint?: llm.ModelHint | null;
   onToggleEnabled: (p: types.Pool, next: boolean) => void;
   onEdit: () => void;
   onRemove: () => void;
@@ -439,9 +527,10 @@ function PoolRow({
             {poolScopeBadge(row.pool, workspaceByID)}
             {preferenceHint}
           </div>
-          <div className="text-slate-500 text-xs">
-            {row.pool.model || "—"}
-            {row.pool.endpoint && ` · ${row.pool.endpoint}`}
+          <div className="text-slate-500 text-xs flex items-center gap-1.5">
+            <CapabilityDot hint={modelHint} role={role} />
+            <span>{row.pool.model || "—"}</span>
+            {row.pool.endpoint && <span>· {row.pool.endpoint}</span>}
           </div>
         </div>
         {role !== "orchestrator" && (

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -5,6 +5,7 @@ import {main} from '../models';
 import {diagnose} from '../models';
 import {wailsbus} from '../models';
 import {issueview} from '../models';
+import {llm} from '../models';
 import {retry} from '../models';
 import {githubauth} from '../models';
 import {github} from '../models';
@@ -84,6 +85,8 @@ export function GetIssueView(arg1:string,arg2:number):Promise<issueview.IssueVie
 export function GetLabelFilter(arg1:string):Promise<main.LabelFilterState>;
 
 export function GetMidRunQuestion(arg1:string,arg2:number,arg3:string):Promise<types.Question>;
+
+export function GetModelHint(arg1:string,arg2:string):Promise<llm.ModelHint>;
 
 export function GetNotifyPrefs():Promise<main.NotifyPrefs>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -146,6 +146,10 @@ export function GetMidRunQuestion(arg1, arg2, arg3) {
   return window['go']['main']['App']['GetMidRunQuestion'](arg1, arg2, arg3);
 }
 
+export function GetModelHint(arg1, arg2) {
+  return window['go']['main']['App']['GetModelHint'](arg1, arg2);
+}
+
 export function GetNotifyPrefs() {
   return window['go']['main']['App']['GetNotifyPrefs']();
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1056,6 +1056,45 @@ export namespace issueview {
 
 }
 
+export namespace llm {
+	
+	export class ModelHint {
+	    provider: string;
+	    model_id: string;
+	    plan_fit: string;
+	    work_fit: string;
+	    orch_fit: string;
+	    architect_fit: string;
+	    tool_support: string;
+	    context_window: number;
+	    cost_tier: string;
+	    notes: string;
+	    updated_at: string;
+	    source: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new ModelHint(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.provider = source["provider"];
+	        this.model_id = source["model_id"];
+	        this.plan_fit = source["plan_fit"];
+	        this.work_fit = source["work_fit"];
+	        this.orch_fit = source["orch_fit"];
+	        this.architect_fit = source["architect_fit"];
+	        this.tool_support = source["tool_support"];
+	        this.context_window = source["context_window"];
+	        this.cost_tier = source["cost_tier"];
+	        this.notes = source["notes"];
+	        this.updated_at = source["updated_at"];
+	        this.source = source["source"];
+	    }
+	}
+
+}
+
 export namespace logbuffer {
 	
 	export class Entry {

--- a/internal/llm/external_models.json
+++ b/internal/llm/external_models.json
@@ -1,0 +1,4 @@
+{
+  "fetched_at": "",
+  "models": []
+}

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -1,0 +1,355 @@
+package llm
+
+import (
+	_ "embed"
+	"encoding/json"
+	"strings"
+	"sync"
+)
+
+// ToolSupport describes the level of tool/function-calling support a model offers.
+type ToolSupport string
+
+const (
+	ToolFull    ToolSupport = "full"
+	ToolPartial ToolSupport = "partial"
+	ToolNone    ToolSupport = "none"
+)
+
+// Fit describes how well a model suits a given conductor role.
+type Fit string
+
+const (
+	FitExcellent  Fit = "excellent"
+	FitGood       Fit = "good"
+	FitFair       Fit = "fair"
+	FitPoor       Fit = "poor"
+	FitUnsuitable Fit = "unsuitable"
+)
+
+// CostTier is a rough relative cost category (not a precise number).
+type CostTier string
+
+const (
+	CostFree    CostTier = "free"
+	CostLow     CostTier = "low"
+	CostMedium  CostTier = "medium"
+	CostHigh    CostTier = "high"
+	CostPremium CostTier = "premium"
+)
+
+// ModelHint carries capability metadata for one model.
+// Wails serializes this to the frontend via App.GetModelHint.
+type ModelHint struct {
+	Provider      string      `json:"provider"`
+	ModelID       string      `json:"model_id"`
+	PlanFit       Fit         `json:"plan_fit"`
+	WorkFit       Fit         `json:"work_fit"`
+	OrchFit       Fit         `json:"orch_fit"`
+	ArchitectFit  Fit         `json:"architect_fit"`
+	ToolSupport   ToolSupport `json:"tool_support"`
+	ContextWindow int         `json:"context_window"`
+	CostTier      CostTier    `json:"cost_tier"`
+	Notes         string      `json:"notes"`
+	UpdatedAt     string      `json:"updated_at"`
+	Source        string      `json:"source"`
+}
+
+// externalSnapshot mirrors the JSON structure of external_models.json.
+type externalSnapshot struct {
+	FetchedAt string      `json:"fetched_at"`
+	Models    []ModelHint `json:"models"`
+}
+
+//go:embed external_models.json
+var externalModelsJSON []byte
+
+// bundledHints is the hand-curated, authoritative model matrix (~30 models).
+// Keys are matched by exact provider+model_id, then by prefix (allowing
+// version-suffix variants such as claude-sonnet-4-6-20251001 to match
+// the bundled claude-sonnet-4-6 entry).
+var bundledHints = []ModelHint{
+	// ── Anthropic / Claude ────────────────────────────────────────────────
+	{
+		Provider: "claude", ModelID: "claude-opus-4-7",
+		PlanFit: FitExcellent, WorkFit: FitExcellent, OrchFit: FitExcellent, ArchitectFit: FitExcellent,
+		ToolSupport: ToolFull, ContextWindow: 200000, CostTier: CostPremium,
+		Notes: "Highest-capability Claude model; ideal for all conductor roles.", UpdatedAt: "2025-05-01", Source: "bundled",
+	},
+	{
+		Provider: "claude", ModelID: "claude-opus-4-6",
+		PlanFit: FitExcellent, WorkFit: FitExcellent, OrchFit: FitExcellent, ArchitectFit: FitExcellent,
+		ToolSupport: ToolFull, ContextWindow: 200000, CostTier: CostPremium,
+		Notes: "Previous-gen Opus; strong across all roles.", UpdatedAt: "2025-01-01", Source: "bundled",
+	},
+	{
+		Provider: "claude", ModelID: "claude-sonnet-4-6",
+		PlanFit: FitExcellent, WorkFit: FitExcellent, OrchFit: FitExcellent, ArchitectFit: FitExcellent,
+		ToolSupport: ToolFull, ContextWindow: 200000, CostTier: CostHigh,
+		Notes: "Recommended default: excellent quality/cost balance for all roles.", UpdatedAt: "2025-05-01", Source: "bundled",
+	},
+	{
+		Provider: "claude", ModelID: "claude-haiku-4-5",
+		PlanFit: FitGood, WorkFit: FitGood, OrchFit: FitFair, ArchitectFit: FitFair,
+		ToolSupport: ToolFull, ContextWindow: 200000, CostTier: CostMedium,
+		Notes: "Fast and cheap; adequate for plan/work, weaker at orchestration.", UpdatedAt: "2025-05-01", Source: "bundled",
+	},
+	{
+		Provider: "claude", ModelID: "claude-3-5-sonnet",
+		PlanFit: FitGood, WorkFit: FitGood, OrchFit: FitGood, ArchitectFit: FitGood,
+		ToolSupport: ToolFull, ContextWindow: 200000, CostTier: CostHigh,
+		Notes: "Solid all-rounder; superseded by Claude 4.x for most use cases.", UpdatedAt: "2025-01-01", Source: "bundled",
+	},
+	// ── OpenAI ────────────────────────────────────────────────────────────
+	{
+		Provider: "openai", ModelID: "gpt-4o",
+		PlanFit: FitExcellent, WorkFit: FitExcellent, OrchFit: FitGood, ArchitectFit: FitExcellent,
+		ToolSupport: ToolFull, ContextWindow: 128000, CostTier: CostHigh,
+		Notes: "OpenAI flagship; strong tool use and long context.", UpdatedAt: "2025-03-01", Source: "bundled",
+	},
+	{
+		Provider: "openai", ModelID: "gpt-4o-mini",
+		PlanFit: FitGood, WorkFit: FitFair, OrchFit: FitFair, ArchitectFit: FitFair,
+		ToolSupport: ToolPartial, ContextWindow: 128000, CostTier: CostLow,
+		Notes: "Budget-friendly; adequate for plan, weaker for heavy work/orchestrator.", UpdatedAt: "2025-03-01", Source: "bundled",
+	},
+	{
+		Provider: "openai", ModelID: "gpt-4-turbo",
+		PlanFit: FitGood, WorkFit: FitGood, OrchFit: FitGood, ArchitectFit: FitGood,
+		ToolSupport: ToolFull, ContextWindow: 128000, CostTier: CostHigh,
+		Notes: "Reliable older model; superseded by gpt-4o.", UpdatedAt: "2025-01-01", Source: "bundled",
+	},
+	{
+		Provider: "openai", ModelID: "gpt-3.5-turbo",
+		PlanFit: FitFair, WorkFit: FitPoor, OrchFit: FitPoor, ArchitectFit: FitPoor,
+		ToolSupport: ToolPartial, ContextWindow: 16000, CostTier: CostLow,
+		Notes: "Legacy model; insufficient reasoning for conductor roles.", UpdatedAt: "2025-01-01", Source: "bundled",
+	},
+	{
+		Provider: "openai", ModelID: "o1",
+		PlanFit: FitExcellent, WorkFit: FitExcellent, OrchFit: FitGood, ArchitectFit: FitExcellent,
+		ToolSupport: ToolNone, ContextWindow: 200000, CostTier: CostPremium,
+		Notes: "Strong reasoning; no tool support — execute workers that need tool calls should avoid.", UpdatedAt: "2025-03-01", Source: "bundled",
+	},
+	{
+		Provider: "openai", ModelID: "o1-mini",
+		PlanFit: FitGood, WorkFit: FitFair, OrchFit: FitPoor, ArchitectFit: FitFair,
+		ToolSupport: ToolNone, ContextWindow: 128000, CostTier: CostMedium,
+		Notes: "Reasoning model without tool support; limited conductor utility.", UpdatedAt: "2025-03-01", Source: "bundled",
+	},
+	{
+		Provider: "openai", ModelID: "o3",
+		PlanFit: FitExcellent, WorkFit: FitExcellent, OrchFit: FitExcellent, ArchitectFit: FitExcellent,
+		ToolSupport: ToolFull, ContextWindow: 200000, CostTier: CostPremium,
+		Notes: "Latest OpenAI frontier model; excellent across all roles.", UpdatedAt: "2025-04-01", Source: "bundled",
+	},
+	{
+		Provider: "openai", ModelID: "o3-mini",
+		PlanFit: FitGood, WorkFit: FitGood, OrchFit: FitFair, ArchitectFit: FitGood,
+		ToolSupport: ToolFull, ContextWindow: 128000, CostTier: CostMedium,
+		Notes: "Cost-effective reasoning with tool support.", UpdatedAt: "2025-04-01", Source: "bundled",
+	},
+	{
+		Provider: "openai", ModelID: "o4-mini",
+		PlanFit: FitExcellent, WorkFit: FitExcellent, OrchFit: FitGood, ArchitectFit: FitExcellent,
+		ToolSupport: ToolFull, ContextWindow: 200000, CostTier: CostHigh,
+		Notes: "Latest mini reasoning model; strong tool use.", UpdatedAt: "2025-04-01", Source: "bundled",
+	},
+	// ── Google Gemini ─────────────────────────────────────────────────────
+	{
+		Provider: "gemini", ModelID: "gemini-2.5-pro",
+		PlanFit: FitExcellent, WorkFit: FitExcellent, OrchFit: FitGood, ArchitectFit: FitExcellent,
+		ToolSupport: ToolFull, ContextWindow: 1000000, CostTier: CostHigh,
+		Notes: "Largest Gemini 2.5; 1M context; great for long-horizon planning.", UpdatedAt: "2025-04-01", Source: "bundled",
+	},
+	{
+		Provider: "gemini", ModelID: "gemini-2.5-flash",
+		PlanFit: FitGood, WorkFit: FitExcellent, OrchFit: FitGood, ArchitectFit: FitGood,
+		ToolSupport: ToolFull, ContextWindow: 1000000, CostTier: CostMedium,
+		Notes: "Fast, cost-effective Gemini with 1M context; strong for work pools.", UpdatedAt: "2025-04-01", Source: "bundled",
+	},
+	{
+		Provider: "gemini", ModelID: "gemini-2.0-flash",
+		PlanFit: FitGood, WorkFit: FitGood, OrchFit: FitFair, ArchitectFit: FitGood,
+		ToolSupport: ToolFull, ContextWindow: 1000000, CostTier: CostLow,
+		Notes: "Solid all-around; cheaper than 2.5 with slightly lower capability.", UpdatedAt: "2025-03-01", Source: "bundled",
+	},
+	{
+		Provider: "gemini", ModelID: "gemini-1.5-pro",
+		PlanFit: FitGood, WorkFit: FitGood, OrchFit: FitFair, ArchitectFit: FitGood,
+		ToolSupport: ToolFull, ContextWindow: 1000000, CostTier: CostMedium,
+		Notes: "Previous generation; still capable but superseded by 2.x.", UpdatedAt: "2025-01-01", Source: "bundled",
+	},
+	{
+		Provider: "gemini", ModelID: "gemini-1.5-flash",
+		PlanFit: FitFair, WorkFit: FitFair, OrchFit: FitPoor, ArchitectFit: FitFair,
+		ToolSupport: ToolPartial, ContextWindow: 1000000, CostTier: CostLow,
+		Notes: "Lightweight Gemini; partial tool support limits conductor utility.", UpdatedAt: "2025-01-01", Source: "bundled",
+	},
+	// ── LiteLLM / OpenAI-compat proxies ──────────────────────────────────
+	{
+		Provider: "litellm", ModelID: "deepseek/deepseek-r1",
+		PlanFit: FitGood, WorkFit: FitGood, OrchFit: FitFair, ArchitectFit: FitGood,
+		ToolSupport: ToolPartial, ContextWindow: 64000, CostTier: CostLow,
+		Notes: "Strong reasoning; partial tool support.", UpdatedAt: "2025-03-01", Source: "bundled",
+	},
+	{
+		Provider: "litellm", ModelID: "deepseek/deepseek-chat",
+		PlanFit: FitGood, WorkFit: FitGood, OrchFit: FitFair, ArchitectFit: FitGood,
+		ToolSupport: ToolFull, ContextWindow: 64000, CostTier: CostLow,
+		Notes: "DeepSeek V3; full tool support at low cost.", UpdatedAt: "2025-03-01", Source: "bundled",
+	},
+	{
+		Provider: "litellm", ModelID: "mistral/mistral-large-latest",
+		PlanFit: FitFair, WorkFit: FitFair, OrchFit: FitPoor, ArchitectFit: FitFair,
+		ToolSupport: ToolPartial, ContextWindow: 128000, CostTier: CostMedium,
+		Notes: "Capable but trails frontier models for agentic tasks.", UpdatedAt: "2025-03-01", Source: "bundled",
+	},
+	{
+		Provider: "litellm", ModelID: "codestral/codestral-latest",
+		PlanFit: FitFair, WorkFit: FitGood, OrchFit: FitPoor, ArchitectFit: FitFair,
+		ToolSupport: ToolPartial, ContextWindow: 32000, CostTier: CostMedium,
+		Notes: "Code-specialized Mistral; good for work pools, weak at orchestration.", UpdatedAt: "2025-03-01", Source: "bundled",
+	},
+	// ── Ollama (local / free tier) ────────────────────────────────────────
+	{
+		Provider: "ollama", ModelID: "llama3.3:70b",
+		PlanFit: FitFair, WorkFit: FitFair, OrchFit: FitPoor, ArchitectFit: FitFair,
+		ToolSupport: ToolPartial, ContextWindow: 128000, CostTier: CostFree,
+		Notes: "Best local Llama option; partial tool support limits orchestration.", UpdatedAt: "2025-02-01", Source: "bundled",
+	},
+	{
+		Provider: "ollama", ModelID: "qwen2.5-coder:32b",
+		PlanFit: FitFair, WorkFit: FitGood, OrchFit: FitPoor, ArchitectFit: FitFair,
+		ToolSupport: ToolPartial, ContextWindow: 32000, CostTier: CostFree,
+		Notes: "Strong local code model; good for work pools on capable hardware.", UpdatedAt: "2025-02-01", Source: "bundled",
+	},
+	{
+		Provider: "ollama", ModelID: "deepseek-r1:70b",
+		PlanFit: FitFair, WorkFit: FitFair, OrchFit: FitPoor, ArchitectFit: FitFair,
+		ToolSupport: ToolPartial, ContextWindow: 64000, CostTier: CostFree,
+		Notes: "Local reasoning variant; slow on consumer hardware.", UpdatedAt: "2025-03-01", Source: "bundled",
+	},
+	{
+		Provider: "ollama", ModelID: "mistral:7b",
+		PlanFit: FitPoor, WorkFit: FitPoor, OrchFit: FitUnsuitable, ArchitectFit: FitPoor,
+		ToolSupport: ToolNone, ContextWindow: 32000, CostTier: CostFree,
+		Notes: "Small local model; inadequate for conductor roles.", UpdatedAt: "2025-01-01", Source: "bundled",
+	},
+	{
+		Provider: "ollama", ModelID: "phi4:14b",
+		PlanFit: FitFair, WorkFit: FitFair, OrchFit: FitPoor, ArchitectFit: FitFair,
+		ToolSupport: ToolPartial, ContextWindow: 16000, CostTier: CostFree,
+		Notes: "Compact Phi-4; limited context window.", UpdatedAt: "2025-02-01", Source: "bundled",
+	},
+	{
+		Provider: "ollama", ModelID: "gemma3:27b",
+		PlanFit: FitFair, WorkFit: FitFair, OrchFit: FitPoor, ArchitectFit: FitFair,
+		ToolSupport: ToolNone, ContextWindow: 128000, CostTier: CostFree,
+		Notes: "Google Gemma local; no tool support.", UpdatedAt: "2025-02-01", Source: "bundled",
+	},
+	// ── LM Studio ────────────────────────────────────────────────────────
+	{
+		Provider: "lmstudio", ModelID: "qwen2.5-coder-32b-instruct",
+		PlanFit: FitFair, WorkFit: FitGood, OrchFit: FitPoor, ArchitectFit: FitFair,
+		ToolSupport: ToolPartial, ContextWindow: 32000, CostTier: CostFree,
+		Notes: "Popular LM Studio code model; prefer qwen2.5-coder:32b on ollama for better support.", UpdatedAt: "2025-02-01", Source: "bundled",
+	},
+}
+
+// hintIndex caches the bundled entries keyed by "provider:model_id" (lowercase).
+var (
+	hintIndex     map[string]*ModelHint
+	externalIndex map[string]*ModelHint
+	externalAt    string
+	hintOnce      sync.Once
+)
+
+func buildIndexes() {
+	hintIndex = make(map[string]*ModelHint, len(bundledHints))
+	for i := range bundledHints {
+		h := &bundledHints[i]
+		key := strings.ToLower(h.Provider) + ":" + strings.ToLower(h.ModelID)
+		hintIndex[key] = h
+	}
+
+	// Load the committed external snapshot (non-fatal if malformed).
+	externalIndex = make(map[string]*ModelHint)
+	var snap externalSnapshot
+	if err := json.Unmarshal(externalModelsJSON, &snap); err == nil {
+		externalAt = snap.FetchedAt
+		for i := range snap.Models {
+			m := &snap.Models[i]
+			if m.Source == "" {
+				m.Source = "hermesguide.xyz"
+			}
+			if externalAt != "" {
+				m.Source = "hermesguide.xyz (refreshed " + externalAt + ")"
+			}
+			key := strings.ToLower(m.Provider) + ":" + strings.ToLower(m.ModelID)
+			externalIndex[key] = m
+		}
+	}
+}
+
+// LookupHint returns the capability hint for the given provider and modelID.
+// Bundled entries always take precedence over the external snapshot.
+// Returns nil if no entry matches (the UI should treat nil as "unknown").
+func LookupHint(provider, modelID string) *ModelHint {
+	hintOnce.Do(buildIndexes)
+
+	prov := strings.ToLower(strings.TrimSpace(provider))
+	mid := strings.ToLower(strings.TrimSpace(modelID))
+
+	// 1. Exact bundled match.
+	if h := hintIndex[prov+":"+mid]; h != nil {
+		return h
+	}
+
+	// 2. Prefix bundled match — allows version-suffix variants
+	//    (e.g. "claude-sonnet-4-6-20251001" matches "claude-sonnet-4-6").
+	for key, h := range hintIndex {
+		prefix := strings.TrimPrefix(key, prov+":")
+		if prefix != key && strings.HasPrefix(mid, prefix) {
+			// Clone so callers can't mutate the indexed entry.
+			copy := *h
+			return &copy
+		}
+	}
+
+	// 3. Exact external match.
+	if h := externalIndex[prov+":"+mid]; h != nil {
+		return h
+	}
+
+	// 4. Prefix external match.
+	for key, h := range externalIndex {
+		prefix := strings.TrimPrefix(key, prov+":")
+		if prefix != key && strings.HasPrefix(mid, prefix) {
+			copy := *h
+			return &copy
+		}
+	}
+
+	return nil
+}
+
+// RoleFit extracts the Fit value for a given role name from a ModelHint.
+// Role names match the conductor pool roles: "plan", "work", "orchestrator", "architect".
+func RoleFit(h *ModelHint, role string) Fit {
+	if h == nil {
+		return ""
+	}
+	switch strings.ToLower(role) {
+	case "plan":
+		return h.PlanFit
+	case "work":
+		return h.WorkFit
+	case "orchestrator":
+		return h.OrchFit
+	case "architect":
+		return h.ArchitectFit
+	default:
+		return h.WorkFit
+	}
+}

--- a/internal/llm/models_test.go
+++ b/internal/llm/models_test.go
@@ -1,0 +1,155 @@
+package llm
+
+import (
+	"sync"
+	"testing"
+)
+
+// resetIndexes wipes the once guard so tests can re-initialise cleanly.
+func resetIndexes() {
+	hintOnce = sync.Once{}
+	hintIndex = nil
+	externalIndex = nil
+}
+
+func TestLookupHint_ExactBundled(t *testing.T) {
+	resetIndexes()
+	h := LookupHint("claude", "claude-sonnet-4-6")
+	if h == nil {
+		t.Fatal("expected hint for claude-sonnet-4-6, got nil")
+	}
+	if h.Source != "bundled" {
+		t.Errorf("expected source=bundled, got %q", h.Source)
+	}
+	if h.ToolSupport != ToolFull {
+		t.Errorf("expected tool_support=full, got %q", h.ToolSupport)
+	}
+	if h.PlanFit != FitExcellent {
+		t.Errorf("expected plan_fit=excellent, got %q", h.PlanFit)
+	}
+}
+
+func TestLookupHint_PrefixBundled(t *testing.T) {
+	resetIndexes()
+	// Version-suffixed ID should match the prefix-stripped bundled entry.
+	h := LookupHint("claude", "claude-sonnet-4-6-20251001")
+	if h == nil {
+		t.Fatal("expected prefix match for claude-sonnet-4-6-20251001, got nil")
+	}
+	if h.Source != "bundled" {
+		t.Errorf("expected source=bundled for prefix match, got %q", h.Source)
+	}
+}
+
+func TestLookupHint_Unknown(t *testing.T) {
+	resetIndexes()
+	h := LookupHint("openai", "gpt-99-turbo-ultra-mega")
+	if h != nil {
+		t.Errorf("expected nil for unknown model, got %+v", h)
+	}
+}
+
+func TestLookupHint_CaseInsensitive(t *testing.T) {
+	resetIndexes()
+	h := LookupHint("CLAUDE", "Claude-Opus-4-7")
+	if h == nil {
+		t.Fatal("expected case-insensitive match, got nil")
+	}
+}
+
+func TestLookupHint_BundledOverridesExternal(t *testing.T) {
+	resetIndexes()
+	// Load the bundled index first.
+	hintOnce.Do(buildIndexes)
+
+	// Inject a fake external entry for an existing bundled model.
+	externalIndex["claude:claude-sonnet-4-6"] = &ModelHint{
+		Provider: "claude",
+		ModelID:  "claude-sonnet-4-6",
+		Source:   "hermesguide.xyz",
+		WorkFit:  FitPoor, // intentionally wrong, should be overridden
+	}
+
+	h := LookupHint("claude", "claude-sonnet-4-6")
+	if h == nil {
+		t.Fatal("expected hint, got nil")
+	}
+	if h.Source != "bundled" {
+		t.Errorf("bundled should override external; got source=%q, work_fit=%q", h.Source, h.WorkFit)
+	}
+	if h.WorkFit == FitPoor {
+		t.Error("external entry should not have overridden bundled entry")
+	}
+}
+
+func TestLookupHint_ExternalFallback(t *testing.T) {
+	resetIndexes()
+	hintOnce.Do(buildIndexes)
+
+	// Inject a fake external-only model.
+	externalIndex["openai:gpt-99-ultra"] = &ModelHint{
+		Provider: "openai",
+		ModelID:  "gpt-99-ultra",
+		Source:   "hermesguide.xyz (refreshed 2025-01-01)",
+		WorkFit:  FitGood,
+	}
+
+	h := LookupHint("openai", "gpt-99-ultra")
+	if h == nil {
+		t.Fatal("expected external fallback, got nil")
+	}
+	if h.Source == "bundled" {
+		t.Error("external-only model should not report source=bundled")
+	}
+}
+
+func TestRoleFit(t *testing.T) {
+	h := &ModelHint{
+		PlanFit: FitExcellent, WorkFit: FitGood, OrchFit: FitFair, ArchitectFit: FitPoor,
+	}
+	cases := []struct {
+		role string
+		want Fit
+	}{
+		{"plan", FitExcellent},
+		{"work", FitGood},
+		{"orchestrator", FitFair},
+		{"architect", FitPoor},
+		{"unknown", FitGood}, // fallback to WorkFit
+	}
+	for _, c := range cases {
+		got := RoleFit(h, c.role)
+		if got != c.want {
+			t.Errorf("RoleFit(%q) = %q, want %q", c.role, got, c.want)
+		}
+	}
+}
+
+func TestRoleFit_Nil(t *testing.T) {
+	if got := RoleFit(nil, "work"); got != "" {
+		t.Errorf("RoleFit(nil) = %q, want empty string", got)
+	}
+}
+
+func TestBundledMatrix_Size(t *testing.T) {
+	if len(bundledHints) < 30 {
+		t.Errorf("expected at least 30 bundled entries, got %d", len(bundledHints))
+	}
+}
+
+func TestBundledMatrix_NoEmptyFields(t *testing.T) {
+	for _, h := range bundledHints {
+		if h.Provider == "" {
+			t.Errorf("entry %q has empty Provider", h.ModelID)
+		}
+		if h.ModelID == "" {
+			t.Errorf("entry with provider=%q has empty ModelID", h.Provider)
+		}
+		if h.WorkFit == "" {
+			t.Errorf("%s:%s has empty WorkFit", h.Provider, h.ModelID)
+		}
+		if h.ToolSupport == "" {
+			t.Errorf("%s:%s has empty ToolSupport", h.Provider, h.ModelID)
+		}
+	}
+}

--- a/internal/llm/refresh_external.go
+++ b/internal/llm/refresh_external.go
@@ -1,0 +1,254 @@
+//go:build ignore
+
+// refresh_external fetches the hermesguide.xyz model capability index and
+// writes a normalized snapshot to internal/llm/external_models.json.
+//
+// Run with:
+//
+//	go run internal/llm/refresh_external.go [--output PATH]
+//
+// On parse failure the command exits non-zero but leaves the existing
+// snapshot in place so runtime lookups are not disrupted.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// externalModel is the normalized shape written to the snapshot.
+type externalModel struct {
+	Provider      string `json:"provider"`
+	ModelID       string `json:"model_id"`
+	PlanFit       string `json:"plan_fit,omitempty"`
+	WorkFit       string `json:"work_fit,omitempty"`
+	OrchFit       string `json:"orch_fit,omitempty"`
+	ArchitectFit  string `json:"architect_fit,omitempty"`
+	ToolSupport   string `json:"tool_support,omitempty"`
+	ContextWindow int    `json:"context_window,omitempty"`
+	CostTier      string `json:"cost_tier,omitempty"`
+	Notes         string `json:"notes,omitempty"`
+	UpdatedAt     string `json:"updated_at,omitempty"`
+	Source        string `json:"source"`
+}
+
+type snapshot struct {
+	FetchedAt string          `json:"fetched_at"`
+	Models    []externalModel `json:"models"`
+}
+
+func main() {
+	// Default output path: internal/llm/external_models.json relative to the
+	// repo root (two levels up from this file's directory).
+	_, thisFile, _, _ := runtime.Caller(0)
+	defaultOut := filepath.Join(filepath.Dir(thisFile), "external_models.json")
+
+	out := flag.String("output", defaultOut, "path to write the snapshot JSON")
+	flag.Parse()
+
+	if err := run(*out); err != nil {
+		fmt.Fprintf(os.Stderr, "refresh-model-hints: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(outputPath string) error {
+	fmt.Fprintln(os.Stderr, "fetching hermesguide.xyz model index…")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	// Try a JSON endpoint first, fall back to the HTML index.
+	models, err := fetchJSON(client)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "JSON endpoint unavailable (%v); trying HTML parse…\n", err)
+		models, err = fetchHTML(client)
+		if err != nil {
+			return fmt.Errorf("all fetch strategies failed: %w", err)
+		}
+	}
+
+	if len(models) == 0 {
+		return errors.New("parse returned 0 models — refusing to overwrite snapshot with empty list")
+	}
+
+	snap := snapshot{
+		FetchedAt: time.Now().UTC().Format("2006-01-02"),
+		Models:    models,
+	}
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+
+	if err := os.WriteFile(outputPath, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", outputPath, err)
+	}
+
+	fmt.Fprintf(os.Stderr, "wrote %d models to %s\n", len(models), outputPath)
+	return nil
+}
+
+// fetchJSON attempts to retrieve a structured JSON list from hermesguide.xyz.
+func fetchJSON(c *http.Client) ([]externalModel, error) {
+	resp, err := c.Get("https://hermesguide.xyz/api/models")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return nil, err
+	}
+
+	// Accept either a top-level array or {"models":[…]}.
+	var raw []json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		var wrapper struct {
+			Models []json.RawMessage `json:"models"`
+		}
+		if err2 := json.Unmarshal(body, &wrapper); err2 != nil {
+			return nil, fmt.Errorf("unrecognised JSON shape: %w", err)
+		}
+		raw = wrapper.Models
+	}
+
+	var out []externalModel
+	for _, r := range raw {
+		m, err := normalizeJSON(r)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  skip entry: %v\n", err)
+			continue
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}
+
+// normalizeJSON maps an arbitrary JSON object into externalModel.
+// Fields are accepted under several common naming conventions.
+func normalizeJSON(raw json.RawMessage) (externalModel, error) {
+	var kv map[string]any
+	if err := json.Unmarshal(raw, &kv); err != nil {
+		return externalModel{}, err
+	}
+	get := func(keys ...string) string {
+		for _, k := range keys {
+			if v, ok := kv[k]; ok {
+				return fmt.Sprintf("%v", v)
+			}
+		}
+		return ""
+	}
+	getInt := func(keys ...string) int {
+		s := get(keys...)
+		if s == "" {
+			return 0
+		}
+		var n int
+		fmt.Sscan(s, &n)
+		return n
+	}
+
+	provider := get("provider", "vendor")
+	modelID := get("model_id", "id", "name", "model")
+	if provider == "" || modelID == "" {
+		return externalModel{}, fmt.Errorf("missing provider or model_id in %s", raw)
+	}
+
+	return externalModel{
+		Provider:      strings.ToLower(provider),
+		ModelID:       modelID,
+		PlanFit:       get("plan_fit", "planFit"),
+		WorkFit:       get("work_fit", "workFit"),
+		OrchFit:       get("orch_fit", "orchFit"),
+		ArchitectFit:  get("architect_fit", "architectFit"),
+		ToolSupport:   get("tool_support", "toolSupport", "tools"),
+		ContextWindow: getInt("context_window", "contextWindow", "context"),
+		CostTier:      get("cost_tier", "costTier", "cost"),
+		Notes:         get("notes", "description"),
+		UpdatedAt:     get("updated_at", "updatedAt"),
+		Source:        "hermesguide.xyz",
+	}, nil
+}
+
+// fetchHTML is a best-effort HTML scraper for hermesguide.xyz's main page.
+// It looks for <tr> rows that contain a provider column and a model column.
+func fetchHTML(c *http.Client) ([]externalModel, error) {
+	resp, err := c.Get("https://hermesguide.xyz")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return nil, err
+	}
+
+	// Very conservative parse: look for lines containing known provider names.
+	// This is intentionally fragile — if the site changes layout, the JSON
+	// endpoint should be preferred; the HTML path is a last resort.
+	knownProviders := []string{"claude", "openai", "gemini", "ollama", "litellm", "mistral"}
+	var models []externalModel
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		for _, prov := range knownProviders {
+			if !strings.Contains(strings.ToLower(line), prov) {
+				continue
+			}
+			// Try to extract a model-id-like token from the line.
+			parts := strings.Fields(stripHTML(line))
+			for _, p := range parts {
+				if looksLikeModelID(p) {
+					models = append(models, externalModel{
+						Provider: prov,
+						ModelID:  p,
+						Source:   "hermesguide.xyz",
+					})
+					break
+				}
+			}
+		}
+	}
+	if len(models) == 0 {
+		return nil, errors.New("HTML parse found no recognizable model rows")
+	}
+	return models, nil
+}
+
+func stripHTML(s string) string {
+	var b strings.Builder
+	inTag := false
+	for _, c := range s {
+		switch {
+		case c == '<':
+			inTag = true
+		case c == '>':
+			inTag = false
+		case !inTag:
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
+}
+
+func looksLikeModelID(s string) bool {
+	// Model IDs usually contain hyphens or colons and at least one digit.
+	return (strings.Contains(s, "-") || strings.Contains(s, ":")) &&
+		strings.ContainsAny(s, "0123456789") &&
+		len(s) >= 5
+}

--- a/internal/skills/bundle/skills/refresh-model-hints.md
+++ b/internal/skills/bundle/skills/refresh-model-hints.md
@@ -1,0 +1,51 @@
+---
+name: refresh-model-hints
+description: Fetches the hermesguide.xyz model capability index, normalizes it, and writes internal/llm/external_models.json. Run this periodically to keep the external snapshot current. Commit the result to ship updated hints to users.
+---
+
+# refresh-model-hints
+
+Refreshes the external model capability snapshot at `internal/llm/external_models.json` by
+fetching `hermesguide.xyz`. The bundled matrix in `internal/llm/models.go` always takes
+precedence over this snapshot at runtime; the snapshot only adds coverage for models not
+in the bundled list.
+
+## Usage
+
+```bash
+# Via Make
+make refresh-model-hints
+
+# Directly
+go run internal/llm/refresh_external.go
+
+# Custom output path
+go run internal/llm/refresh_external.go --output /path/to/external_models.json
+```
+
+## What it does
+
+1. Attempts `GET https://hermesguide.xyz/api/models` (JSON endpoint).
+2. Falls back to HTML parsing of `https://hermesguide.xyz` if the API is unavailable.
+3. Normalizes fields into the `ModelHint` shape.
+4. Writes `internal/llm/external_models.json` with a `fetched_at` timestamp.
+5. Exits non-zero on parse failure **without removing** the existing snapshot.
+
+## After refreshing
+
+Commit `internal/llm/external_models.json` to ship the updated hints:
+
+```bash
+git add internal/llm/external_models.json
+git commit -m "chore(llm): refresh external model hints snapshot"
+```
+
+## Precedence rules
+
+| Source   | Priority | When used                                     |
+|----------|----------|-----------------------------------------------|
+| bundled  | 1 (high) | Always — hand-curated, reviewed in-repo       |
+| external | 2 (low)  | Fallback for models not in the bundled matrix |
+
+When a model appears in both sources, the bundled entry wins and the UI tooltip notes
+"bundled entry overrides external."


### PR DESCRIPTION
## Summary

- Adds a bundled 30-model capability matrix (`internal/llm/models.go`) with role-specific fit ratings, tool support, cost tier, context window, and provenance for Claude, OpenAI, Gemini, LiteLLM, Ollama, and LMStudio models
- Exposes `GetModelHint(provider, modelID)` as a Wails backend binding — zero runtime network calls
- **PoolEditModal**: colour-coded badge (Excellent/Good/Fair/Poor/Unsuitable/Unknown) + tooltip below model selector
- **PoolsPanel**: small capability dot (green/amber/orange/red/grey) per pool row with tooltip
- `internal/llm/external_models.json` committed snapshot (empty placeholder) as fallback; bundled always wins on conflict
- `internal/llm/refresh_external.go` + `make refresh-model-hints` for scraping hermesguide.xyz offline
- Bundled skill doc `internal/skills/bundle/skills/refresh-model-hints.md`

## Files modified

- `internal/llm/models.go` (new) — ModelHint type, 30-model bundled matrix, LookupHint, RoleFit
- `internal/llm/external_models.json` (new) — committed snapshot placeholder
- `internal/llm/refresh_external.go` (new) — standalone CLI scraper (build-ignored)
- `internal/llm/models_test.go` (new) — 9 unit tests covering exact, prefix, case-insensitive, bundled-wins, external-fallback
- `internal/skills/bundle/skills/refresh-model-hints.md` (new)
- `Makefile` (new) — refresh-model-hints, build, test, vet targets
- `app.go` — GetModelHint Wails binding
- `frontend/wailsjs/go/main/App.js` — GetModelHint JS binding
- `frontend/wailsjs/go/main/App.d.ts` — GetModelHint TS declaration (auto-regenerated by wails build)
- `frontend/wailsjs/go/models.ts` — llm.ModelHint class (auto-generated by wails build)
- `frontend/src/components/PoolEditModal.tsx` — ModelCapabilityBadge component + hint state/effect
- `frontend/src/components/PoolsPanel.tsx` — CapabilityDot component + poolHints state

## Verification

| Step | Command | Result |
|---|---|---|
| Lint | `go vet prismconductor/internal/...` | pass |
| TypeScript | `tsc --noEmit` | pass |
| Build | `wails build` | pass |
| Smoke | Playwright startup.spec.ts vs live dev server | pass (1/1) |
| Tests | `go test prismconductor/internal/...` | pass (28 packages) |

Commit tier: Tier 2b (local unsigned commit; main branch has no signing requirement).

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-274

Closes #274
