### PR TITLE
feat(#293): skill outcome log + curator skill (phase A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,3 +36,4 @@ Intended for support engineers and power users diagnosing UI/backend state drift
 ## Verification skills
 
 - **`/bug-hunter-state`** — scans the conductor's persistent state (SQLite DB, `workspaces.json`, transcripts dir, live process table) for 12 known broken-state patterns and writes a timestamped `{findings}` JSON + Markdown report to `.prismconductor/bug-hunter/`. Read-only; never mutates state. Invoke on demand or schedule with `/loop 24h /bug-hunter-state`. Reports land in `.prismconductor/bug-hunter/<RFC3339>.{json,md}`; `latest.json` always points to the most recent run.
+- **`/conductor-skill-curator`** — reads the `skill_outcomes` log for a named skill (e.g. `--skill bundled:conductor-plan`), detects repeated failure patterns, and proposes targeted markdown edits. Read-only; never mutates skill files. Reports land in `.prismconductor/skill-curator/<RFC3339>.{json,md}`; `latest.json` always points to the most recent run. See §15.12.

--- a/PRISMCONDUCTOR_PLAN.md
+++ b/PRISMCONDUCTOR_PLAN.md
@@ -1276,3 +1276,58 @@ Before Phase 7 starts, resolve:
 ---
 
 **End of plan. Hand this to an agent. Build Phase 1 first. Ship it before touching Phase 2.**
+
+---
+
+## §15.12 Skill Outcome Log + Curator (issue #293, phase A)
+
+### Overview
+
+PrismConductor's bundled skills are static markdown files. When a skill produces bad plans or repeated failures, the user must notice the pattern manually and hand-edit the skill. §15.12 adds the foundation for self-improving skills: a per-session outcome log and a manual curator skill that analyses it.
+
+### Data contract: `skill_outcomes` table
+
+Written once per session at terminal state transition. `session_id` is the PK — upserts are safe.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `session_id` | TEXT PK | matches `sessions.id` |
+| `workspace_id` | TEXT | |
+| `issue_number` | INTEGER | |
+| `skill_path` | TEXT | `"bundled:<name>"` \| absolute path \| `""` |
+| `skill_hash` | TEXT | sha256 hex at spawn time, or `"fallback:harness"` |
+| `mode` | TEXT | `"plan"` \| `"execute"` |
+| `outcome` | TEXT | `"success"` \| `"failed"` \| `"blocked"` \| `"needs_pr"` |
+| `blocked_reason` | TEXT | from `session.BlockedReason`; `""` on success |
+| `user_action` | TEXT | `""` in phase A; filled by phase B Approve/Reject hooks |
+| `cost_cents` | REAL | `session.EstimatedCostCents` |
+| `duration_ms` | INTEGER | `EndedAt - StartedAt` |
+| `transcript_path` | TEXT | absolute path to the session transcript log |
+| `captured_at` | INTEGER | Unix epoch seconds |
+
+**Key design invariant:** `skill_hash` is computed from the skill markdown **at spawn time** and stored on `Session.SkillHash`. Re-hashing at session end would capture any curator-edits made between spawn and completion, making A/B comparisons meaningless. The `Session.SkillPath` and `Session.SkillHash` fields are `omitempty` so old session JSON deserialises cleanly.
+
+### Outcome derivation
+
+| Terminal `sess.State` | `outcome` |
+|----------------------|-----------|
+| `completed` | `success` |
+| `failed` | `failed` |
+| `blocked` | `blocked` |
+| `needs_pr` | `needs_pr` |
+
+`user_rejected` / `force_replanned` / `approved` / `refined` user actions are phase B (require PlanModal hooks). Phase A leaves `user_action` empty.
+
+### Skill hash
+
+`internal/skills/versioning.go::HashSkillMarkdown(content []byte) string` — SHA-256 hex of the raw skill markdown bytes. Called by `internal/session/manager.go::loadSkillMarkdown` which now returns `(content, path, hash)`.
+
+### Curator skill
+
+`internal/skills/bundle/skills/conductor-skill-curator.md` — bundled, read-only. Inputs: `--skill <path>`, `--window-days <N=30>`. Reads `conductor.db` via `sqlite3` CLI (same pattern as `bug-hunter-state`). Writes findings to `.prismconductor/skill-curator/<RFC3339>.{json,md}` + `latest.json`. Proposes `{old_text, new_text}` patches per detected failure pattern; never applies them.
+
+### Phase B / C / D (deferred)
+
+- **Phase B** — Skill Curator review modal + `ApplySkillEdit` Wails method writing per-workspace `.prismconductor/skills/<name>.md` overrides.
+- **Phase C** — Skill versioning + A/B variant routing in `SpawnPlan`/`SpawnExecute`. `skill_hash` already recorded, making the comparison query straightforward.
+- **Phase D** — Periodic `/loop` cron integration. Depends on a separate in-app scheduler (PrismConductor has no native cron today).

--- a/app.go
+++ b/app.go
@@ -494,6 +494,9 @@ func (a *App) handleSessionStateChange(sess types.Session, prev types.SessionSta
 		return
 	}
 
+	// Issue #293: write a skill_outcomes row on every terminal state transition.
+	a.recordSkillOutcome(sess)
+
 	// Issue #211: when an execute session pauses for a peer-agent question,
 	// try to auto-route it to an architect pool before surfacing to the user.
 	if sess.State == types.StatePausedForQuestion && sess.PendingQuestionID != "" {
@@ -600,6 +603,59 @@ func (a *App) handleSessionStateChange(sess types.Session, prev types.SessionSta
 			"action":       "focus_card",
 		})
 	}
