### PR TITLE
feat(frontend): model capability hints in workspace pool pickers (#278)

### DIFF
--- a/frontend/src/components/PoolEditModal.tsx
+++ b/frontend/src/components/PoolEditModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   CreatePool,
   GetModelHint,
@@ -10,19 +10,9 @@ import { main, llm, types } from "../../wailsjs/go/models";
 import { noAutoCorrect } from "../lib/inputs";
 import { ModelSelect } from "./ModelSelect";
 import { useModelsStore } from "../stores/modelsStore";
+import { costRank, fitForRole, meetsThreshold } from "./fitGlyph";
 
 type Fit = "excellent" | "good" | "fair" | "poor" | "unsuitable" | "";
-
-function fitForRole(hint: llm.ModelHint | null, role: string): Fit {
-  if (!hint) return "";
-  switch (role) {
-    case "plan": return (hint.plan_fit as Fit) || "";
-    case "work": return (hint.work_fit as Fit) || "";
-    case "orchestrator": return (hint.orch_fit as Fit) || "";
-    case "architect": return (hint.architect_fit as Fit) || "";
-    default: return (hint.work_fit as Fit) || "";
-  }
-}
 
 function fmtCtx(n: number): string {
   if (!n) return "—";
@@ -191,6 +181,7 @@ export function PoolEditModal({
   const [endpoint, setEndpoint] = useState<string>(initial?.endpoint ?? "");
   const [apiKey, setApiKey] = useState<string>(initial?.api_key ?? "");
   const [model, setModel] = useState<string>(initial?.model ?? "");
+  const userEditedModel = useRef(false);
   const [capacity, setCapacity] = useState<number>(initial?.capacity ?? 1);
   const [enabled, setEnabled] = useState<boolean>(initial?.enabled ?? true);
   const [temperatureStr, setTemperatureStr] = useState<string>(
@@ -286,6 +277,39 @@ export function PoolEditModal({
       .then((h) => setModelHint(h ?? null))
       .catch(() => setModelHint(null));
   }, [providerKind, model]);
+
+  // On add-mode with a role set, auto-select the cheapest suitable model once
+  // the model list loads. Never clobbers a user-typed value.
+  useEffect(() => {
+    if (initial) return;
+    if (userEditedModel.current) return;
+    const models = modelEntry?.models ?? [];
+    if (models.length === 0) return;
+
+    let canceled = false;
+    Promise.all(
+      models.map((m) =>
+        GetModelHint(providerKind, m)
+          .then((h) => ({ model: m, hint: h ?? null }))
+          .catch(() => ({ model: m, hint: null as llm.ModelHint | null })),
+      ),
+    ).then((entries) => {
+      if (canceled || userEditedModel.current) return;
+      const candidates = entries.filter(({ hint }) => {
+        if (!hint) return false;
+        const fit = fitForRole(hint, role);
+        if (role === "orchestrator") {
+          return meetsThreshold(fit, role) && hint.tool_support === "full";
+        }
+        return meetsThreshold(fit, role);
+      });
+      candidates.sort((a, b) => costRank(a.hint?.cost_tier ?? "") - costRank(b.hint?.cost_tier ?? ""));
+      if (candidates.length > 0 && !userEditedModel.current) {
+        setModel(candidates[0].model);
+      }
+    });
+    return () => { canceled = true; };
+  }, [providerKind, modelEntry?.models, role, initial]);
 
   async function onEndpointBlur() {
     if (!providerInfo) return;
@@ -502,7 +526,7 @@ export function PoolEditModal({
               endpoint={resolvedEndpoint}
               apiKey={apiKey}
               value={model}
-              onChange={setModel}
+              onChange={(v) => { userEditedModel.current = true; setModel(v); }}
             />
             {model && (
               <div className="mt-1">

--- a/frontend/src/components/SkillProfileEditor.tsx
+++ b/frontend/src/components/SkillProfileEditor.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
-import { DiscoverWorkspaceSkills, ListPools, UpdateWorkspace } from "../../wailsjs/go/main/App";
-import { types, workerpool } from "../../wailsjs/go/models";
+import { DiscoverWorkspaceSkills, GetModelHint, ListPools, UpdateWorkspace } from "../../wailsjs/go/main/App";
+import { llm, types, workerpool } from "../../wailsjs/go/models";
 import { useWorkspaceStore } from "../stores/workspaceStore";
 import { SkillDropdown } from "./SkillDropdown";
 import { noAutoCorrect } from "../lib/inputs";
+import { fitOptionSuffix } from "./fitGlyph";
 
 type SkillMode = "bundled" | "hybrid" | "native";
 const MODES: SkillMode[] = ["bundled", "hybrid", "native"];
@@ -124,12 +125,14 @@ export function SkillProfileEditor({ workspace }: { workspace: types.Workspace }
           label="Plan pool"
           value={sp.preferred_plan_pool_id ?? ""}
           pools={planPools}
+          role="plan"
           onChange={(v) => update({ preferred_plan_pool_id: v })}
         />
         <PoolPicker
           label="Work pool"
           value={sp.preferred_work_pool_id ?? ""}
           pools={workPools}
+          role="work"
           onChange={(v) => update({ preferred_work_pool_id: v })}
         />
       </div>
@@ -209,13 +212,27 @@ function PoolPicker({
   label,
   value,
   pools,
+  role,
   onChange,
 }: {
   label: string;
   value: string;
   pools: workerpool.PoolStatus[];
+  role: string;
   onChange: (v: string) => void;
 }) {
+  const [hints, setHints] = useState<Record<string, llm.ModelHint | null>>({});
+
+  useEffect(() => {
+    pools.forEach((row) => {
+      const { provider, model, id } = row.pool;
+      if (!provider || !model) return;
+      GetModelHint(provider, model)
+        .then((h) => setHints((prev) => ({ ...prev, [id]: h ?? null })))
+        .catch(() => setHints((prev) => ({ ...prev, [row.pool.id]: null })));
+    });
+  }, [pools]);
+
   return (
     <label className="block">
       <div className="text-xs text-slate-500 mb-1">{label}</div>
@@ -225,11 +242,15 @@ function PoolPicker({
         className="w-full bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-200 text-xs"
       >
         <option value="">(any compatible)</option>
-        {pools.map((row) => (
-          <option key={row.pool.id} value={row.pool.id}>
-            {row.pool.name} · {row.pool.provider}
-          </option>
-        ))}
+        {pools.map((row) => {
+          const hint = hints[row.pool.id] ?? null;
+          const suffix = fitOptionSuffix(hint, role);
+          return (
+            <option key={row.pool.id} value={row.pool.id}>
+              {row.pool.name} · {row.pool.provider}{suffix}
+            </option>
+          );
+        })}
       </select>
     </label>
   );

--- a/frontend/src/components/fitGlyph.test.ts
+++ b/frontend/src/components/fitGlyph.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { fitForRole, fitOptionSuffix, costRank, meetsThreshold } from "./fitGlyph";
+import { llm } from "../../wailsjs/go/models";
+
+function hint(overrides: Partial<llm.ModelHint> = {}): llm.ModelHint {
+  return new llm.ModelHint({
+    plan_fit: "good",
+    work_fit: "fair",
+    orch_fit: "fair",
+    architect_fit: "excellent",
+    tool_support: "full",
+    cost_tier: "low",
+    ...overrides,
+  });
+}
+
+describe("fitForRole", () => {
+  it("returns plan_fit for role=plan", () => {
+    expect(fitForRole(hint({ plan_fit: "excellent" }), "plan")).toBe("excellent");
+  });
+  it("returns work_fit for role=work", () => {
+    expect(fitForRole(hint({ work_fit: "poor" }), "work")).toBe("poor");
+  });
+  it("returns orch_fit for role=orchestrator", () => {
+    expect(fitForRole(hint({ orch_fit: "fair" }), "orchestrator")).toBe("fair");
+  });
+  it("returns architect_fit for role=architect", () => {
+    expect(fitForRole(hint({ architect_fit: "unsuitable" }), "architect")).toBe("unsuitable");
+  });
+  it("falls back to work_fit for unknown role", () => {
+    expect(fitForRole(hint({ work_fit: "good" }), "unknown")).toBe("good");
+  });
+  it("returns empty string when hint is null", () => {
+    expect(fitForRole(null, "plan")).toBe("");
+  });
+});
+
+describe("meetsThreshold", () => {
+  it("plan/work: excellent and good pass, fair fails", () => {
+    expect(meetsThreshold("excellent", "plan")).toBe(true);
+    expect(meetsThreshold("good", "plan")).toBe(true);
+    expect(meetsThreshold("fair", "plan")).toBe(false);
+    expect(meetsThreshold("poor", "work")).toBe(false);
+    expect(meetsThreshold("unsuitable", "work")).toBe(false);
+  });
+  it("orchestrator: excellent/good/fair pass, poor fails", () => {
+    expect(meetsThreshold("excellent", "orchestrator")).toBe(true);
+    expect(meetsThreshold("good", "orchestrator")).toBe(true);
+    expect(meetsThreshold("fair", "orchestrator")).toBe(true);
+    expect(meetsThreshold("poor", "orchestrator")).toBe(false);
+    expect(meetsThreshold("unsuitable", "orchestrator")).toBe(false);
+  });
+  it("returns false for empty fit", () => {
+    expect(meetsThreshold("", "plan")).toBe(false);
+  });
+});
+
+describe("costRank", () => {
+  it("micro < low < medium < high < very_high", () => {
+    expect(costRank("micro")).toBeLessThan(costRank("low"));
+    expect(costRank("low")).toBeLessThan(costRank("medium"));
+    expect(costRank("medium")).toBeLessThan(costRank("high"));
+    expect(costRank("high")).toBeLessThan(costRank("very_high"));
+  });
+  it("unknown tier returns large sentinel", () => {
+    expect(costRank("unknown")).toBe(99);
+  });
+});
+
+describe("fitOptionSuffix", () => {
+  it("returns checkmark for excellent/good", () => {
+    expect(fitOptionSuffix(hint({ plan_fit: "excellent" }), "plan")).toBe(" ✓");
+    expect(fitOptionSuffix(hint({ plan_fit: "good" }), "plan")).toBe(" ✓");
+  });
+  it("returns dot for fair", () => {
+    expect(fitOptionSuffix(hint({ plan_fit: "fair" }), "plan")).toBe(" ◦");
+  });
+  it("returns warning for poor", () => {
+    expect(fitOptionSuffix(hint({ plan_fit: "poor" }), "plan")).toBe(" ⚠ (Poor fit)");
+  });
+  it("returns cross for unsuitable", () => {
+    expect(fitOptionSuffix(hint({ plan_fit: "unsuitable" }), "plan")).toBe(" ✗ (Unsuitable)");
+  });
+  it("returns (?) for null hint", () => {
+    expect(fitOptionSuffix(null, "plan")).toBe(" (?)");
+  });
+});

--- a/frontend/src/components/fitGlyph.tsx
+++ b/frontend/src/components/fitGlyph.tsx
@@ -1,0 +1,57 @@
+import { llm } from "../../wailsjs/go/models";
+
+export type Fit = "excellent" | "good" | "fair" | "poor" | "unsuitable" | "";
+
+export function fitForRole(hint: llm.ModelHint | null, role: string): Fit {
+  if (!hint) return "";
+  switch (role) {
+    case "plan":        return (hint.plan_fit as Fit) || "";
+    case "work":        return (hint.work_fit as Fit) || "";
+    case "orchestrator": return (hint.orch_fit as Fit) || "";
+    case "architect":   return (hint.architect_fit as Fit) || "";
+    default:            return (hint.work_fit as Fit) || "";
+  }
+}
+
+/** Numeric cost rank — lower is cheaper. */
+const COST_RANK: Record<string, number> = {
+  micro: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  very_high: 4,
+};
+
+export function costRank(tier: string): number {
+  return COST_RANK[tier] ?? 99;
+}
+
+/** Returns true when the fit level meets the threshold for a role. */
+export function meetsThreshold(fit: Fit, role: string): boolean {
+  if (!fit) return false;
+  switch (role) {
+    case "orchestrator":
+      return fit === "excellent" || fit === "good" || fit === "fair";
+    case "plan":
+    case "work":
+    case "architect":
+    default:
+      return fit === "excellent" || fit === "good";
+  }
+}
+
+/**
+ * Short text label appended to a native <select> option for the given hint.
+ * Returns empty string when no hint is available.
+ */
+export function fitOptionSuffix(hint: llm.ModelHint | null, role: string): string {
+  const fit = fitForRole(hint, role);
+  switch (fit) {
+    case "excellent": return " ✓";
+    case "good":      return " ✓";
+    case "fair":      return " ◦";
+    case "poor":      return " ⚠ (Poor fit)";
+    case "unsuitable": return " ✗ (Unsuitable)";
+    default:          return " (?)";
+  }
+}


### PR DESCRIPTION
## Summary

- **PoolPicker** in `SkillProfileEditor` now shows model fit glyphs (✓ / ◦ / ⚠ (Poor fit) / ✗ (Unsuitable) / (?)) appended to each pool's native `<select>` option label, fetched via `GetModelHint` on mount
- **PoolEditModal** add-mode now auto-selects the cheapest model meeting the role's quality threshold (plan/work: PlanFit >= Good; orchestrator: OrchFit >= Fair + Tools=Full) when the model list loads, without clobbering user-typed values
- Shared `fitGlyph.tsx` helper consolidates glyph rendering, threshold checking, and cost ranking; `PoolEditModal`'s duplicate `fitForRole` removed and replaced with the shared import

## Files modified

- `frontend/src/components/fitGlyph.tsx` (**new**) — shared utilities: `fitForRole`, `meetsThreshold`, `costRank`, `fitOptionSuffix`
- `frontend/src/components/fitGlyph.test.ts` (**new**) — 16 unit tests covering all helpers and edge cases
- `frontend/src/components/SkillProfileEditor.tsx` — `PoolPicker` fetches hints per pool and appends suffix to option labels; `role` prop added
- `frontend/src/components/PoolEditModal.tsx` — role-aware default model effect; local `fitForRole` deduped via import

## Verification

| Check | Command | Result |
|-------|---------|--------|
| Go lint | `go vet ./internal/...` | pass |
| TS typecheck | `tsc --noEmit` | pass |
| Unit tests | `vitest run` | **142 passed** (16 files) |
| Smoke test | `playwright test e2e/startup.spec.ts` | `wails dev` started cleanly (Go compiled, bindings generated); Playwright UI-mount wait killed at timeout — consistent with other feature branches in a bare worktree |

Commit tier: **Tier 2b** (unsigned; `main` branch protection does not require signed commits)

Workspace mode: per-execute worktree at `/Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-278`

Closes #278
