### PR TITLE
feat(llm): add codex CLI subprocess provider (#281)

### DIFF
--- a/app.go
+++ b/app.go
@@ -154,6 +154,7 @@ func (a *App) startup(ctx context.Context) {
 		llm.NewLMStudioProvider(),
 		llm.NewOllamaProvider(),
 		llm.NewGeminiProvider(),
+		llm.NewCodexProvider(),
 	)
 	a.poolReg = workerpool.NewRegistry(a.providers.CanSpawn)
 	a.orch = orchestrator.New(a.bus, a.resolveOrchestratorLLM)

--- a/frontend/src/components/PoolEditModal.tsx
+++ b/frontend/src/components/PoolEditModal.tsx
@@ -267,6 +267,13 @@ export function PoolEditModal({
     fetchModels(providerKind, resolvedEndpoint, apiKey).catch(() => {});
   }, [providerKind]);
 
+  // Codex pools default to capacity 1 (subscription limits are per-account).
+  useEffect(() => {
+    if (providerKind === "codex" && !initial) {
+      setCapacity(1);
+    }
+  }, [providerKind]);
+
   // Fetch model capability hint whenever provider or model changes.
   useEffect(() => {
     if (!model || !providerKind) {
@@ -491,7 +498,15 @@ export function PoolEditModal({
             </select>
           </div>
 
-          {providerInfo && providerKind !== "claude" && (
+          {providerKind === "codex" && (
+            <div className="text-xs text-amber-300/80 bg-amber-950/30 border border-amber-900/40 rounded px-2 py-1.5">
+              Codex uses a local CLI and browser OAuth — no endpoint or API key needed.
+              Run <code className="font-mono">codex login</code> before adding this provider.
+              Pool capacity defaults to 1 (subscription limits are per-account).
+            </div>
+          )}
+
+          {providerInfo && providerKind !== "claude" && providerKind !== "codex" && (
             <div>
               <div className="text-xs text-slate-500 mb-1">Endpoint URL</div>
               <input

--- a/frontend/src/components/ProvidersPanel.tsx
+++ b/frontend/src/components/ProvidersPanel.tsx
@@ -181,7 +181,14 @@ function ProviderEditModal({
             </select>
           </div>
 
-          {driver && kind !== "claude" && (
+          {kind === "codex" && (
+            <div className="text-xs text-amber-300/80 bg-amber-950/30 border border-amber-900/40 rounded px-2 py-1.5">
+              Codex uses a local CLI and browser OAuth — no endpoint or API key needed.
+              Run <code className="font-mono">codex login</code> before adding this provider.
+            </div>
+          )}
+
+          {driver && kind !== "claude" && kind !== "codex" && (
             <div>
               <div className="text-xs text-slate-500 mb-1">Endpoint URL</div>
               <input

--- a/internal/llm/codex.go
+++ b/internal/llm/codex.go
@@ -1,0 +1,83 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"prismconductor/internal/types"
+)
+
+// codexKnownModels is the static list of models available via the codex CLI.
+// The CLI does not expose a listing API; models are enumerated from OpenAI
+// documentation. Update via /refresh-model-hints when new models ship.
+var codexKnownModels = []string{
+	"o3",
+	"o4-mini",
+	"gpt-4o",
+	"gpt-4.1",
+	"gpt-4.1-mini",
+}
+
+type codexProvider struct{}
+
+func NewCodexProvider() Provider {
+	return codexProvider{}
+}
+
+func (codexProvider) Kind() types.Provider    { return types.ProviderCodex }
+func (codexProvider) DisplayName() string     { return "Codex CLI" }
+func (codexProvider) DefaultEndpoint() string { return "" }
+func (codexProvider) NeedsAPIKey() bool       { return false }
+func (codexProvider) CanSpawn() bool          { return true }
+
+// ListModels probes the local codex binary. If the binary is not found in
+// PATH, ListModels returns an error so the UI's "Test connection" button
+// surfaces the install hint. When the binary is found, the static model list
+// is returned — codex has no model-listing API.
+func (codexProvider) ListModels(ctx context.Context, _ types.Pool) ([]string, error) {
+	path, err := exec.LookPath("codex")
+	if err != nil {
+		return nil, fmt.Errorf("codex binary not found in PATH — install it with `npm install -g @openai/codex` and run `codex login`")
+	}
+	// Quick version probe with a short timeout so "Test connection" is snappy.
+	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(probeCtx, path, "--version").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("codex --version failed (%w); run `codex login` to authenticate", err)
+	}
+	_ = strings.TrimSpace(string(out)) // version string, unused but confirms binary is healthy
+	return codexKnownModels, nil
+}
+
+// SpawnArgs returns the argv for the codex subprocess. Mirrors the Claude
+// pattern: the prompt is the last positional argument, and the model is
+// threaded through --model when set on the pool. --approval-mode full-auto
+// suppresses interactive permission prompts so the conductor's PTY tail can
+// parse output without waiting for user interaction.
+func (codexProvider) SpawnArgs(p types.Pool, prompt string) ([]string, error) {
+	args := []string{
+		"codex",
+		"--approval-mode", "full-auto",
+	}
+	if p.Model != "" {
+		args = append(args, "--model", p.Model)
+	}
+	return append(args, prompt), nil
+}
+
+// ChatJSON is unsupported for codex pools — inference runs through the local
+// CLI subprocess, not an HTTP endpoint. The orchestrator's rank+deps call
+// should route to a non-codex orchestrator pool.
+func (codexProvider) ChatJSON(_ context.Context, _ types.Pool, _, _ string) (string, error) {
+	return "", ErrNotSupported
+}
+
+// ToolChat is unsupported for codex pools — codex runs as a subprocess and
+// has its own internal tool loop. The harness strategy does not apply.
+func (codexProvider) ToolChat(_ context.Context, _ types.Pool, _ ChatRequest) (ChatResponse, error) {
+	return ChatResponse{}, ErrNotSupported
+}

--- a/internal/llm/codex_test.go
+++ b/internal/llm/codex_test.go
@@ -1,0 +1,118 @@
+package llm
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"prismconductor/internal/types"
+)
+
+func TestCodexProviderKind(t *testing.T) {
+	p := NewCodexProvider()
+	if p.Kind() != types.ProviderCodex {
+		t.Fatalf("Kind() = %s, want %s", p.Kind(), types.ProviderCodex)
+	}
+}
+
+func TestCodexProviderNeedsNoAPIKey(t *testing.T) {
+	p := NewCodexProvider()
+	if p.NeedsAPIKey() {
+		t.Fatal("codex uses browser OAuth — NeedsAPIKey() should be false")
+	}
+}
+
+func TestCodexProviderCanSpawn(t *testing.T) {
+	p := NewCodexProvider()
+	if !p.CanSpawn() {
+		t.Fatal("codex is a subprocess provider — CanSpawn() should be true")
+	}
+}
+
+func TestCodexSpawnArgsThreadsModel(t *testing.T) {
+	p := NewCodexProvider()
+	args, err := p.SpawnArgs(types.Pool{Model: "o3"}, "plan issue #1")
+	if err != nil {
+		t.Fatalf("SpawnArgs error: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--model o3") {
+		t.Errorf("argv missing --model o3: %v", args)
+	}
+	if args[len(args)-1] != "plan issue #1" {
+		t.Errorf("last arg = %q, want prompt", args[len(args)-1])
+	}
+	if args[0] != "codex" {
+		t.Errorf("args[0] = %q, want codex", args[0])
+	}
+}
+
+func TestCodexSpawnArgsOmitsEmptyModel(t *testing.T) {
+	p := NewCodexProvider()
+	args, err := p.SpawnArgs(types.Pool{}, "task")
+	if err != nil {
+		t.Fatalf("SpawnArgs error: %v", err)
+	}
+	for _, a := range args {
+		if a == "--model" {
+			t.Fatalf("--model present despite empty Pool.Model: %v", args)
+		}
+	}
+}
+
+func TestCodexSpawnArgsIncludesFullAutoApproval(t *testing.T) {
+	p := NewCodexProvider()
+	args, err := p.SpawnArgs(types.Pool{}, "task")
+	if err != nil {
+		t.Fatalf("SpawnArgs error: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--approval-mode full-auto") {
+		t.Errorf("argv missing --approval-mode full-auto: %v", args)
+	}
+}
+
+func TestCodexChatJSONNotSupported(t *testing.T) {
+	p := NewCodexProvider()
+	if _, err := p.ChatJSON(context.Background(), types.Pool{}, "sys", "user"); err != ErrNotSupported {
+		t.Fatalf("ChatJSON returned %v, want ErrNotSupported", err)
+	}
+}
+
+func TestCodexToolChatNotSupported(t *testing.T) {
+	p := NewCodexProvider()
+	if _, err := p.ToolChat(context.Background(), types.Pool{}, ChatRequest{}); err != ErrNotSupported {
+		t.Fatalf("ToolChat returned %v, want ErrNotSupported", err)
+	}
+}
+
+// TestCodexListModelsErrorsWhenBinaryMissing verifies that ListModels returns
+// an actionable error when `codex` is not found in PATH. The test manipulates
+// PATH to guarantee the binary is absent — robust against developer machines
+// that happen to have codex installed.
+func TestCodexListModelsErrorsWhenBinaryMissing(t *testing.T) {
+	t.Setenv("PATH", "/nonexistent-empty-path")
+	p := NewCodexProvider()
+	_, err := p.ListModels(context.Background(), types.Pool{})
+	if err == nil {
+		t.Fatal("expected error when codex binary is absent, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found in PATH") {
+		t.Errorf("error message = %q, want 'not found in PATH' hint", err.Error())
+	}
+}
+
+func TestCodexRegisteredInRegistry(t *testing.T) {
+	r := NewRegistry(NewCodexProvider())
+	p, ok := r.Get(types.ProviderCodex)
+	if !ok {
+		t.Fatal("codex provider not found in registry after registration")
+	}
+	if p.Kind() != types.ProviderCodex {
+		t.Fatalf("Kind() = %s, want codex", p.Kind())
+	}
+}
+
+func TestCodexImplementsProviderInterface(t *testing.T) {
+	var _ Provider = NewCodexProvider()
+}

--- a/internal/session/codex_stream.go
+++ b/internal/session/codex_stream.go
@@ -1,0 +1,55 @@
+package session
+
+import "strings"
+
+// Quota error substrings emitted by the codex CLI when a ChatGPT subscription
+// limit is reached. Plain string contains, no regex (§10.3).
+var codexQuotaSignals = []string{
+	"exceeded your subscription quota",
+	"subscription limit reached",
+	"ChatGPT subscription",
+	"rate limit exceeded",
+	"quota exceeded",
+	"usage limit",
+	"usage cap",
+	"hit your limit",
+}
+
+// codexResetSignals are prefixes/substrings in codex quota error output that
+// precede a reset time. They're used to extract the human-readable reset time
+// from the raw reason string.
+var codexResetSignals = []string{
+	"resets at",
+	"resets on",
+	"reset at",
+	"try again after",
+	"available again at",
+}
+
+// ParseCodexQuotaError inspects a BLOCKED reason string and reports whether
+// it represents a codex subscription-quota failure. When it does, resetAt is
+// the reset-time substring extracted from the reason (empty when not found).
+func ParseCodexQuotaError(reason string) (isQuota bool, resetAt string) {
+	lower := strings.ToLower(reason)
+	for _, sig := range codexQuotaSignals {
+		if strings.Contains(lower, sig) {
+			isQuota = true
+			break
+		}
+	}
+	if !isQuota {
+		return false, ""
+	}
+	for _, sig := range codexResetSignals {
+		if i := strings.Index(lower, sig); i >= 0 {
+			// Return everything after the reset signal as the time hint.
+			suffix := strings.TrimSpace(reason[i+len(sig):])
+			// Trim trailing punctuation.
+			suffix = strings.TrimRight(suffix, ".;,")
+			if suffix != "" {
+				return true, suffix
+			}
+		}
+	}
+	return true, ""
+}

--- a/internal/session/codex_stream_test.go
+++ b/internal/session/codex_stream_test.go
@@ -1,0 +1,64 @@
+package session
+
+import "testing"
+
+func TestParseCodexQuotaError(t *testing.T) {
+	cases := []struct {
+		reason      string
+		wantQuota   bool
+		wantResetAt string
+	}{
+		{
+			reason:    "tests failed — 3 failures",
+			wantQuota: false,
+		},
+		{
+			reason:      "exceeded your subscription quota; resets at 2026-05-14 08:00 UTC",
+			wantQuota:   true,
+			wantResetAt: "2026-05-14 08:00 UTC",
+		},
+		{
+			reason:      "ChatGPT subscription limit reached — try again after midnight",
+			wantQuota:   true,
+			wantResetAt: "midnight",
+		},
+		{
+			reason:      "subscription limit reached",
+			wantQuota:   true,
+			wantResetAt: "",
+		},
+		{
+			reason:      "rate limit exceeded; resets on 2026-05-15",
+			wantQuota:   true,
+			wantResetAt: "2026-05-15",
+		},
+		{
+			reason:      "quota exceeded",
+			wantQuota:   true,
+			wantResetAt: "",
+		},
+		{
+			reason:      "hit your limit; available again at 06:00",
+			wantQuota:   true,
+			wantResetAt: "06:00",
+		},
+		{
+			reason:    "BLOCKED: lint failed — go vet exited 1",
+			wantQuota: false,
+		},
+		{
+			reason:    "",
+			wantQuota: false,
+		},
+	}
+
+	for _, tc := range cases {
+		got, resetAt := ParseCodexQuotaError(tc.reason)
+		if got != tc.wantQuota {
+			t.Errorf("ParseCodexQuotaError(%q) isQuota = %v, want %v", tc.reason, got, tc.wantQuota)
+		}
+		if resetAt != tc.wantResetAt {
+			t.Errorf("ParseCodexQuotaError(%q) resetAt = %q, want %q", tc.reason, resetAt, tc.wantResetAt)
+		}
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -193,7 +193,8 @@ type runtimeSession struct {
 
 	// Issue #101: pool model name captured at spawn time so ResolveUsage can
 	// look up per-token rates when computing estimated cost for harness sessions.
-	poolModel string
+	poolModel    string
+	poolProvider types.Provider
 	// harnessInputTokens / harnessOutputTokens accumulate token counts from
 	// the harness OnTurnUsage callback. Zero for subprocess (Claude) sessions
 	// where CostData from the stream parser is authoritative.
@@ -782,6 +783,7 @@ func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types
 		poolID:         pool.ID,
 		poolName:       pool.Name,
 		poolModel:      pool.Model,
+		poolProvider:   pool.Provider,
 		lastLineAt:     time.Now(),
 	}
 
@@ -948,6 +950,7 @@ func (m *Manager) spawnRemote(ws types.Workspace, issue types.Issue, plan types.
 		poolID:         pool.ID,
 		poolName:       pool.Name,
 		poolModel:      pool.Model,
+		poolProvider:   pool.Provider,
 		lastLineAt:     time.Now(),
 	}
 
@@ -1439,9 +1442,22 @@ func (m *Manager) matchPatterns(rs *runtimeSession, line string) {
 				reason = reason[:500]
 			}
 			rs.sess.BlockedReason = reason
+			// For codex pools, inspect the reason for subscription-quota errors
+			// and stamp a structured FailureCause with kind="subscription_quota"
+			// so the UI can surface a friendlier message (issue #281).
+			causeKind := "blocked"
+			if rs.poolProvider == types.ProviderCodex {
+				if isQuota, resetAt := ParseCodexQuotaError(reason); isQuota {
+					causeKind = "subscription_quota"
+					if resetAt != "" && !strings.Contains(reason, "resets at") {
+						reason = reason + "; resets at " + resetAt
+						rs.sess.BlockedReason = reason
+					}
+				}
+			}
 			// Stamp FailureCause so the card always has a structured reason (#30).
 			rs.sess.FailureCause = &types.FailureCause{
-				Kind:   "blocked",
+				Kind:   causeKind,
 				Reason: reason,
 			}
 			// Re-save the full JSON so BlockedReason and FailureCause survive restart.

--- a/internal/skills/bundle/skills/conductor-execute-codex.md
+++ b/internal/skills/bundle/skills/conductor-execute-codex.md
@@ -1,0 +1,102 @@
+---
+name: conductor-execute-codex
+description: Codex-adapted execute skill. Implements an approved plan on a feature branch, verifies the build, commits and pushes, then opens a draft PR. Designed for the codex CLI subprocess provider which uses its own built-in agent loop.
+---
+
+# conductor-execute-codex
+
+Bundled by PrismConductor (PRISMCONDUCTOR_PLAN.md §15.7, issue #281).
+
+> NOTE (issue #281): This skill is the codex-adapted variant of `conductor-execute`. It is
+> functionally identical in output contract — same commit/push/PR flow, same sentinels — but
+> written as a self-contained task description suitable for an autonomous agent CLI. Use this
+> as the workspace execute skill when the pool's provider is `codex`.
+>
+> The conductor spawns this skill inside a per-execute git worktree off `origin/<BASE>`.
+> The branch is pre-created. The user's primary checkout is unaffected.
+
+## Task
+
+You are an autonomous software implementation agent. Your job is to implement an approved plan on a feature branch, verify the build passes, and open a draft pull request.
+
+## Inputs
+
+- `--issue <number>` (required)
+- `--revision <N>` (required — which approved plan to execute)
+- `--repo <path>` (defaults to cwd)
+- `--resume-question <id>` (resume mode: continue after a mid-run question was answered)
+- `--related-repos <path>` (repeatable; absolute paths to sibling repositories you may grep / read for context)
+
+Parse these from the arguments you were invoked with.
+
+## Behavior
+
+These steps are mandatory. Do not edit files until you are on the feature branch.
+
+### 1. Setup
+
+1. Read `.prismconductor/plans/<issue>-rev<N>.json` (the approved plan).
+2. Read `.prismconductor/answers/<issue>-rev<N>.json` (the user's question answers, if any).
+3. Read `CLAUDE.md`, `.claude/rules/`, and understand the project's build/lint/test commands.
+
+### 2. Branch hygiene
+
+4. Verify you are on a branch named `feat/issue-<num>-<slug>` (pre-created by the conductor):
+   ```
+   git status --short   # should be empty
+   git branch --show-current   # should start with feat/issue-<num>-
+   ```
+   If either check fails: print `BLOCKED: worktree integrity check failed — <reason>` and stop.
+
+### 3. Implementation
+
+5. Implement every `files_to_modify` entry from the plan.
+6. For every `add` intent, write at least one test.
+
+### 4. Verification
+
+Set up a sandboxed data directory:
+```bash
+export PRISMCONDUCTOR_DATA_DIR="$(mktemp -d)"
+```
+
+7. Run lint / typecheck:
+   - Go: `go vet ./...`
+   - TypeScript: `npx tsc --noEmit`
+   Non-zero exit → `BLOCKED: lint failed — <command> exited <code>`.
+
+8. Build: `wails build` (or `go build ./...` for Go-only).
+   Non-zero exit → `BLOCKED: build failed — <command> exited <code>`.
+
+9. Run tests: `go test ./...` (or the project's test command).
+   Non-zero exit → `BLOCKED: tests failed — <N> failures`.
+
+### 5. Commit + push + PR
+
+10. Stage only modified files (avoid `git add -A`).
+11. Commit with a message ending with `Closes #<num>`.
+12. Push: `git push -u origin HEAD`.
+13. Create draft PR:
+    ```
+    gh pr create --draft --base <BASE> --title "<subject> (#<num>)" --body "..."
+    ```
+    PR body must include: summary, files changed, verification results, `Closes #<num>`.
+
+14. Capture the PR URL from `gh pr create`.
+
+### 6. Sentinels
+
+15. Print `PR_OPENED: <url>` on its own line.
+16. Print `Work complete.` on its own line.
+
+## Failure
+
+For any blocking failure:
+- Print `BLOCKED: <one-line reason>` as the last line and stop.
+- Do NOT print `PR_OPENED:` or `Work complete.` on a failure path.
+
+## Quota / subscription errors
+
+If the ChatGPT subscription limit is reached during execution:
+- Print `BLOCKED: ChatGPT subscription limit reached on <provider-name>; resets at <time>` and stop.
+- The conductor translates this into a `subscription_quota` failure with the reset time.

--- a/internal/skills/bundle/skills/conductor-plan-codex.md
+++ b/internal/skills/bundle/skills/conductor-plan-codex.md
@@ -1,0 +1,85 @@
+---
+name: conductor-plan-codex
+description: Codex-adapted planning skill. Reads a GitHub issue, analyzes the codebase, and emits a structured plan JSON. Designed for the codex CLI subprocess provider which uses its own built-in agent loop rather than Claude Code's slash-command skill system.
+---
+
+# conductor-plan-codex
+
+Bundled by PrismConductor. Used by codex-provider pools (PRISMCONDUCTOR_PLAN.md §15.7, issue #281).
+
+> NOTE (issue #281): This skill is the codex-adapted variant of `conductor-plan`. It is
+> functionally identical in output contract — same plan JSON schema, same sentinels — but
+> written as a self-contained task description suitable for an autonomous agent CLI that
+> does not have Claude Code's slash-command skill system. Use this as the workspace plan
+> skill when the pool's provider is `codex`.
+
+## Task
+
+You are an autonomous software planning agent. Your job is to read a GitHub issue, understand the codebase it references, and produce a structured plan JSON that a downstream execute worker can implement.
+
+## Inputs
+
+- `--issue <number>` (required)
+- `--repo <path>` (defaults to cwd)
+- `--related-repos <path>` (repeatable; absolute paths to sibling repositories you may grep / read for context)
+
+Parse these from the arguments you were invoked with.
+
+## Sibling repos (read-only)
+
+If `--related-repos` is set: the listed paths are SIBLING repositories you may grep / read for context. **Do NOT modify any file under those paths.**
+
+## Behavior
+
+1. Fetch the issue body:
+   ```
+   gh issue view <number> --json title,body,labels
+   ```
+   If this fails, print `BLOCKED: cannot fetch issue #<number>: <error>` and stop.
+
+2. Read `CLAUDE.md` (if present at `<repo>/CLAUDE.md`) and any files in `<repo>/.claude/rules/`.
+
+3. Explore the repository structure: list top-level directories, read key files relevant to the issue, grep for symbols, types, and patterns that the issue references.
+
+4. Synthesize a plan. The plan must:
+   - Identify every file that must be created or modified (with explicit `"intent": "add"` or `"intent": "modify"`).
+   - List `dependencies_detected` (issue numbers this depends on, if any are referenced in the body).
+   - Include `suggested_labels` (array of strings).
+   - Set `estimated_complexity` to one of the values defined in the workspace complexity scale (S, M, L, XL, or as shown in the prompt prefix).
+   - Set `ready_to_execute` to `true` only when all questions have defaults or are answered.
+   - Set `goal_summary` (1-2 sentences) and `executive_summary` (2-3 sentences) and `plan_markdown` (full Markdown description of the approach).
+   - If clarifying questions are needed before implementation can begin, add them to the `questions` array. Each question must have `id`, `type` (`single_choice` or `yes_no`), `prompt`, `options` (for single_choice), `default`, and `required` fields.
+
+5. Write the plan JSON to `.prismconductor/plans/<issue>-rev<N>.json` where `<N>` is the next revision number (1 for a new issue, previous+1 for re-plans). The schema:
+
+```json
+{
+  "issue_number": <number>,
+  "revision": <N>,
+  "goal_summary": "...",
+  "executive_summary": "...",
+  "plan_markdown": "...",
+  "files_to_modify": [
+    {"path": "...", "intent": "add|modify"}
+  ],
+  "dependencies_detected": [],
+  "suggested_labels": [],
+  "questions": [],
+  "estimated_complexity": "M",
+  "ready_to_execute": true
+}
+```
+
+6. After writing the file, print the sentinel on its own line:
+   ```
+   Plan written to .prismconductor/plans/<issue>-rev<N>.json
+   ```
+   This is mandatory — the conductor parses this line to advance the card state.
+
+7. Print `Work complete.` on its own line.
+
+## Failure
+
+If anything blocks you from completing a valid plan:
+- Print `BLOCKED: <one-line reason>` on its own line and stop.
+- Do NOT write a partial plan file.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -333,6 +333,12 @@ const (
 	// the native API can round-trip `thought_signature` for thinking-tier
 	// models. First trial of the any-llm-go integration.
 	ProviderGemini Provider = "gemini"
+	// ProviderCodex routes inference through the local `codex` CLI binary
+	// (OpenAI's agent CLI) using the same PTY subprocess pattern as Claude.
+	// Auth is managed by the codex CLI itself (browser OAuth against a
+	// ChatGPT subscription); no API key is stored in the conductor.
+	// Pool capacity defaults to 1 — subscription limits are per-account.
+	ProviderCodex Provider = "codex"
 )
 
 // --- Goal (§6.2) ---


### PR DESCRIPTION
## Summary

- Adds `codex` as a new provider kind that routes inference through OpenAI's `codex` CLI binary (browser OAuth / ChatGPT subscription) using the same PTY subprocess pattern as the existing Claude provider
- Maps codex subscription-quota errors to `failure_cause.kind = "subscription_quota"` so the UI can surface a friendlier message with reset time
- Hides endpoint/API-key fields in pool/provider UIs for codex; adds a help note directing users to `codex login`

## Files modified

| File | Change |
|------|--------|
| `internal/types/types.go` | Add `ProviderCodex = "codex"` constant |
| `internal/llm/codex.go` | New provider client — binary detection, static model list, SpawnArgs with `--approval-mode full-auto` |
| `internal/llm/codex_test.go` | Unit tests for provider interface, SpawnArgs, ListModels, ErrNotSupported contracts |
| `internal/session/codex_stream.go` | Quota error detection — `ParseCodexQuotaError(reason)` |
| `internal/session/codex_stream_test.go` | Table tests for quota error parsing |
| `internal/session/manager.go` | Add `poolProvider` to `runtimeSession`; BLOCKED handler sets `kind="subscription_quota"` for codex quota errors |
| `app.go` | Register `NewCodexProvider()` in provider registry |
| `internal/skills/bundle/skills/conductor-plan-codex.md` | Codex-adapted plan skill (self-contained task description for autonomous agent CLI) |
| `internal/skills/bundle/skills/conductor-execute-codex.md` | Codex-adapted execute skill |
| `frontend/src/components/PoolEditModal.tsx` | Hide endpoint/key for codex; amber help text → `codex login`; auto-reset capacity to 1 on provider switch |
| `frontend/src/components/ProvidersPanel.tsx` | Same endpoint/key hiding + help text in provider edit modal |

## Verification

| Gate | Command | Result |
|------|---------|--------|
| Go vet | `go vet prismconductor/internal/types prismconductor/internal/llm prismconductor/internal/session` | ✅ pass |
| TypeScript typecheck | `npx tsc --noEmit` (frontend) | ✅ pass |
| Build | Frontend `npm run build` (creates dist) | ✅ pass |
| Smoke test | `npx --prefix tests playwright test tests/e2e/startup.spec.ts` | ✅ pass (1/1 — app boots, React mounts, no console errors) |
| Unit tests | `go test prismconductor/internal/llm prismconductor/internal/session prismconductor/internal/types` | ✅ pass (12 new codex tests + all existing tests) |

Commit tier: **Tier 1** (GitHub API signed commit)

## Notes for reviewers

- **Spike deferred**: per Q2, the `codex` binary was not available on the build machine. `conductor-plan-codex.md` and `conductor-execute-codex.md` are included as self-contained task descriptions for an autonomous agent CLI; they should be validated against actual `codex` invocations and updated if needed.
- **Skill prompt plumbing**: for subprocess providers, `skillMarkdown` is currently not injected into the child process (it's only used by the harness strategy. Codex pools will receive  as the task unless the workspace is reconfigured to use the codex-specific skill files via a mechanism that injects skill content for subprocess providers (follow-up).
- **Model list**: static (no listing API on codex CLI). Update  in  as new models are confirmed.

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-281

Closes #281
EOF
)