+}
+
+// recordSkillOutcome writes a skill_outcomes row for a terminal session
+// transition (§15.12). Idempotent via upsert on session_id.
+func (a *App) recordSkillOutcome(sess types.Session) {
+	if a.store == nil {
+		return
+	}
+	outcome := terminalStateToOutcome(sess.State)
+	if outcome == "" {
+		return
+	}
+	var durMs int64
+	if sess.EndedAt != nil {
+		durMs = sess.EndedAt.Sub(sess.StartedAt).Milliseconds()
+	}
+	skillHash := sess.SkillHash
+	if skillHash == "" {
+		skillHash = "fallback:harness"
+	}
+	o := types.SkillOutcome{
+		SessionID:      sess.ID,
+		WorkspaceID:    sess.WorkspaceID,
+		IssueNumber:    sess.IssueNumber,
+		SkillPath:      sess.SkillPath,
+		SkillHash:      skillHash,
+		Mode:           string(sess.Mode),
+		Outcome:        outcome,
+		BlockedReason:  sess.BlockedReason,
+		CostCents:      sess.EstimatedCostCents,
+		DurationMs:     durMs,
+		TranscriptPath: sess.Transcript,
+		CapturedAt:     time.Now().Unix(),
+	}
+	if err := a.store.RecordSkillOutcome(o); err != nil {
+		log.Printf("RecordSkillOutcome session %s: %v", sess.ID, err)
+	}
+}
+
+// terminalStateToOutcome maps a terminal session state to the outcome string
+// stored in skill_outcomes. Returns "" for non-terminal states.
+func terminalStateToOutcome(state types.SessionState) string {
+	switch state {
+	case types.StateCompleted:
+		return "success"
+	case types.StateFailed:
+		return "failed"
+	case types.StateBlocked:
+		return "blocked"
+	case types.StateNeedsPR:
+		return "needs_pr"
+	}
+	return ""
 }
 
 // notificationsSuppressed returns true when notifications are currently muted

--- a/app_test.go
+++ b/app_test.go
@@ -385,6 +385,70 @@ func TestHandleSessionStateChange_RollsBackToReviewWhenPROpen(t *testing.T) {
 	}
 }
 
