### PR TITLE
feat(frontend): rank models by fit in dropdowns, silence unknown badge (#280)

### DIFF
--- a/frontend/src/components/ModelSelect.tsx
+++ b/frontend/src/components/ModelSelect.tsx
@@ -1,5 +1,7 @@
+import { llm } from "../../wailsjs/go/models";
 import { noAutoCorrect } from "../lib/inputs";
 import { useModelsStore } from "../stores/modelsStore";
+import { fitForRole, fitOptionPrefix, fitOptionDescriptor, sortModelsByFit } from "./fitGlyph";
 
 type Props = {
   provider: string;
@@ -7,15 +9,48 @@ type Props = {
   apiKey: string;
   value: string;
   onChange: (v: string) => void;
+  role?: string;
+  hints?: Record<string, llm.ModelHint | null>;
 };
 
-export function ModelSelect({ provider, endpoint, apiKey, value, onChange }: Props) {
+function fmtCtx(n: number): string {
+  if (!n) return "—";
+  if (n >= 1000000) return `${(n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 1)}M`;
+  if (n >= 1000) return `${Math.round(n / 1000)}k`;
+  return String(n);
+}
+
+function hintTooltip(hint: llm.ModelHint, role: string): string {
+  const fit = fitForRole(hint, role);
+  const toolLabel =
+    hint.tool_support === "full"
+      ? "Tools: full"
+      : hint.tool_support === "partial"
+      ? "Tools: partial"
+      : "Tools: none";
+  return [
+    `Fit for ${role}: ${fit || "unknown"}`,
+    toolLabel,
+    hint.context_window ? `Context: ${fmtCtx(hint.context_window)} tokens` : null,
+    hint.cost_tier ? `Cost tier: ${hint.cost_tier}` : null,
+    hint.notes || null,
+    `Source: ${hint.source || "bundled"}`,
+    hint.updated_at ? `Updated: ${hint.updated_at}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function ModelSelect({ provider, endpoint, apiKey, value, onChange, role, hints }: Props) {
   const entry = useModelsStore((s) => s.getEntry(provider, endpoint));
   const { invalidate, fetch } = useModelsStore();
 
   const models = entry?.models ?? [];
   const loading = entry?.loading ?? false;
   const error = entry?.error ?? null;
+
+  const displayModels =
+    role && hints && models.length > 0 ? sortModelsByFit(models, hints, role) : models;
 
   async function handleRefresh() {
     invalidate(provider, endpoint);
@@ -35,11 +70,18 @@ export function ModelSelect({ provider, endpoint, apiKey, value, onChange }: Pro
           className="flex-1 bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-100"
         >
           <option value="">— pick a model —</option>
-          {models.map((m) => (
-            <option key={m} value={m}>
-              {m}
-            </option>
-          ))}
+          {displayModels.map((m) => {
+            const hint = role && hints ? (hints[m] ?? null) : null;
+            const prefix = role && hints ? fitOptionPrefix(hint, role) : "";
+            const descriptor = role && hints ? fitOptionDescriptor(hint, role) : "";
+            const title =
+              role && hint ? hintTooltip(hint, role) : undefined;
+            return (
+              <option key={m} value={m} title={title}>
+                {prefix}{m}{descriptor}
+              </option>
+            );
+          })}
         </select>
       ) : (
         <input

--- a/frontend/src/components/PoolEditModal.tsx
+++ b/frontend/src/components/PoolEditModal.tsx
@@ -31,14 +31,7 @@ function ModelCapabilityBadge({
   const fit = fitForRole(hint, role);
 
   if (!hint) {
-    return (
-      <span
-        className="inline-flex items-center gap-1 text-[10px] italic text-slate-500"
-        title="No capability data for this model. It may work but is unverified."
-      >
-        ? unknown model
-      </span>
-    );
+    return null;
   }
 
   const toolLabel =
@@ -107,14 +100,7 @@ function ModelCapabilityBadge({
         </span>
       );
     default:
-      return (
-        <span
-          className="inline-flex items-center gap-1 text-[10px] italic text-slate-500"
-          title={tooltip}
-        >
-          ? unknown fit for {role}
-        </span>
-      );
+      return null;
   }
 }
 
@@ -206,6 +192,7 @@ export function PoolEditModal({
   const [busy, setBusy] = useState(false);
   const [saveErr, setSaveErr] = useState<string>("");
   const [modelHint, setModelHint] = useState<llm.ModelHint | null>(null);
+  const [modelHints, setModelHints] = useState<Record<string, llm.ModelHint | null>>({});
 
   const providerInfo = useMemo(
     () => providers.find((p) => p.kind === providerKind),
@@ -278,13 +265,15 @@ export function PoolEditModal({
       .catch(() => setModelHint(null));
   }, [providerKind, model]);
 
-  // On add-mode with a role set, auto-select the cheapest suitable model once
-  // the model list loads. Never clobbers a user-typed value.
+  // Fetch hints for all models (both add and edit mode) to populate the
+  // dropdown labels and sort order. Auto-select the cheapest suitable model
+  // in add mode only, and only when the user has not already typed a value.
   useEffect(() => {
-    if (initial) return;
-    if (userEditedModel.current) return;
     const models = modelEntry?.models ?? [];
-    if (models.length === 0) return;
+    if (models.length === 0) {
+      setModelHints({});
+      return;
+    }
 
     let canceled = false;
     Promise.all(
@@ -294,7 +283,12 @@ export function PoolEditModal({
           .catch(() => ({ model: m, hint: null as llm.ModelHint | null })),
       ),
     ).then((entries) => {
-      if (canceled || userEditedModel.current) return;
+      if (canceled) return;
+      const hintsMap: Record<string, llm.ModelHint | null> = {};
+      entries.forEach(({ model: m, hint: h }) => { hintsMap[m] = h; });
+      setModelHints(hintsMap);
+
+      if (initial || userEditedModel.current) return;
       const candidates = entries.filter(({ hint }) => {
         if (!hint) return false;
         const fit = fitForRole(hint, role);
@@ -527,6 +521,8 @@ export function PoolEditModal({
               apiKey={apiKey}
               value={model}
               onChange={(v) => { userEditedModel.current = true; setModel(v); }}
+              role={role}
+              hints={modelHints}
             />
             {model && (
               <div className="mt-1">

--- a/frontend/src/components/SkillProfileEditor.tsx
+++ b/frontend/src/components/SkillProfileEditor.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { DiscoverWorkspaceSkills, GetModelHint, ListPools, UpdateWorkspace } from "../../wailsjs/go/main/App";
 import { llm, types, workerpool } from "../../wailsjs/go/models";
 import { useWorkspaceStore } from "../stores/workspaceStore";
 import { SkillDropdown } from "./SkillDropdown";
 import { noAutoCorrect } from "../lib/inputs";
-import { fitOptionSuffix } from "./fitGlyph";
+import { costRank, fitForRole, fitOptionSuffix, fitRank } from "./fitGlyph";
 
 type SkillMode = "bundled" | "hybrid" | "native";
 const MODES: SkillMode[] = ["bundled", "hybrid", "native"];
@@ -233,6 +233,22 @@ function PoolPicker({
     });
   }, [pools]);
 
+  const sortedPools = useMemo(
+    () =>
+      [...pools].sort((a, b) => {
+        const hintA = hints[a.pool.id] ?? null;
+        const hintB = hints[b.pool.id] ?? null;
+        const rankDiff =
+          fitRank(fitForRole(hintB, role)) - fitRank(fitForRole(hintA, role));
+        if (rankDiff !== 0) return rankDiff;
+        const costDiff =
+          costRank(hintA?.cost_tier ?? "") - costRank(hintB?.cost_tier ?? "");
+        if (costDiff !== 0) return costDiff;
+        return a.pool.name.localeCompare(b.pool.name);
+      }),
+    [pools, hints, role],
+  );
+
   return (
     <label className="block">
       <div className="text-xs text-slate-500 mb-1">{label}</div>
@@ -242,7 +258,7 @@ function PoolPicker({
         className="w-full bg-slate-950 border border-slate-700 rounded px-2 py-1 text-slate-200 text-xs"
       >
         <option value="">(any compatible)</option>
-        {pools.map((row) => {
+        {sortedPools.map((row) => {
           const hint = hints[row.pool.id] ?? null;
           const suffix = fitOptionSuffix(hint, role);
           return (

--- a/frontend/src/components/fitGlyph.test.ts
+++ b/frontend/src/components/fitGlyph.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { fitForRole, fitOptionSuffix, costRank, meetsThreshold } from "./fitGlyph";
+import {
+  fitForRole,
+  fitOptionSuffix,
+  fitOptionPrefix,
+  fitOptionDescriptor,
+  fitRank,
+  sortModelsByFit,
+  costRank,
+  meetsThreshold,
+} from "./fitGlyph";
 import { llm } from "../../wailsjs/go/models";
 
 function hint(overrides: Partial<llm.ModelHint> = {}): llm.ModelHint {
@@ -67,6 +76,20 @@ describe("costRank", () => {
   });
 });
 
+describe("fitRank", () => {
+  it("excellent > good > fair > poor > unsuitable > unknown", () => {
+    expect(fitRank("excellent")).toBeGreaterThan(fitRank("good"));
+    expect(fitRank("good")).toBeGreaterThan(fitRank("fair"));
+    expect(fitRank("fair")).toBeGreaterThan(fitRank("poor"));
+    expect(fitRank("poor")).toBeGreaterThan(fitRank("unsuitable"));
+    expect(fitRank("unsuitable")).toBeGreaterThan(fitRank(""));
+  });
+  it("unknown/empty returns 0", () => {
+    expect(fitRank("")).toBe(0);
+    expect(fitRank("unknown")).toBe(0);
+  });
+});
+
 describe("fitOptionSuffix", () => {
   it("returns checkmark for excellent/good", () => {
     expect(fitOptionSuffix(hint({ plan_fit: "excellent" }), "plan")).toBe(" ✓");
@@ -81,7 +104,90 @@ describe("fitOptionSuffix", () => {
   it("returns cross for unsuitable", () => {
     expect(fitOptionSuffix(hint({ plan_fit: "unsuitable" }), "plan")).toBe(" ✗ (Unsuitable)");
   });
-  it("returns (?) for null hint", () => {
-    expect(fitOptionSuffix(null, "plan")).toBe(" (?)");
+  it("returns empty string for null hint", () => {
+    expect(fitOptionSuffix(null, "plan")).toBe("");
+  });
+  it("returns empty string when hint present but role fit is empty", () => {
+    expect(fitOptionSuffix(hint({ plan_fit: "" }), "plan")).toBe("");
+  });
+});
+
+describe("fitOptionPrefix", () => {
+  it("returns leading checkmark for excellent", () => {
+    expect(fitOptionPrefix(hint({ plan_fit: "excellent" }), "plan")).toBe("✓ ");
+  });
+  it("returns leading checkmark for good", () => {
+    expect(fitOptionPrefix(hint({ plan_fit: "good" }), "plan")).toBe("✓ ");
+  });
+  it("returns leading dot for fair", () => {
+    expect(fitOptionPrefix(hint({ plan_fit: "fair" }), "plan")).toBe("· ");
+  });
+  it("returns leading warning for poor", () => {
+    expect(fitOptionPrefix(hint({ plan_fit: "poor" }), "plan")).toBe("⚠ ");
+  });
+  it("returns leading cross for unsuitable", () => {
+    expect(fitOptionPrefix(hint({ plan_fit: "unsuitable" }), "plan")).toBe("✗ ");
+  });
+  it("returns empty string for null hint", () => {
+    expect(fitOptionPrefix(null, "plan")).toBe("");
+  });
+  it("returns empty string when hint present but role fit is empty", () => {
+    expect(fitOptionPrefix(hint({ plan_fit: "" }), "plan")).toBe("");
+  });
+});
+
+describe("fitOptionDescriptor", () => {
+  it("returns (Fit · cost) when hint present with fit and cost", () => {
+    expect(fitOptionDescriptor(hint({ plan_fit: "excellent", cost_tier: "high" }), "plan")).toBe(" (Excellent · high)");
+  });
+  it("returns (Fit) when hint present with fit but no cost tier", () => {
+    expect(fitOptionDescriptor(hint({ plan_fit: "good", cost_tier: "" }), "plan")).toBe(" (Good)");
+  });
+  it("returns empty string for null hint", () => {
+    expect(fitOptionDescriptor(null, "plan")).toBe("");
+  });
+  it("returns empty string when fit is empty", () => {
+    expect(fitOptionDescriptor(hint({ plan_fit: "" }), "plan")).toBe("");
+  });
+});
+
+describe("sortModelsByFit", () => {
+  const modelsHints: Record<string, llm.ModelHint | null> = {
+    "model-excellent-high": hint({ plan_fit: "excellent", cost_tier: "high" }),
+    "model-excellent-low": hint({ plan_fit: "excellent", cost_tier: "low" }),
+    "model-good": hint({ plan_fit: "good", cost_tier: "medium" }),
+    "model-fair": hint({ plan_fit: "fair", cost_tier: "low" }),
+    "model-unknown-1": null,
+    "model-unknown-2": null,
+  };
+
+  it("sorts by descending fit rank", () => {
+    const models = ["model-fair", "model-good", "model-excellent-low"];
+    const sorted = sortModelsByFit(models, modelsHints, "plan");
+    expect(sorted[0]).toBe("model-excellent-low");
+    expect(sorted[1]).toBe("model-good");
+    expect(sorted[2]).toBe("model-fair");
+  });
+
+  it("uses cost as tiebreaker within the same fit level", () => {
+    const models = ["model-excellent-high", "model-excellent-low"];
+    const sorted = sortModelsByFit(models, modelsHints, "plan");
+    expect(sorted[0]).toBe("model-excellent-low");
+    expect(sorted[1]).toBe("model-excellent-high");
+  });
+
+  it("unknown-hint models sort last, then alphabetically", () => {
+    const models = ["model-unknown-2", "model-fair", "model-unknown-1"];
+    const sorted = sortModelsByFit(models, modelsHints, "plan");
+    expect(sorted[0]).toBe("model-fair");
+    expect(sorted[1]).toBe("model-unknown-1");
+    expect(sorted[2]).toBe("model-unknown-2");
+  });
+
+  it("does not mutate the input array", () => {
+    const models = ["model-fair", "model-good"];
+    const copy = [...models];
+    sortModelsByFit(models, modelsHints, "plan");
+    expect(models).toEqual(copy);
   });
 });

--- a/frontend/src/components/fitGlyph.tsx
+++ b/frontend/src/components/fitGlyph.tsx
@@ -42,7 +42,7 @@ export function meetsThreshold(fit: Fit, role: string): boolean {
 
 /**
  * Short text label appended to a native <select> option for the given hint.
- * Returns empty string when no hint is available.
+ * Returns empty string when no hint is available or fit is unknown.
  */
 export function fitOptionSuffix(hint: llm.ModelHint | null, role: string): string {
   const fit = fitForRole(hint, role);
@@ -52,6 +52,61 @@ export function fitOptionSuffix(hint: llm.ModelHint | null, role: string): strin
     case "fair":      return " ◦";
     case "poor":      return " ⚠ (Poor fit)";
     case "unsuitable": return " ✗ (Unsuitable)";
-    default:          return " (?)";
+    default:          return "";
   }
+}
+
+/** Numeric fit rank — higher is better. Unknown/empty → 0. */
+const FIT_RANK: Record<string, number> = {
+  excellent: 5,
+  good: 4,
+  fair: 3,
+  poor: 2,
+  unsuitable: 1,
+};
+
+export function fitRank(fit: string): number {
+  return FIT_RANK[fit] ?? 0;
+}
+
+/** Leading glyph prefix for use at the start of a dropdown option label. */
+export function fitOptionPrefix(hint: llm.ModelHint | null, role: string): string {
+  const fit = fitForRole(hint, role);
+  switch (fit) {
+    case "excellent": return "✓ ";
+    case "good":      return "✓ ";
+    case "fair":      return "· ";
+    case "poor":      return "⚠ ";
+    case "unsuitable": return "✗ ";
+    default:          return "";
+  }
+}
+
+/** Parenthetical descriptor appended after the model name: " (Excellent · high)". */
+export function fitOptionDescriptor(hint: llm.ModelHint | null, role: string): string {
+  const fit = fitForRole(hint, role);
+  if (!fit) return "";
+  const label = fit.charAt(0).toUpperCase() + fit.slice(1);
+  const cost = hint?.cost_tier ?? "";
+  return cost ? ` (${label} · ${cost})` : ` (${label})`;
+}
+
+/**
+ * Sorts a model list by descending fit rank, then ascending cost rank, then
+ * alphabetical. Models with no hint data sort to the end.
+ */
+export function sortModelsByFit(
+  models: string[],
+  hints: Record<string, llm.ModelHint | null>,
+  role: string,
+): string[] {
+  return [...models].sort((a, b) => {
+    const hintA = hints[a] ?? null;
+    const hintB = hints[b] ?? null;
+    const rankDiff = fitRank(fitForRole(hintB, role)) - fitRank(fitForRole(hintA, role));
+    if (rankDiff !== 0) return rankDiff;
+    const costDiff = costRank(hintA?.cost_tier ?? "") - costRank(hintB?.cost_tier ?? "");
+    if (costDiff !== 0) return costDiff;
+    return a.toLowerCase().localeCompare(b.toLowerCase());
+  });
 }


### PR DESCRIPTION
## Summary

- Dropdown options now show a leading glyph + `(Fit · Cost)` descriptor (e.g. `✓ claude-opus-4-7 (Excellent · high)`) and are sorted by descending fit rank with cost as tiebreaker, so the best+cheapest model floats to the top.
- Models with no capability data appear bare at the bottom with no annotation.
- The post-selection badge under the model selector now returns `null` for both no-hint and blank-fit cases (silence instead of `? unknown model`).
- `PoolPicker` in workspace SkillProfile settings now ranks pools by role fit with the same sort order; unknown pools render as `name · provider` with no trailing `(?)`.

## Files modified

- `frontend/src/components/fitGlyph.tsx` — added `fitRank`, `fitOptionPrefix`, `fitOptionDescriptor`, `sortModelsByFit`; `fitOptionSuffix` default branch now returns `""`
- `frontend/src/components/fitGlyph.test.ts` — updated null-hint tests, added tests for all new helpers (34 tests total)
- `frontend/src/components/ModelSelect.tsx` — accepts optional `role` + `hints` props; sorts and labels options when provided
- `frontend/src/components/PoolEditModal.tsx` — adds `modelHints` state; bulk-fetches hints in both add and edit mode; passes `role`/`hints` to `ModelSelect`; `ModelCapabilityBadge` returns `null` for no-hint and blank-fit cases
- `frontend/src/components/SkillProfileEditor.tsx` — `PoolPicker` sorts pool options by fit rank + cost tiebreaker

## Verification

| Check | Command | Result |
|-------|---------|--------|
| TypeScript | `./node_modules/.bin/tsc --noEmit` | ✅ pass |
| Vite build | `./node_modules/.bin/vite build` | ✅ pass (360 modules) |
| Frontend tests | `./node_modules/.bin/vitest run` | ✅ 160/160 pass |
| go vet | `go vet ./...` | ✅ pass |
| Go tests | `go test ./...` | ✅ all packages pass |
| Smoke test | Playwright startup spec | ⚠ skipped — requires `wails dev` boot (240s) in this worktree; frontend-only change, no Go files modified |

Commit tier: Tier 2b (unsigned local commit; signing not enforced on base branch)

Workspace mode: per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-280

Closes #280