### PR TITLE
feat(frontend): add IssueView reconciler for convergence (#275)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,12 +32,14 @@ import { PoolsHeader } from "./components/PoolsHeader";
 import { AgentTerminalDrawer } from "./components/AgentTerminalDrawer";
 import { useAgentTerminalStore } from "./stores/useAgentTerminalStore";
 import { useDiagnosticUnlock } from "./hooks/useDiagnosticUnlock";
+import { useReconciler } from "./stores/reconciler";
 
 type PlanRef = { workspace_id: string; number: number };
 type PlanTarget = PlanRef | null;
 
 function App() {
   useDiagnosticUnlock();
+  useReconciler();
   const appendLine = useSessionStore((s) => s.appendLine);
   const setMeta = useSessionStore((s) => s.setMeta);
   const setActive = useSessionStore((s) => s.setActive);

--- a/frontend/src/components/EventDiagnostics.tsx
+++ b/frontend/src/components/EventDiagnostics.tsx
@@ -2,8 +2,9 @@ import { useEffect, useState, useCallback } from "react";
 import { GetEventBusDebugEmits, ReplayEventBusEmit } from "../../wailsjs/go/main/App";
 import { wailsbus } from "../../wailsjs/go/models";
 import type { EventRecord } from "../lib/eventBus";
+import { getDriftBuffer, type ReconcilerDriftEntry } from "../stores/reconciler";
 
-type View = "receives" | "sends";
+type View = "receives" | "sends" | "reconciler";
 
 function fmtTime(ts: number | string): string {
   const d = typeof ts === "number" ? new Date(ts) : new Date(ts);
@@ -58,15 +59,39 @@ function RowSend({ rec, onReplay }: { rec: wailsbus.EmitRecord; onReplay: (name:
   );
 }
 
+function RowDrift({ entry }: { entry: ReconcilerDriftEntry }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border-b border-slate-800 text-[11px]">
+      <button
+        className="w-full text-left flex items-center gap-2 px-2 py-1 hover:bg-slate-800/50"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="text-slate-500 font-mono shrink-0">{fmtTime(entry.ts)}</span>
+        <span className="text-violet-400 font-mono">#{entry.issueNumber}</span>
+        <span className="text-slate-400 truncate">{entry.missedFields.join(", ")}</span>
+        <span className="text-slate-600 ml-auto">{open ? "▲" : "▼"}</span>
+      </button>
+      {open && (
+        <pre className="px-4 py-2 text-slate-300 overflow-x-auto bg-slate-950/40 text-[10px]">
+          {JSON.stringify(entry, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
 export function EventDiagnostics() {
   const [view, setView] = useState<View>("receives");
   const [filter, setFilter] = useState("");
   const [receives, setReceives] = useState<EventRecord[]>([]);
   const [sends, setSends] = useState<wailsbus.EmitRecord[]>([]);
+  const [drifts, setDrifts] = useState<ReconcilerDriftEntry[]>([]);
   const [replayStatus, setReplayStatus] = useState("");
 
   const refresh = useCallback(() => {
     setReceives(window.__pcEventBuffer?.receives ?? []);
+    setDrifts(getDriftBuffer());
     GetEventBusDebugEmits()
       .then((r) => setSends(r ?? []))
       .catch(() => {});
@@ -97,6 +122,10 @@ export function EventDiagnostics() {
     ? sends.filter((s) => s.name.includes(filter))
     : sends;
 
+  const filteredDrifts = filter
+    ? drifts.filter((d) => String(d.issueNumber).includes(filter) || d.missedFields.some((f) => f.includes(filter)))
+    : drifts;
+
   // Compute names present in sends but not in receives for the last 500 events,
   // to highlight potential send-without-receive mismatches.
   const receivedNames = new Set(receives.map((r) => r.name));
@@ -110,6 +139,14 @@ export function EventDiagnostics() {
         <span className="text-emerald-500">{receives.length} received</span>
         <span className="text-slate-600">·</span>
         <span className="text-sky-500">{sends.length} sent</span>
+        {drifts.length > 0 && (
+          <>
+            <span className="text-slate-600">·</span>
+            <span className="text-violet-400" title="Reconciler-detected drift corrections">
+              {drifts.length} drift{drifts.length !== 1 ? "s" : ""}
+            </span>
+          </>
+        )}
         {orphanSends.size > 0 && (
           <>
             <span className="text-slate-600">·</span>
@@ -149,6 +186,15 @@ export function EventDiagnostics() {
           >
             Sent ({sends.length})
           </button>
+          <button
+            onClick={() => setView("reconciler")}
+            className={
+              "px-2 py-1 rounded " +
+              (view === "reconciler" ? "bg-violet-900/40 text-violet-300 border border-violet-800" : "text-slate-400 hover:text-slate-200")
+            }
+          >
+            Reconciler drift ({drifts.length})
+          </button>
         </div>
         <input
           value={filter}
@@ -174,6 +220,11 @@ export function EventDiagnostics() {
           filteredSends.length === 0
             ? <div className="px-3 py-4 text-xs text-slate-500 text-center">No sends yet{filter ? " matching filter" : ""}</div>
             : filteredSends.map((s, i) => <RowSend key={i} rec={s} onReplay={handleReplay} />)
+        )}
+        {view === "reconciler" && (
+          filteredDrifts.length === 0
+            ? <div className="px-3 py-4 text-xs text-slate-500 text-center">No drift detected yet{filter ? " matching filter" : ""}</div>
+            : filteredDrifts.map((d, i) => <RowDrift key={i} entry={d} />)
         )}
       </div>
     </div>

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -10,6 +10,64 @@ import { CollectionsPanel } from "./CollectionsPanel";
 import { EventDiagnostics } from "./EventDiagnostics";
 import { useSettingsStore } from "../stores/useSettingsStore";
 
+function AdvancedPanel({
+  showDiagnostics,
+  setShowDiagnostics,
+}: {
+  showDiagnostics: boolean;
+  setShowDiagnostics: (v: boolean) => void;
+}) {
+  const reconcilerEnabled = useSettingsStore((s) => s.reconcilerEnabled);
+  const setReconcilerEnabled = useSettingsStore((s) => s.setReconcilerEnabled);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <div className="text-slate-300 text-sm font-medium mb-1">Diagnostics</div>
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={showDiagnostics}
+            onChange={(e) => setShowDiagnostics(e.target.checked)}
+            className="accent-sky-500"
+          />
+          <span className="text-slate-400 text-sm">
+            Show Diagnostics tab
+          </span>
+        </label>
+        <p className="text-slate-500 text-xs mt-1">
+          Exposes the Event Diagnostics panel for on-device debugging. Persists across restarts.
+          You can also unlock it for the current session with{" "}
+          <kbd className="px-1 py-0.5 bg-slate-800 rounded text-slate-300">
+            {typeof navigator !== "undefined" && /Mac|Macintosh/.test(navigator.platform || navigator.userAgent)
+              ? "⌘⌥D"
+              : "Ctrl+Alt+D"}
+          </kbd>.
+        </p>
+      </div>
+      <div>
+        <div className="text-slate-300 text-sm font-medium mb-1">IssueView reconciler</div>
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={reconcilerEnabled}
+            onChange={(e) => setReconcilerEnabled(e.target.checked)}
+            className="accent-sky-500"
+          />
+          <span className="text-slate-400 text-sm">
+            Enable convergence reconciler
+          </span>
+        </label>
+        <p className="text-slate-500 text-xs mt-1">
+          Periodically checks visible cards against the backend and silently corrects any state
+          that was missed due to a dropped event bus delivery. Corrections are logged in the
+          Diagnostics → Reconciler drift tab. Disable if you observe unexpected refreshes.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 type Tab = "workspaces" | "collections" | "providers" | "pools" | "skills" | "notify" | "appearance" | "logs" | "advanced" | "diagnostics";
 
 export function Settings({
@@ -74,31 +132,10 @@ export function Settings({
             {tab === "appearance" && <AppearancePanel />}
             {tab === "logs" && <LogsPanel />}
             {tab === "advanced" && (
-              <div className="space-y-4">
-                <div>
-                  <div className="text-slate-300 text-sm font-medium mb-1">Diagnostics</div>
-                  <label className="flex items-center gap-3 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={showDiagnostics}
-                      onChange={(e) => setShowDiagnostics(e.target.checked)}
-                      className="accent-sky-500"
-                    />
-                    <span className="text-slate-400 text-sm">
-                      Show Diagnostics tab
-                    </span>
-                  </label>
-                  <p className="text-slate-500 text-xs mt-1">
-                    Exposes the Event Diagnostics panel for on-device debugging. Persists across restarts.
-                    You can also unlock it for the current session with{" "}
-                    <kbd className="px-1 py-0.5 bg-slate-800 rounded text-slate-300">
-                      {typeof navigator !== "undefined" && /Mac|Macintosh/.test(navigator.platform || navigator.userAgent)
-                        ? "⌘⌥D"
-                        : "Ctrl+Alt+D"}
-                    </kbd>.
-                  </p>
-                </div>
-              </div>
+              <AdvancedPanel
+                showDiagnostics={showDiagnostics}
+                setShowDiagnostics={setShowDiagnostics}
+              />
             )}
             {tab === "diagnostics" && diagnosticsVisible && <EventDiagnostics />}
           </div>

--- a/frontend/src/stores/reconciler.test.ts
+++ b/frontend/src/stores/reconciler.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock Wails runtime before any imports that transitively call EventsOn at module level.
+vi.mock("../../wailsjs/runtime/runtime", () => ({
+  EventsOn: vi.fn(() => () => {}),
+}));
+vi.mock("../../wailsjs/go/main/App", () => ({
+  GetIssueView: vi.fn(),
+  ListIssueViews: vi.fn(),
+}));
+
+import { diffIssueView, getDriftBuffer, logDrift, type ReconcilerDriftEntry } from "./reconciler";
+import { issueview } from "../../wailsjs/go/models";
+
+// Minimal IssueView factory — only sets the load-bearing fields.
+function makeView(overrides: Partial<{
+  card_state: string | undefined;
+  derived_column: string;
+  active_session_state: string | undefined;
+  last_failure_id: string | undefined;
+  tests_failing_info: object | undefined;
+  conflicts_info: object | undefined;
+  needs_pr_info: object | undefined;
+  latest_plan_ready: boolean | undefined;
+}> = {}): issueview.IssueView {
+  const v = issueview.IssueView.createFrom({
+    issue: { workspace_id: "ws1", number: 1 },
+    derived_column: overrides.derived_column ?? "todo",
+    card_state: overrides.card_state,
+    active_session: overrides.active_session_state !== undefined
+      ? { id: "s1", state: overrides.active_session_state }
+      : undefined,
+    last_failure: overrides.last_failure_id !== undefined
+      ? { id: overrides.last_failure_id, state: "failed" }
+      : undefined,
+    tests_failing_info: overrides.tests_failing_info ?? undefined,
+    conflicts_info: overrides.conflicts_info ?? undefined,
+    needs_pr_info: overrides.needs_pr_info ?? undefined,
+    latest_plan: overrides.latest_plan_ready !== undefined
+      ? { id: "p1", ready_to_execute: overrides.latest_plan_ready }
+      : undefined,
+  });
+  return v;
+}
+
+// Drain the drift buffer between tests.
+function drainDriftBuffer() {
+  // logDrift adds to the front; read it to see current length, then reset via private module state.
+  // Since the buffer is module-level, we drain it by reading via getDriftBuffer() — we can't
+  // reset it directly, but we can count entries before each test and ignore earlier ones.
+}
+
+describe("diffIssueView", () => {
+  it("returns empty array when views are identical", () => {
+    const a = makeView({ card_state: "glow_blue", derived_column: "in_progress" });
+    const b = makeView({ card_state: "glow_blue", derived_column: "in_progress" });
+    expect(diffIssueView(a, b)).toEqual([]);
+  });
+
+  it("detects card_state mismatch", () => {
+    const a = makeView({ card_state: "glow_blue" });
+    const b = makeView({ card_state: "glow_red" });
+    expect(diffIssueView(a, b)).toContain("card_state");
+  });
+
+  it("detects derived_column mismatch", () => {
+    const a = makeView({ derived_column: "todo" });
+    const b = makeView({ derived_column: "in_progress" });
+    expect(diffIssueView(a, b)).toContain("derived_column");
+  });
+
+  it("detects active_session.state mismatch", () => {
+    const a = makeView({ active_session_state: "running" });
+    const b = makeView({ active_session_state: "stopped" });
+    expect(diffIssueView(a, b)).toContain("active_session.state");
+  });
+
+  it("detects active_session appearing (null → value)", () => {
+    const a = makeView({ active_session_state: undefined });
+    const b = makeView({ active_session_state: "running" });
+    expect(diffIssueView(a, b)).toContain("active_session.state");
+  });
+
+  it("detects last_failure id mismatch", () => {
+    const a = makeView({ last_failure_id: "old-fail" });
+    const b = makeView({ last_failure_id: "new-fail" });
+    expect(diffIssueView(a, b)).toContain("last_failure");
+  });
+
+  it("detects tests_failing_info appearing", () => {
+    const a = makeView({ tests_failing_info: undefined });
+    const b = makeView({ tests_failing_info: { count: 3 } });
+    expect(diffIssueView(a, b)).toContain("tests_failing_info");
+  });
+
+  it("detects conflicts_info appearing", () => {
+    const a = makeView({ conflicts_info: undefined });
+    const b = makeView({ conflicts_info: { has_conflict: true } });
+    expect(diffIssueView(a, b)).toContain("conflicts_info");
+  });
+
+  it("detects needs_pr_info appearing", () => {
+    const a = makeView({ needs_pr_info: undefined });
+    const b = makeView({ needs_pr_info: { branch: "feat/x" } });
+    expect(diffIssueView(a, b)).toContain("needs_pr_info");
+  });
+
+  it("detects latest_plan.ready_to_execute mismatch", () => {
+    const a = makeView({ latest_plan_ready: false });
+    const b = makeView({ latest_plan_ready: true });
+    expect(diffIssueView(a, b)).toContain("latest_plan.ready_to_execute");
+  });
+
+  it("returns multiple fields when several differ", () => {
+    const a = makeView({ card_state: "glow_blue", derived_column: "todo" });
+    const b = makeView({ card_state: "glow_red", derived_column: "review" });
+    const missed = diffIssueView(a, b);
+    expect(missed).toContain("card_state");
+    expect(missed).toContain("derived_column");
+  });
+
+  it("ignores non-load-bearing field differences (e.g. unread_comment_count)", () => {
+    const a = issueview.IssueView.createFrom({ issue: { workspace_id: "ws1", number: 1 }, derived_column: "todo", unread_comment_count: 0 });
+    const b = issueview.IssueView.createFrom({ issue: { workspace_id: "ws1", number: 1 }, derived_column: "todo", unread_comment_count: 5 });
+    expect(diffIssueView(a, b)).toEqual([]);
+  });
+});
+
+describe("drift buffer", () => {
+  let baseLen: number;
+
+  beforeEach(() => {
+    baseLen = getDriftBuffer().length;
+  });
+
+  it("logDrift appends an entry to the front", () => {
+    const entry: ReconcilerDriftEntry = {
+      kind: "reconciler_drift",
+      workspaceID: "ws1",
+      issueNumber: 42,
+      missedFields: ["card_state"],
+      ts: Date.now(),
+    };
+    logDrift(entry);
+    const buf = getDriftBuffer();
+    expect(buf.length).toBe(baseLen + 1);
+    expect(buf[0]).toEqual(entry);
+  });
+
+  it("getDriftBuffer returns a copy, not the live array", () => {
+    const snap1 = getDriftBuffer();
+    logDrift({ kind: "reconciler_drift", workspaceID: "ws1", issueNumber: 99, missedFields: [], ts: 0 });
+    const snap2 = getDriftBuffer();
+    expect(snap2.length).toBe(snap1.length + 1);
+    expect(snap1.length).toBe(snap1.length); // unchanged original snapshot
+  });
+});

--- a/frontend/src/stores/reconciler.ts
+++ b/frontend/src/stores/reconciler.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useRef } from "react";
+import { GetIssueView } from "../../wailsjs/go/main/App";
+import { issueview } from "../../wailsjs/go/models";
+import { useIssueViewStore } from "./useIssueViewStore";
+import { useIssueStore } from "./issueStore";
+import { useWorkspaceStore } from "./workspaceStore";
+import { useSettingsStore } from "./useSettingsStore";
+
+export type ReconcilerDriftEntry = {
+  kind: "reconciler_drift";
+  workspaceID: string;
+  issueNumber: number;
+  missedFields: string[];
+  ts: number;
+};
+
+const DRIFT_CAP = 200;
+const driftBuffer: ReconcilerDriftEntry[] = [];
+
+export function logDrift(entry: ReconcilerDriftEntry): void {
+  driftBuffer.unshift(entry);
+  if (driftBuffer.length > DRIFT_CAP) driftBuffer.pop();
+}
+
+export function getDriftBuffer(): ReconcilerDriftEntry[] {
+  return driftBuffer.slice();
+}
+
+/** Compare load-bearing fields; return names of fields that differ. */
+export function diffIssueView(
+  cached: issueview.IssueView,
+  fresh: issueview.IssueView,
+): string[] {
+  const missed: string[] = [];
+
+  if (cached.card_state !== fresh.card_state) missed.push("card_state");
+  if (cached.derived_column !== fresh.derived_column) missed.push("derived_column");
+
+  const cachedActiveState = cached.active_session?.state ?? null;
+  const freshActiveState = fresh.active_session?.state ?? null;
+  if (cachedActiveState !== freshActiveState) missed.push("active_session.state");
+
+  const cachedFailureID = cached.last_failure?.id ?? null;
+  const freshFailureID = fresh.last_failure?.id ?? null;
+  if (cachedFailureID !== freshFailureID) missed.push("last_failure");
+
+  const cachedTestsFailing = cached.tests_failing_info != null;
+  const freshTestsFailing = fresh.tests_failing_info != null;
+  if (cachedTestsFailing !== freshTestsFailing) missed.push("tests_failing_info");
+
+  const cachedConflicts = cached.conflicts_info != null;
+  const freshConflicts = fresh.conflicts_info != null;
+  if (cachedConflicts !== freshConflicts) missed.push("conflicts_info");
+
+  const cachedNeedsPR = cached.needs_pr_info != null;
+  const freshNeedsPR = fresh.needs_pr_info != null;
+  if (cachedNeedsPR !== freshNeedsPR) missed.push("needs_pr_info");
+
+  const cachedPlanReady = cached.latest_plan?.ready_to_execute ?? null;
+  const freshPlanReady = fresh.latest_plan?.ready_to_execute ?? null;
+  if (cachedPlanReady !== freshPlanReady) missed.push("latest_plan.ready_to_execute");
+
+  return missed;
+}
+
+const RECONCILER_INTERVAL_MS = 5000;
+
+export function useReconciler(): void {
+  const reconcilerEnabled = useSettingsStore((s) => s.reconcilerEnabled);
+  const workspaceID = useWorkspaceStore((s) => s.selectedID);
+  const issues = useIssueStore((s) => s.issues);
+
+  // Refs so the interval/focus handler always see latest values without re-wiring.
+  const enabledRef = useRef(reconcilerEnabled);
+  const workspaceIDRef = useRef(workspaceID);
+  const issuesRef = useRef(issues);
+
+  useEffect(() => { enabledRef.current = reconcilerEnabled; }, [reconcilerEnabled]);
+  useEffect(() => { workspaceIDRef.current = workspaceID; }, [workspaceID]);
+  useEffect(() => { issuesRef.current = issues; }, [issues]);
+
+  const runReconcile = useCallback(async () => {
+    if (!enabledRef.current) return;
+    const wsID = workspaceIDRef.current;
+    if (!wsID) return;
+    const visibleIssues = issuesRef.current.filter((i) => i.workspace_id === wsID);
+    for (const issue of visibleIssues) {
+      try {
+        const fresh = await GetIssueView(wsID, issue.number);
+        if (!fresh) continue;
+        const cached = useIssueViewStore.getState().get(wsID, issue.number);
+        if (!cached) {
+          useIssueViewStore.setState((s) => ({
+            views: { ...s.views, [`${wsID}#${issue.number}`]: fresh },
+          }));
+          continue;
+        }
+        const missed = diffIssueView(cached, fresh);
+        if (missed.length > 0) {
+          useIssueViewStore.setState((s) => ({
+            views: { ...s.views, [`${wsID}#${issue.number}`]: fresh },
+          }));
+          logDrift({
+            kind: "reconciler_drift",
+            workspaceID: wsID,
+            issueNumber: issue.number,
+            missedFields: missed,
+            ts: Date.now(),
+          });
+        }
+      } catch {
+        // IPC errors are transient; skip and try next issue.
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const tick = () => { void runReconcile(); };
+    const id = setInterval(tick, RECONCILER_INTERVAL_MS);
+    window.addEventListener("focus", tick);
+    return () => {
+      clearInterval(id);
+      window.removeEventListener("focus", tick);
+    };
+  }, [runReconcile]);
+
+  // Re-run immediately on workspace switch.
+  useEffect(() => {
+    if (workspaceID) void runReconcile();
+  }, [workspaceID, runReconcile]);
+}

--- a/frontend/src/stores/useSettingsStore.ts
+++ b/frontend/src/stores/useSettingsStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 
 const DIAGNOSTICS_KEY = "prismconductor.showDiagnostics";
+const RECONCILER_KEY = "prismconductor.reconcilerEnabled";
 
 function loadShowDiagnostics(): boolean {
   try {
@@ -10,16 +11,28 @@ function loadShowDiagnostics(): boolean {
   }
 }
 
+function loadReconcilerEnabled(): boolean {
+  try {
+    const v = localStorage.getItem(RECONCILER_KEY);
+    return v === null ? true : v === "true";
+  } catch {
+    return true;
+  }
+}
+
 type State = {
   showDiagnostics: boolean;
   diagnosticsUnlocked: boolean;
+  reconcilerEnabled: boolean;
   setShowDiagnostics: (val: boolean) => void;
   setDiagnosticsUnlocked: (val: boolean) => void;
+  setReconcilerEnabled: (val: boolean) => void;
 };
 
 export const useSettingsStore = create<State>((set) => ({
   showDiagnostics: loadShowDiagnostics(),
   diagnosticsUnlocked: false,
+  reconcilerEnabled: loadReconcilerEnabled(),
   setShowDiagnostics: (val) => {
     try {
       localStorage.setItem(DIAGNOSTICS_KEY, String(val));
@@ -29,4 +42,12 @@ export const useSettingsStore = create<State>((set) => ({
     set({ showDiagnostics: val });
   },
   setDiagnosticsUnlocked: (val) => set({ diagnosticsUnlocked: val }),
+  setReconcilerEnabled: (val) => {
+    try {
+      localStorage.setItem(RECONCILER_KEY, String(val));
+    } catch {
+      // ignore
+    }
+    set({ reconcilerEnabled: val });
+  },
 }));


### PR DESCRIPTION
## Summary

- Adds a lightweight client-side convergence reconciler that polls `GetIssueView` every 5 seconds (and on window focus / workspace switch) for all visible issues, silently corrects any store drift caused by missed event bus deliveries, and logs each correction to a new **Reconciler drift** tab in the Diagnostics panel.
- Ships opt-out (default ON) via a new toggle in **Settings → Advanced → IssueView reconciler**. Persisted to `localStorage` at key `prismconductor.reconcilerEnabled`.

## Files modified

| File | Change |
|---|---|
| `frontend/src/stores/reconciler.ts` | New — `diffIssueView`, drift ring buffer, `useReconciler` hook |
| `frontend/src/stores/reconciler.test.ts` | New — 14 unit tests for diff logic and buffer |
| `frontend/src/stores/useSettingsStore.ts` | Add `reconcilerEnabled` + `setReconcilerEnabled` |
| `frontend/src/components/Settings.tsx` | Advanced tab: reconciler opt-out toggle |
| `frontend/src/components/EventDiagnostics.tsx` | New "Reconciler drift" tab showing `ReconcilerDriftEntry` items |
| `frontend/src/App.tsx` | Wire `useReconciler()` hook alongside `useDiagnosticUnlock()` |

## Verification

| Gate | Command | Result |
|---|---|---|
| TypeScript typecheck | `./node_modules/.bin/tsc --noEmit` | pass |
| Unit tests | `./node_modules/.bin/vitest run` | pass — 126 tests (15 files), +14 new reconciler tests |
| Build | `wails build` | pass — 9.5s |
| Smoke test | `playwright test tests/e2e/startup.spec.ts` | pass — 1/1 |

Commit tier: **Tier 1** (GitHub API signed commit).

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-275

Closes #275