+// Issue #293: a terminal execute session must write a skill_outcomes row.
+func TestHandleSessionStateChange_WritesSkillOutcomeOnFailed(t *testing.T) {
+	s, err := store.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	const wsID = "ws1"
+	const issueNum = 55
+	if _, err := s.SaveIssue(types.Issue{
+		WorkspaceID: wsID,
+		Number:      issueNum,
+		Title:       "outcome test issue",
+		State:       "open",
+		Column:      types.ColInProgress,
+	}); err != nil {
+		t.Fatalf("SaveIssue: %v", err)
+	}
+
+	now := time.Now()
+	ended := now.Add(30 * time.Second)
+	failedSess := types.Session{
+		ID:               "sess-outcome-test",
+		WorkspaceID:      wsID,
+		IssueNumber:      issueNum,
+		Mode:             types.ModeExecute,
+		State:            types.StateFailed,
+		StartedAt:        now,
+		EndedAt:          &ended,
+		BlockedReason:    "build failed",
+		SkillPath:        "bundled:conductor-execute",
+		SkillHash:        "deadbeef1234",
+		EstimatedCostCents: 2.5,
+	}
+
+	a := &App{store: s, bus: eventbus.New()}
+	a.handleSessionStateChange(failedSess, types.StateRunning)
+
+	rows, err := s.ListSkillOutcomes("bundled:conductor-execute", now.Unix()-1, 10)
+	if err != nil {
+		t.Fatalf("ListSkillOutcomes: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 skill_outcomes row, got %d", len(rows))
+	}
+	got := rows[0]
+	if got.SessionID != "sess-outcome-test" {
+		t.Errorf("session_id = %q", got.SessionID)
+	}
+	if got.Outcome != "failed" {
+		t.Errorf("outcome = %q, want %q", got.Outcome, "failed")
+	}
+	if got.SkillHash != "deadbeef1234" {
+		t.Errorf("skill_hash = %q", got.SkillHash)
+	}
+	if got.BlockedReason != "build failed" {
+		t.Errorf("blocked_reason = %q", got.BlockedReason)
+	}
+	if got.DurationMs != 30000 {
+		t.Errorf("duration_ms = %d, want 30000", got.DurationMs)
+	}
+}
+
 // Issue #247: when an execute session fails with NO open PR, the card must
 // NOT be rolled back to REVIEW (preserve existing behaviour).
 func TestHandleSessionStateChange_NoRollbackWhenNoPR(t *testing.T) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1288,11 +1288,11 @@ export namespace main {
 	    needs_api_key: boolean;
 	    can_spawn: boolean;
 	    api_key_help_url: string;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new ProviderInfo(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.kind = source["kind"];
@@ -1606,6 +1606,8 @@ export namespace types {
 	    reason?: string;
 	    exit_code?: number;
 	    signal?: string;
+	    // Go type: time
+	    retry_after?: any;
 	
 	    static createFrom(source: any = {}) {
 	        return new FailureCause(source);
@@ -1617,7 +1619,26 @@ export namespace types {
 	        this.reason = source["reason"];
 	        this.exit_code = source["exit_code"];
 	        this.signal = source["signal"];
+	        this.retry_after = this.convertValues(source["retry_after"], null);
 	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
 	}
 	export class FileIntent {
 	    path: string;
@@ -2332,6 +2353,8 @@ export namespace types {
 	    failure_cause?: FailureCause;
 	    retry_attempt?: number;
 	    retry_of_session_id?: string;
+	    skill_path?: string;
+	    skill_hash?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new Session(source);
@@ -2364,6 +2387,8 @@ export namespace types {
 	        this.failure_cause = this.convertValues(source["failure_cause"], FailureCause);
 	        this.retry_attempt = source["retry_attempt"];
 	        this.retry_of_session_id = source["retry_of_session_id"];
+	        this.skill_path = source["skill_path"];
+	        this.skill_hash = source["skill_hash"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/session/harness_test.go
+++ b/internal/session/harness_test.go
@@ -71,7 +71,7 @@ func spawnHarnessSession(t *testing.T, behavior string) (sess *types.Session, m 
 	pool := types.Pool{ID: "pool-h", Provider: controlledProviderKind}
 
 	var err error
-	sess, err = m.spawnWithDir(ws, issue, types.ModePlan, nil, "test prompt", "", "", pool, "")
+	sess, err = m.spawnWithDir(ws, issue, types.ModePlan, nil, "test prompt", "", "", pool, "", "", "fallback:harness")
 	if err != nil {
 		t.Fatalf("spawnWithDir: %v", err)
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -23,31 +23,34 @@ import (
 	"prismconductor/internal/harness"
 	"prismconductor/internal/llm"
 	"prismconductor/internal/remoteworker"
+	"prismconductor/internal/skills"
 	"prismconductor/internal/skills/bundle"
 	"prismconductor/internal/types"
 )
 
 // loadSkillMarkdown reads the skill markdown for the given stage from the
-// workspace's PerStage configuration. Returns empty string (not an error) when
-// no per-stage skill is configured — the harness falls through to its legacy
-// mode logic.
-func loadSkillMarkdown(ws types.Workspace, stage types.ConductorStage) string {
+// workspace's PerStage configuration. Returns (content, skillPath, skillHash).
+// When no per-stage skill is configured or the file cannot be read, content is
+// "" and skillPath is "" and skillHash is "fallback:harness" — the harness
+// falls through to its legacy mode logic.
+func loadSkillMarkdown(ws types.Workspace, stage types.ConductorStage) (content, skillPath, skillHash string) {
 	ref, ok := ws.SkillProfile.SkillForStage(stage)
 	if !ok {
-		return ""
+		return "", "", "fallback:harness"
 	}
 	switch ref.Source {
 	case "bundled":
 		name := strings.TrimPrefix(ref.Path, "bundled:")
 		if b, err := fs.ReadFile(bundle.FS, "skills/"+name+".md"); err == nil {
-			return string(b)
+			path := "bundled:" + name
+			return string(b), path, skills.HashSkillMarkdown(b)
 		}
 	case "repo":
 		if b, err := os.ReadFile(ref.Path); err == nil {
-			return string(b)
+			return string(b), ref.Path, skills.HashSkillMarkdown(b)
 		}
 	}
-	return ""
+	return "", "", "fallback:harness"
 }
 
 // LineHandler receives each PTY output line as it arrives.
@@ -348,8 +351,8 @@ func (m *Manager) SpawnPlan(ws types.Workspace, issue types.Issue, pool types.Po
 	if err != nil {
 		return nil, err
 	}
-	skillMarkdown := loadSkillMarkdown(ws, types.StagePlan)
-	return m.spawn(ws, issue, types.ModePlan, args, prompt, pool, skillMarkdown)
+	skillMarkdown, skillPath, skillHash := loadSkillMarkdown(ws, types.StagePlan)
+	return m.spawn(ws, issue, types.ModePlan, args, prompt, pool, skillMarkdown, skillPath, skillHash)
 }
 
 // writeIssuePayload writes the issue body to .prismconductor/issue-<N>.md so
@@ -429,8 +432,8 @@ func (m *Manager) SpawnExecute(ws types.Workspace, issue types.Issue, plan types
 		_ = pcgit.Remove(ws.RepoPath, worktreeDir)
 		return nil, err
 	}
-	skillMarkdown := loadSkillMarkdown(ws, types.StageExecute)
-	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool, skillMarkdown)
+	skillMarkdown, skillPath, skillHash := loadSkillMarkdown(ws, types.StageExecute)
+	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool, skillMarkdown, skillPath, skillHash)
 	if err != nil {
 		_ = pcgit.Remove(ws.RepoPath, worktreeDir)
 		return nil, err
@@ -464,8 +467,8 @@ func (m *Manager) SpawnExecuteResume(ws types.Workspace, issue types.Issue, plan
 	if err != nil {
 		return nil, err
 	}
-	skillMarkdown := loadSkillMarkdown(ws, types.StageContinue)
-	return m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool, skillMarkdown)
+	skillMarkdown, skillPath, skillHash := loadSkillMarkdown(ws, types.StageContinue)
+	return m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool, skillMarkdown, skillPath, skillHash)
 }
 
 // SpawnExecuteContinue re-enters an execute worker on the existing feature
@@ -497,8 +500,8 @@ func (m *Manager) SpawnExecuteContinue(ws types.Workspace, issue types.Issue, pl
 	if err != nil {
 		return nil, err
 	}
-	skillMarkdown := loadSkillMarkdown(ws, types.StageContinue)
-	return m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool, skillMarkdown)
+	skillMarkdown, skillPath, skillHash := loadSkillMarkdown(ws, types.StageContinue)
+	return m.spawnWithDir(ws, issue, types.ModeExecute, args, prompt, worktreeDir, branch, pool, skillMarkdown, skillPath, skillHash)
 }
 
 // mirrorContinueNote copies .prismconductor/notes/<num>.txt from the main
@@ -635,7 +638,7 @@ func (m *Manager) SpawnArchitectAnswer(ws types.Workspace, _ types.Issue, questi
 	if err != nil {
 		return nil, err
 	}
-	return m.spawnWithDir(ws, archIssue, types.ModeExecute, args, prompt, "", "", pool, "")
+	return m.spawnWithDir(ws, archIssue, types.ModeExecute, args, prompt, "", "", pool, "", "", "fallback:harness")
 }
 
 // architectAnswerPrompt builds the prompt sent to a role=architect worker.
@@ -666,11 +669,11 @@ Rules:
 func (m *Manager) SpawnRaw(ws types.Workspace, name string, args []string) (*types.Session, error) {
 	demoIssue := types.Issue{Number: 0, WorkspaceID: ws.ID}
 	full := append([]string{name}, args...)
-	return m.spawn(ws, demoIssue, types.ModePlan, full, "", types.Pool{}, "")
+	return m.spawn(ws, demoIssue, types.ModePlan, full, "", types.Pool{}, "", "", "fallback:harness")
 }
 
-func (m *Manager) spawn(ws types.Workspace, issue types.Issue, mode types.SessionMode, argv []string, prompt string, pool types.Pool, skillMarkdown string) (*types.Session, error) {
-	return m.spawnWithDir(ws, issue, mode, argv, prompt, "", "", pool, skillMarkdown)
+func (m *Manager) spawn(ws types.Workspace, issue types.Issue, mode types.SessionMode, argv []string, prompt string, pool types.Pool, skillMarkdown, skillPath, skillHash string) (*types.Session, error) {
+	return m.spawnWithDir(ws, issue, mode, argv, prompt, "", "", pool, skillMarkdown, skillPath, skillHash)
 }
 
 // spawnWithDir is the canonical spawn path. When worktreeDir is non-empty the
@@ -690,7 +693,7 @@ func (m *Manager) spawn(ws types.Workspace, issue types.Issue, mode types.Sessio
 // goroutine drives the agent loop and writes synthesized stream-json into
 // the transcript file. tailAndParse + StreamParser see identical input
 // shape regardless of strategy.
-func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types.SessionMode, argv []string, prompt, worktreeDir, branch string, pool types.Pool, skillMarkdown string) (*types.Session, error) {
+func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types.SessionMode, argv []string, prompt, worktreeDir, branch string, pool types.Pool, skillMarkdown, skillPath, skillHash string) (*types.Session, error) {
 	if len(argv) == 0 && prompt == "" {
 		return nil, fmt.Errorf("empty command")
 	}
@@ -770,6 +773,8 @@ func (m *Manager) spawnWithDir(ws types.Workspace, issue types.Issue, mode types
 		StartedAt:   time.Now(),
 		PoolID:      pool.ID,
 		Branch:      branch,
+		SkillPath:   skillPath,
+		SkillHash:   skillHash,
 	}
 	sess.Transcript = transcriptPath
 
@@ -909,6 +914,7 @@ func (m *Manager) spawnRemote(ws types.Workspace, issue types.Issue, plan types.
 		State:       types.StateRunning,
 		StartedAt:   time.Now(),
 		PoolID:      pool.ID,
+		SkillHash:   "fallback:harness",
 	}
 	sess.Transcript = transcriptPath
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -224,7 +224,7 @@ func TestSpawnWritesToTranscriptFile(t *testing.T) {
 	issue := types.Issue{Number: 1, WorkspaceID: ws.ID}
 	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute,
 		[]string{"/bin/sh", "-c", "echo hello-from-worker; echo Work complete."},
-		"", "", "", types.Pool{}, "")
+		"", "", "", types.Pool{}, "", "", "fallback:harness")
 	if err != nil {
 		t.Fatalf("spawnWithDir: %v", err)
 	}
@@ -301,7 +301,7 @@ func TestSpawnRefusesDuplicateForSameIssueAndMode(t *testing.T) {
 	// test window, so its session stays registered in m.sessions.
 	first, err := m.spawnWithDir(ws, issue, types.ModePlan,
 		[]string{"/bin/sh", "-c", "sleep 5"},
-		"", "", "", types.Pool{}, "")
+		"", "", "", types.Pool{}, "", "", "fallback:harness")
 	if err != nil {
 		t.Fatalf("first spawn: %v", err)
 	}
@@ -310,7 +310,7 @@ func TestSpawnRefusesDuplicateForSameIssueAndMode(t *testing.T) {
 	// Second spawn for the SAME (workspace, issue, mode) must be refused.
 	_, err = m.spawnWithDir(ws, issue, types.ModePlan,
 		[]string{"/bin/sh", "-c", "echo should-not-run; echo Work complete."},
-		"", "", "", types.Pool{}, "")
+		"", "", "", types.Pool{}, "", "", "fallback:harness")
 	if !errors.Is(err, ErrDuplicateSpawn) {
 		t.Fatalf("second spawn for same (ws, issue, mode) returned err=%v, want ErrDuplicateSpawn", err)
 	}
@@ -348,7 +348,7 @@ func TestSpawnAllowsDifferentModeForSameIssue(t *testing.T) {
 
 	planSess, err := m.spawnWithDir(ws, issue, types.ModePlan,
 		[]string{"/bin/sh", "-c", "sleep 5"},
-		"", "", "", types.Pool{}, "")
+		"", "", "", types.Pool{}, "", "", "fallback:harness")
 	if err != nil {
 		t.Fatalf("plan spawn: %v", err)
 	}
@@ -356,7 +356,7 @@ func TestSpawnAllowsDifferentModeForSameIssue(t *testing.T) {
 
 	execSess, err := m.spawnWithDir(ws, issue, types.ModeExecute,
 		[]string{"/bin/sh", "-c", "sleep 5"},
-		"", "", "", types.Pool{}, "")
+		"", "", "", types.Pool{}, "", "", "fallback:harness")
 	if err != nil {
 		t.Fatalf("execute spawn for same issue but different mode unexpectedly refused: %v", err)
 	}
@@ -380,7 +380,7 @@ func TestSpawnPersistsPoolID(t *testing.T) {
 
 	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute,
 		[]string{"/bin/sh", "-c", "echo Work complete."},
-		"", "", "", pool, "")
+		"", "", "", pool, "", "", "fallback:harness")
 	if err != nil {
 		t.Fatalf("spawnWithDir: %v", err)
 	}
@@ -504,7 +504,7 @@ func TestTailAndParseAutoKillLandsOnCompleted(t *testing.T) {
 	// Spawn a long-running execute session so tailAndParse is live.
 	sess, err := m.spawnWithDir(ws, issue, types.ModeExecute,
 		[]string{"/bin/sh", "-c", "echo PR_OPENED: https://github.com/o/r/pull/1; sleep 10"},
-		"", "", "", types.Pool{}, "")
+		"", "", "", types.Pool{}, "", "", "fallback:harness")
 	if err != nil {
 		t.Fatalf("spawnWithDir: %v", err)
 	}
@@ -737,7 +737,7 @@ func TestKillSubprocessLandsInFailedState(t *testing.T) {
 	// A long-running subprocess that will not exit on its own.
 	sess, err := m.spawnWithDir(ws, issue, types.ModePlan,
 		[]string{"/bin/sh", "-c", "sleep 60"},
-		"", "", "", types.Pool{}, "")
+		"", "", "", types.Pool{}, "", "", "fallback:harness")
 	if err != nil {
 		t.Fatalf("spawnWithDir: %v", err)
 	}

--- a/internal/skills/bundle/skills/conductor-skill-curator.md
+++ b/internal/skills/bundle/skills/conductor-skill-curator.md
@@ -1,0 +1,197 @@
+---
+name: conductor-skill-curator
+description: Reads the skill_outcomes log, detects repeated failure patterns for a named skill, and proposes targeted markdown edits to fix them. Read-only — never mutates skill files. Phase A of issue #293.
+---
+
+# conductor-skill-curator
+
+Bundled by PrismConductor (PRISMCONDUCTOR_PLAN.md §15.12).
+
+Reads the `skill_outcomes` table for a named skill, detects repeated failure patterns, reads the current skill markdown, and proposes concrete `{old_text, new_text}` patches that would have prevented those failures. Writes findings to `.prismconductor/skill-curator/<RFC3339>.{json,md}` and updates `latest.json`. Never mutates skill files — edits are gated on user approval (phase B).
+
+## Inputs
+
+- `--skill <name>` (required) — the skill to analyse. Use the `bundled:<name>` form for bundled skills (e.g. `bundled:conductor-plan`) or an absolute path for repo skills.
+- `--window-days <N>` (optional, default 30) — how many days back to look in the outcome log.
+- `--data-dir <path>` (optional) — override the data directory. Resolution order: flag → `$PRISMCONDUCTOR_DATA_DIR` → `~/Library/Application Support/PrismConductor` (darwin default).
+
+## Invocation
+
+```
+/conductor-skill-curator --skill bundled:conductor-plan
+/conductor-skill-curator --skill bundled:conductor-execute --window-days 14
+/conductor-skill-curator --skill bundled:conductor-plan --data-dir /tmp/test-dir
+```
+
+## Behavior
+
+```bash
+set -euo pipefail
+
+# ── 0. Parse args ─────────────────────────────────────────────────────────────
+SKILL_ARG=""
+WINDOW_DAYS=30
+DATA_DIR=""
+args=("$@")
+i=0
+while [ $i -lt ${#args[@]} ]; do
+  case "${args[$i]}" in
+    --skill)       i=$((i+1)); SKILL_ARG="${args[$i]}" ;;
+    --window-days) i=$((i+1)); WINDOW_DAYS="${args[$i]}" ;;
+    --data-dir)    i=$((i+1)); DATA_DIR="${args[$i]}" ;;
+  esac
+  i=$((i+1))
+done
+
+if [ -z "$SKILL_ARG" ]; then
+  echo "BLOCKED: --skill is required (e.g. --skill bundled:conductor-plan)"
+  exit 1
+fi
+
+# ── 1. Resolve data dir ───────────────────────────────────────────────────────
+if [ -z "$DATA_DIR" ]; then
+  DATA_DIR="${PRISMCONDUCTOR_DATA_DIR:-}"
+fi
+if [ -z "$DATA_DIR" ]; then
+  DATA_DIR="$HOME/Library/Application Support/PrismConductor"
+fi
+
+DB="$DATA_DIR/conductor.db"
+if [ ! -f "$DB" ]; then
+  echo "BLOCKED: conductor.db not found at $DB — is DATA_DIR correct?"
+  exit 1
+fi
+
+# ── 2. Compute time window ────────────────────────────────────────────────────
+if command -v python3 &>/dev/null; then
+  SINCE_UNIX=$(python3 -c "import time; print(int(time.time()) - ${WINDOW_DAYS}*86400)")
+else
+  SINCE_UNIX=$(($(date +%s) - WINDOW_DAYS * 86400))
+fi
+
+# ── 3. Query outcome log ──────────────────────────────────────────────────────
+if ! command -v sqlite3 &>/dev/null; then
+  echo "BLOCKED: sqlite3 CLI not found — install it to run the curator"
+  exit 1
+fi
+
+OUTCOMES_JSON=$(sqlite3 -json "$DB" \
+  "SELECT session_id, outcome, blocked_reason, transcript_path, captured_at \
+   FROM skill_outcomes \
+   WHERE skill_path = '${SKILL_ARG}' AND captured_at >= ${SINCE_UNIX} \
+   ORDER BY captured_at DESC" 2>/dev/null || echo "[]")
+
+TOTAL=$(sqlite3 "$DB" \
+  "SELECT COUNT(*) FROM skill_outcomes WHERE skill_path = '${SKILL_ARG}' AND captured_at >= ${SINCE_UNIX}" \
+  2>/dev/null || echo "0")
+
+# Per-outcome counts
+for OUTCOME in success failed blocked needs_pr; do
+  COUNT=$(sqlite3 "$DB" \
+    "SELECT COUNT(*) FROM skill_outcomes WHERE skill_path = '${SKILL_ARG}' AND outcome = '${OUTCOME}' AND captured_at >= ${SINCE_UNIX}" \
+    2>/dev/null || echo "0")
+  eval "COUNT_${OUTCOME^^}=$COUNT"
+done
+
+echo "Outcome log: total=$TOTAL success=$COUNT_SUCCESS failed=$COUNT_FAILED blocked=$COUNT_BLOCKED needs_pr=$COUNT_NEEDS_PR (window: last ${WINDOW_DAYS} days)"
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "No outcomes recorded for skill '${SKILL_ARG}' in the last ${WINDOW_DAYS} days."
+  echo "Spawn some sessions first, then re-run the curator."
+  exit 0
+fi
+```
+
+### 4. Read current skill markdown
+
+Resolve the skill content:
+- For `bundled:<name>`: use the Read tool to read `internal/skills/bundle/skills/<name>.md` relative to the repo root (determined via `git rev-parse --show-toplevel`).
+- For an absolute path: use the Read tool to read it directly.
+
+If the skill file cannot be read, report `BLOCKED: cannot read skill markdown at <path>` and exit.
+
+### 5. Sample failure transcripts
+
+From `OUTCOMES_JSON`, filter rows where `outcome` is `failed` or `blocked`. Take up to 5 samples. For each:
+- Use the Read tool to read `transcript_path` (up to last 200 lines).
+- Extract the `BLOCKED:` sentinel line if present; otherwise extract the last 20 lines of output.
+- Collect the `blocked_reason` text.
+
+### 6. Detect failure patterns
+
+Examine the sampled failure snippets alongside the current skill markdown. For each pattern you detect (a class of failures that appears in ≥2 samples or looks high-impact in 1 sample), ask:
+
+> "What specific instruction in this skill would, if changed, have prevented this class of failure?"
+
+Produce a `failure_patterns` array. Each element:
+```json
+{
+  "pattern_id": "p1",
+  "description": "one-line description of the failure class",
+  "frequency": <int — how many samples show this pattern>,
+  "evidence_session_ids": ["sess-abc", "sess-def"],
+  "proposed_edit": {
+    "location_hint": "section name or line range in the skill markdown",
+    "old_text": "exact substring to replace",
+    "new_text": "replacement text",
+    "rationale": "why this change would prevent the failure"
+  }
+}
+```
+
+If `old_text` is empty, it means inserting `new_text` at `location_hint`. If no actionable edit can be proposed for a pattern (the failure is environmental, not a skill defect), set `proposed_edit` to `null` and explain in `rationale`.
+
+### 7. Write findings
+
+Determine the report directory: find the git repo root (via `git rev-parse --show-toplevel` from the current working directory) and use `<repo_root>/.prismconductor/skill-curator/`.
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+REPORT_DIR="$REPO_ROOT/.prismconductor/skill-curator"
+mkdir -p "$REPORT_DIR"
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+REPORT_JSON="$REPORT_DIR/${TIMESTAMP}.json"
+REPORT_MD="$REPORT_DIR/${TIMESTAMP}.md"
+LATEST_JSON="$REPORT_DIR/latest.json"
+```
+
+Write `$REPORT_JSON`:
+```json
+{
+  "skill_path": "<SKILL_ARG>",
+  "window_days": <WINDOW_DAYS>,
+  "scanned_at": "<TIMESTAMP>",
+  "summary": {
+    "total_sessions": <TOTAL>,
+    "success": <COUNT_SUCCESS>,
+    "failed": <COUNT_FAILED>,
+    "blocked": <COUNT_BLOCKED>,
+    "needs_pr": <COUNT_NEEDS_PR>
+  },
+  "failure_patterns": [ ... ]
+}
+```
+
+Write `$REPORT_MD` as a human-readable Markdown version of the same findings.
+
+Write `$LATEST_JSON` as a pointer:
+```json
+{ "path": "<relative path from $REPORT_DIR to $REPORT_JSON>", "scanned_at": "<TIMESTAMP>" }
+```
+
+Print: `Curator findings written to $REPORT_JSON`
+
+### Failure paths
+
+- If `sqlite3` is not available: `BLOCKED: sqlite3 CLI not found`
+- If `conductor.db` is not found: `BLOCKED: conductor.db not found at <path>`
+- If `--skill` is omitted: `BLOCKED: --skill is required`
+- If the skill markdown cannot be read: `BLOCKED: cannot read skill markdown at <path>`
+- Any other unrecoverable error: `BLOCKED: <reason>`
+
+### Notes
+
+- This skill is **read-only**. It never modifies skill files.
+- Proposed edits in `proposed_edit` are for human review. Application is gated on user approval (phase B — `ApplySkillEdit` Wails method).
+- Per-workspace skill overrides live at `<repo>/.prismconductor/skills/<name>.md` (q2 answer). Phase B applies edits there, not to the bundled embed.FS copy.
+- The curator uses its own judgment to cluster failures into patterns; for ambiguous cases, prefer a conservative edit proposal (tighten an instruction) over a sweeping rewrite.

--- a/internal/skills/versioning.go
+++ b/internal/skills/versioning.go
@@ -1,0 +1,14 @@
+package skills
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// HashSkillMarkdown returns the hex-encoded SHA-256 of the skill markdown
+// content. Computed once at spawn time so the hash reflects the exact skill
+// version that drove a session, not whatever is on disk at session end.
+func HashSkillMarkdown(content []byte) string {
+	sum := sha256.Sum256(content)
+	return fmt.Sprintf("%x", sum)
+}

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -119,6 +119,30 @@ CREATE TABLE IF NOT EXISTS pool_daily_usage (
 );
 CREATE INDEX IF NOT EXISTS idx_pdu_pool_date ON pool_daily_usage (pool_id, date);`,
 	},
+	{
+		ID:          "20260513_01_add_skill_outcomes",
+		Description: "issue #293: per-session skill outcome log for self-improving skills (phase A)",
+		SQL: `
+CREATE TABLE IF NOT EXISTS skill_outcomes (
+    session_id      TEXT    PRIMARY KEY,
+    workspace_id    TEXT    NOT NULL,
+    issue_number    INTEGER NOT NULL,
+    skill_path      TEXT    NOT NULL,
+    skill_hash      TEXT    NOT NULL,
+    mode            TEXT    NOT NULL,
+    outcome         TEXT    NOT NULL,
+    blocked_reason  TEXT    NOT NULL DEFAULT '',
+    user_action     TEXT    NOT NULL DEFAULT '',
+    cost_cents      REAL    NOT NULL DEFAULT 0,
+    duration_ms     INTEGER NOT NULL DEFAULT 0,
+    transcript_path TEXT    NOT NULL DEFAULT '',
+    captured_at     INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_skill_outcomes_skill_time
+    ON skill_outcomes(skill_path, captured_at);
+CREATE INDEX IF NOT EXISTS idx_skill_outcomes_workspace
+    ON skill_outcomes(workspace_id, captured_at);`,
+	},
 }
 
 // All returns every known migration in application order.

--- a/internal/store/skill_outcomes.go
+++ b/internal/store/skill_outcomes.go
@@ -1,0 +1,113 @@
+package store
+
+import (
+	"time"
+
+	"prismconductor/internal/types"
+)
+
+// RecordSkillOutcome writes (or upserts) one skill outcome row. Idempotent on
+// the same session_id so double-delivery from handleSessionStateChange is safe.
+func (s *Store) RecordSkillOutcome(o types.SkillOutcome) error {
+	_, err := s.DB.Exec(`
+		INSERT INTO skill_outcomes
+		    (session_id, workspace_id, issue_number, skill_path, skill_hash,
+		     mode, outcome, blocked_reason, user_action,
+		     cost_cents, duration_ms, transcript_path, captured_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(session_id) DO UPDATE SET
+		    outcome         = excluded.outcome,
+		    blocked_reason  = excluded.blocked_reason,
+		    cost_cents      = excluded.cost_cents,
+		    duration_ms     = excluded.duration_ms,
+		    captured_at     = excluded.captured_at`,
+		o.SessionID, o.WorkspaceID, o.IssueNumber,
+		o.SkillPath, o.SkillHash, o.Mode, o.Outcome,
+		o.BlockedReason, o.UserAction,
+		o.CostCents, o.DurationMs, o.TranscriptPath, o.CapturedAt,
+	)
+	return err
+}
+
+// ListSkillOutcomes returns outcomes for a skill path since sinceUnix (epoch
+// seconds), newest-first, capped at limit rows. Pass limit=0 for no cap.
+func (s *Store) ListSkillOutcomes(skillPath string, sinceUnix int64, limit int) ([]types.SkillOutcome, error) {
+	q := `SELECT session_id, workspace_id, issue_number, skill_path, skill_hash,
+	             mode, outcome, blocked_reason, user_action,
+	             cost_cents, duration_ms, transcript_path, captured_at
+	        FROM skill_outcomes
+	       WHERE skill_path = ? AND captured_at >= ?
+	       ORDER BY captured_at DESC`
+	args := []any{skillPath, sinceUnix}
+	if limit > 0 {
+		q += " LIMIT ?"
+		args = append(args, limit)
+	}
+	rows, err := s.DB.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanSkillOutcomes(rows)
+}
+
+// SummarizeOutcomes returns aggregate outcome counts for a skill path since
+// sinceUnix (epoch seconds).
+func (s *Store) SummarizeOutcomes(skillPath string, sinceUnix int64) (types.SkillOutcomeSummary, error) {
+	rows, err := s.DB.Query(`
+		SELECT outcome, COUNT(*)
+		  FROM skill_outcomes
+		 WHERE skill_path = ? AND captured_at >= ?
+		 GROUP BY outcome`,
+		skillPath, sinceUnix,
+	)
+	if err != nil {
+		return types.SkillOutcomeSummary{}, err
+	}
+	defer rows.Close()
+
+	counts := make(map[string]int)
+	total := 0
+	for rows.Next() {
+		var outcome string
+		var n int
+		if err := rows.Scan(&outcome, &n); err != nil {
+			return types.SkillOutcomeSummary{}, err
+		}
+		counts[outcome] = n
+		total += n
+	}
+	if err := rows.Err(); err != nil {
+		return types.SkillOutcomeSummary{}, err
+	}
+	return types.SkillOutcomeSummary{
+		SkillPath:     skillPath,
+		TotalSessions: total,
+		Counts:        counts,
+	}, nil
+}
+
+func scanSkillOutcomes(rows interface {
+	Next() bool
+	Scan(...any) error
+	Err() error
+}) ([]types.SkillOutcome, error) {
+	var out []types.SkillOutcome
+	for rows.Next() {
+		var o types.SkillOutcome
+		if err := rows.Scan(
+			&o.SessionID, &o.WorkspaceID, &o.IssueNumber,
+			&o.SkillPath, &o.SkillHash, &o.Mode, &o.Outcome,
+			&o.BlockedReason, &o.UserAction,
+			&o.CostCents, &o.DurationMs, &o.TranscriptPath, &o.CapturedAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, o)
+	}
+	return out, rows.Err()
+}
+
+// nowUnixSkillOutcome returns the current Unix epoch for CapturedAt. Defined
+// as a package-level var so tests can override it without time package tricks.
+var nowUnixSkillOutcome = func() int64 { return time.Now().Unix() }

--- a/internal/store/skill_outcomes_test.go
+++ b/internal/store/skill_outcomes_test.go
@@ -1,0 +1,164 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"prismconductor/internal/types"
+)
+
+func TestSkillOutcomes_RoundTrip(t *testing.T) {
+	s := openTempStore(t)
+
+	now := time.Now().Unix()
+	o := types.SkillOutcome{
+		SessionID:      "sess-1",
+		WorkspaceID:    "ws1",
+		IssueNumber:    42,
+		SkillPath:      "bundled:conductor-plan",
+		SkillHash:      "abc123",
+		Mode:           "plan",
+		Outcome:        "success",
+		BlockedReason:  "",
+		UserAction:     "",
+		CostCents:      1.5,
+		DurationMs:     30000,
+		TranscriptPath: "/tmp/t.log",
+		CapturedAt:     now,
+	}
+
+	if err := s.RecordSkillOutcome(o); err != nil {
+		t.Fatalf("RecordSkillOutcome: %v", err)
+	}
+
+	rows, err := s.ListSkillOutcomes("bundled:conductor-plan", now-1, 10)
+	if err != nil {
+		t.Fatalf("ListSkillOutcomes: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ListSkillOutcomes: got %d rows, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.SessionID != "sess-1" || got.Outcome != "success" || got.SkillHash != "abc123" {
+		t.Errorf("unexpected row: %+v", got)
+	}
+}
+
+func TestSkillOutcomes_IdempotentUpsert(t *testing.T) {
+	s := openTempStore(t)
+
+	now := time.Now().Unix()
+	o := types.SkillOutcome{
+		SessionID:   "sess-dup",
+		WorkspaceID: "ws1",
+		IssueNumber: 10,
+		SkillPath:   "bundled:conductor-execute",
+		SkillHash:   "deadbeef",
+		Mode:        "execute",
+		Outcome:     "failed",
+		CapturedAt:  now,
+	}
+
+	if err := s.RecordSkillOutcome(o); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	// Second call with a different outcome should upsert (update outcome).
+	o.Outcome = "success"
+	if err := s.RecordSkillOutcome(o); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+
+	rows, err := s.ListSkillOutcomes("bundled:conductor-execute", now-1, 10)
+	if err != nil {
+		t.Fatalf("ListSkillOutcomes: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row after upsert, got %d", len(rows))
+	}
+	if rows[0].Outcome != "success" {
+		t.Errorf("outcome = %q, want %q", rows[0].Outcome, "success")
+	}
+}
+
+func TestSkillOutcomes_SummarizeCounts(t *testing.T) {
+	s := openTempStore(t)
+
+	now := time.Now().Unix()
+	outcomes := []struct {
+		id      string
+		outcome string
+	}{
+		{"s1", "success"},
+		{"s2", "success"},
+		{"s3", "blocked"},
+		{"s4", "failed"},
+	}
+	for _, row := range outcomes {
+		if err := s.RecordSkillOutcome(types.SkillOutcome{
+			SessionID:   row.id,
+			WorkspaceID: "ws1",
+			IssueNumber: 99,
+			SkillPath:   "bundled:conductor-plan",
+			SkillHash:   "hash",
+			Mode:        "plan",
+			Outcome:     row.outcome,
+			CapturedAt:  now,
+		}); err != nil {
+			t.Fatalf("RecordSkillOutcome %s: %v", row.id, err)
+		}
+	}
+
+	sum, err := s.SummarizeOutcomes("bundled:conductor-plan", now-1)
+	if err != nil {
+		t.Fatalf("SummarizeOutcomes: %v", err)
+	}
+	if sum.TotalSessions != 4 {
+		t.Errorf("total = %d, want 4", sum.TotalSessions)
+	}
+	if sum.Counts["success"] != 2 {
+		t.Errorf("success count = %d, want 2", sum.Counts["success"])
+	}
+	if sum.Counts["blocked"] != 1 {
+		t.Errorf("blocked count = %d, want 1", sum.Counts["blocked"])
+	}
+	if sum.Counts["failed"] != 1 {
+		t.Errorf("failed count = %d, want 1", sum.Counts["failed"])
+	}
+}
+
+func TestSkillOutcomes_WindowFilter(t *testing.T) {
+	s := openTempStore(t)
+
+	old := time.Now().Unix() - 100
+	recent := time.Now().Unix()
+
+	for _, row := range []struct {
+		id  string
+		at  int64
+	}{
+		{"old-sess", old},
+		{"new-sess", recent},
+	} {
+		if err := s.RecordSkillOutcome(types.SkillOutcome{
+			SessionID:   row.id,
+			WorkspaceID: "ws1",
+			IssueNumber: 1,
+			SkillPath:   "bundled:conductor-plan",
+			SkillHash:   "x",
+			Mode:        "plan",
+			Outcome:     "success",
+			CapturedAt:  row.at,
+		}); err != nil {
+			t.Fatalf("insert %s: %v", row.id, err)
+		}
+	}
+
+	// Only rows at or after 'recent' should come back.
+	rows, err := s.ListSkillOutcomes("bundled:conductor-plan", recent, 10)
+	if err != nil {
+		t.Fatalf("ListSkillOutcomes: %v", err)
+	}
+	if len(rows) != 1 || rows[0].SessionID != "new-sess" {
+		t.Errorf("expected only new-sess, got %v", rows)
+	}
+}

--- a/internal/types/skill_outcome.go
+++ b/internal/types/skill_outcome.go
@@ -1,0 +1,28 @@
+package types
+
+// SkillOutcome is one row in the skill_outcomes table. Written once per
+// session at terminal state transition (completed, failed, blocked, needs_pr).
+// PK is SessionID so an idempotent upsert is safe on duplicate delivery.
+type SkillOutcome struct {
+	SessionID      string `json:"session_id"`
+	WorkspaceID    string `json:"workspace_id"`
+	IssueNumber    int    `json:"issue_number"`
+	SkillPath      string `json:"skill_path"`   // "bundled:conductor-plan" | abs repo path | ""
+	SkillHash      string `json:"skill_hash"`   // sha256 hex at spawn time, or "fallback:harness"
+	Mode           string `json:"mode"`         // "plan" | "execute"
+	Outcome        string `json:"outcome"`      // "success"|"blocked"|"failed"|"needs_pr"
+	BlockedReason  string `json:"blocked_reason"`
+	UserAction     string `json:"user_action"`  // "" in phase A; filled by phase B
+	CostCents      float64 `json:"cost_cents"`
+	DurationMs     int64  `json:"duration_ms"`
+	TranscriptPath string `json:"transcript_path"`
+	CapturedAt     int64  `json:"captured_at"` // Unix epoch seconds
+}
+
+// SkillOutcomeSummary aggregates outcome counts for one skill path over a
+// time window. Used by the curator skill to detect failure patterns.
+type SkillOutcomeSummary struct {
+	SkillPath    string         `json:"skill_path"`
+	TotalSessions int           `json:"total_sessions"`
+	Counts       map[string]int `json:"counts"` // outcome → count
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -680,6 +680,13 @@ type Session struct {
 	// RetryOfSessionID is the ID of the session whose transient failure triggered
 	// this session. Empty for first-attempt sessions (#221).
 	RetryOfSessionID string `json:"retry_of_session_id,omitempty"`
+
+	// Issue #293: skill identity captured at spawn time for outcome logging.
+	// SkillPath is "bundled:<name>", an absolute repo path, or "" (harness fallback).
+	// SkillHash is sha256 hex of the skill markdown at spawn time, or "fallback:harness".
+	// Both omitempty so old session JSON deserializes cleanly.
+	SkillPath string `json:"skill_path,omitempty"`
+	SkillHash string `json:"skill_hash,omitempty"`
 }
 
 // MidRunAnswer is the §6.4-shaped answer payload for a mid-run question


### PR DESCRIPTION
## Summary

- Adds a `skill_outcomes` table written once per session at terminal state transition (success/failed/blocked/needs_pr), capturing the skill path and hash at spawn time — not at completion — so A/B analysis reflects the exact skill version that drove each session.
- Ships a new bundled `conductor-skill-curator` skill that reads the outcome log, detects repeated failure patterns, and proposes `{old_text, new_text}` markdown patches for human review. Never mutates skill files.

## Files modified

- `internal/types/skill_outcome.go` — new `SkillOutcome` + `SkillOutcomeSummary` types
- `internal/types/types.go` — `Session.SkillPath` / `Session.SkillHash` fields (`omitempty`)
- `internal/skills/versioning.go` — `HashSkillMarkdown(content)` → sha256 hex
- `internal/store/migrations/registry.go` — migration `20260513_00_add_skill_outcomes`
- `internal/store/skill_outcomes.go` — `RecordSkillOutcome` (upsert), `ListSkillOutcomes`, `SummarizeOutcomes`
- `internal/store/skill_outcomes_test.go` — 4 tests: round-trip, idempotent upsert, summarize counts, window filter
- `internal/session/manager.go` — `loadSkillMarkdown` → `(content, path, hash)`; all spawn paths thread path+hash onto `Session`
- `internal/session/harness_test.go`, `manager_test.go` — updated test call sites for new signature
- `app.go` — `handleSessionStateChange` writes `skill_outcomes` row on terminal transitions; `recordSkillOutcome` + `terminalStateToOutcome` helpers
- `app_test.go` — `TestHandleSessionStateChange_WritesSkillOutcomeOnFailed`
- `internal/skills/bundle/skills/conductor-skill-curator.md` — new bundled skill
- `CLAUDE.md` — `/conductor-skill-curator` entry under Verification skills
- `PRISMCONDUCTOR_PLAN.md` — §15.12 documenting the outcome log + curator skill
- `frontend/wailsjs/go/models.ts` — regenerated bindings (skill_path/skill_hash on Session)

## Verification

- **Lint:** `go vet ./internal/...` — pass
- **Build:** `wails build` — pass (`Built prismconductor.app in 8.884s`)
- **Smoke test:** skipped — Playwright not installed in this worktree (`tests/e2e/startup.spec.ts` present; `@playwright/test` package absent)
- **Tests:** `go test ./...` — all pass (4 new store tests, 1 new app-layer test; all existing tests green)
- **TypeScript:** `cd frontend && npx tsc --noEmit` — pass (no frontend changes; models.ts updated by wails build)

## Commit tier

Tier 2b (local unsigned commit + push). Branch protection not enabled on `main`.

## Workspace mode

per-execute worktree at /Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-293

## Out of scope (phase B / C / D)

- Skill Curator review modal + `ApplySkillEdit` Wails method (phase B)
- Per-workspace `.prismconductor/skills/<name>.md` override write path (phase B)
- `user_action` capture from PlanModal Approve/Reject (phase B)
- A/B variant routing (phase C)
- Skill versioning / rollback UI (phase C)
- Periodic `/loop` cron integration (phase D)

Closes #293