### PR TITLE
feat(#298): per-issue session ledger with cost/time breakdown

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -3471,6 +3473,73 @@ func (a *App) ListIssueViews(workspaceID string) ([]issueview.IssueView, error) 
 		return nil, fmt.Errorf("assembler unavailable")
 	}
 	return a.assembler.ListForWorkspace(workspaceID)
+}
+
+// GetSessionLedger returns the per-session cost/time ledger for a card (issue #298).
+// Rows are ordered newest-first. Pool model/provider reflect current pool config
+// (resolve-on-read; no schema migration needed). Capped at 1000 rows server-side.
+func (a *App) GetSessionLedger(workspaceID string, issueNumber int) ([]types.SessionLedgerRow, error) {
+	if a.assembler == nil {
+		return nil, fmt.Errorf("assembler unavailable")
+	}
+	return a.assembler.BuildSessionLedger(workspaceID, issueNumber)
+}
+
+// ExportSessionLedgerCSV opens a native Save As dialog, then writes the
+// session ledger as CSV to the chosen path (issue #298).
+func (a *App) ExportSessionLedgerCSV(workspaceID string, issueNumber int) error {
+	if a.assembler == nil {
+		return fmt.Errorf("assembler unavailable")
+	}
+	rows, err := a.assembler.BuildSessionLedger(workspaceID, issueNumber)
+	if err != nil {
+		return err
+	}
+	path, err := wruntime.SaveFileDialog(a.ctx, wruntime.SaveDialogOptions{
+		Title:           "Export session ledger",
+		DefaultFilename: fmt.Sprintf("ledger-issue-%d.csv", issueNumber),
+		Filters: []wruntime.FileFilter{
+			{DisplayName: "CSV files (*.csv)", Pattern: "*.csv"},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if path == "" {
+		return nil // user cancelled
+	}
+	var buf bytes.Buffer
+	w := csv.NewWriter(&buf)
+	_ = w.Write([]string{"session_id", "role", "pool_name", "provider", "model",
+		"started_at", "duration_s", "cost_usd", "input_tokens", "output_tokens", "outcome", "failure_cause"})
+	for _, r := range rows {
+		fc := ""
+		if r.FailureCause != nil {
+			fc = r.FailureCause.Reason
+			if fc == "" {
+				fc = r.FailureCause.Kind
+			}
+		}
+		_ = w.Write([]string{
+			r.SessionID,
+			r.Role,
+			r.PoolName,
+			r.Provider,
+			r.Model,
+			r.StartedAt.UTC().Format(time.RFC3339),
+			strconv.FormatFloat(r.DurationS, 'f', 2, 64),
+			strconv.FormatFloat(r.CostUSD, 'f', 6, 64),
+			strconv.FormatInt(r.InputTokens, 10),
+			strconv.FormatInt(r.OutputTokens, 10),
+			r.Outcome,
+			fc,
+		})
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return err
+	}
+	return os.WriteFile(path, buf.Bytes(), 0o644)
 }
 
 // LatestPlan returns the highest-revision plan for an issue.

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -17,6 +17,7 @@ import { ContinueModal } from "./ContinueModal";
 import { PRCommentReviewModal } from "./PRCommentReviewModal";
 import { AgentActivityStrip } from "./AgentActivityStrip";
 import { DiagnosticPopover } from "./DiagnosticPopover";
+import { SessionLedger } from "./SessionLedger";
 import { cn } from "../lib/cn";
 import { CopyMenu, CopyAction, toQuotedBlock } from "./CopyMenu";
 import { useGlowColorsStore, type GlowState } from "../stores/useGlowColorsStore";
@@ -213,6 +214,7 @@ export function Card({ issue, workspaceColor, workspaceLabel, relatedSiblings, o
   const [prCommentOpen, setPrCommentOpen] = useState(false);
   const [cardMenu, setCardMenu] = useState<{ x: number; y: number; actions: CopyAction[] } | null>(null);
   const [diagAnchor, setDiagAnchor] = useState<{ x: number; y: number } | null>(null);
+  const [ledgerAnchor, setLedgerAnchor] = useState<{ x: number; y: number } | null>(null);
 
   function openCardMenu(e: React.MouseEvent, actions: CopyAction[]) {
     e.preventDefault();
@@ -370,11 +372,21 @@ export function Card({ issue, workspaceColor, workspaceLabel, relatedSiblings, o
       )}
       <div className="flex justify-end items-center gap-2 mt-0.5">
         {(issue.cost_usd ?? 0) > 0 && (
-          <CostChip
-            costUSD={issue.cost_usd!}
-            inputTokens={view?.last_session?.input_tokens ?? null}
-            outputTokens={view?.last_session?.output_tokens ?? null}
-          />
+          <button
+            type="button"
+            className="cursor-pointer focus:outline-none"
+            onClick={(e) => {
+              e.stopPropagation();
+              setLedgerAnchor({ x: e.clientX, y: e.clientY });
+            }}
+            aria-label="View session ledger"
+          >
+            <CostChip
+              costUSD={issue.cost_usd!}
+              inputTokens={view?.last_session?.input_tokens ?? null}
+              outputTokens={view?.last_session?.output_tokens ?? null}
+            />
+          </button>
         )}
         <WorkTimerChip
           baseSecs={issue.work_seconds ?? 0}
@@ -425,6 +437,14 @@ export function Card({ issue, workspaceColor, workspaceLabel, relatedSiblings, o
           issueNumber={issue.number}
           anchor={diagAnchor}
           onClose={() => setDiagAnchor(null)}
+        />
+      )}
+      {ledgerAnchor && (
+        <SessionLedger
+          workspaceID={issue.workspace_id}
+          issueNumber={issue.number}
+          anchor={ledgerAnchor}
+          onClose={() => setLedgerAnchor(null)}
         />
       )}
     </div>

--- a/frontend/src/components/SessionLedger.tsx
+++ b/frontend/src/components/SessionLedger.tsx
@@ -1,0 +1,331 @@
+import { useEffect, useRef, useState } from "react";
+import { GetSessionLedger, ExportSessionLedgerCSV } from "../../wailsjs/go/main/App";
+
+// SessionLedgerRow mirrors types.SessionLedgerRow on the backend (issue #298).
+type SessionLedgerRow = {
+  session_id: string;
+  role: string;
+  pool_id: string;
+  pool_name: string;
+  provider: string;
+  model: string;
+  started_at: string;
+  duration_s: number;
+  cost_usd: number;
+  input_tokens: number;
+  output_tokens: number;
+  outcome: string;
+  failure_cause?: { kind: string; reason?: string } | null;
+};
+
+// Rows ≤ this threshold use a popover; larger histories use a modal.
+const POPOVER_THRESHOLD = 8;
+
+type SortKey = "role" | "pool_name" | "model" | "started_at" | "duration_s" | "cost_usd" | "input_tokens" | "outcome";
+type SortDir = "asc" | "desc";
+
+type Props = {
+  workspaceID: string;
+  issueNumber: number;
+  anchor: { x: number; y: number } | null;
+  onClose: () => void;
+};
+
+export function SessionLedger({ workspaceID, issueNumber, anchor, onClose }: Props) {
+  const [rows, setRows] = useState<SessionLedgerRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>("started_at");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [roleFolded, setRoleFolded] = useState(true);
+  const [exporting, setExporting] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    GetSessionLedger(workspaceID, issueNumber)
+      .then((data: any[]) => setRows(data ?? []))
+      .catch((e: any) => setErr(String(e?.message ?? e)))
+      .finally(() => setLoading(false));
+  }, [workspaceID, issueNumber]);
+
+  // Close on outside click.
+  useEffect(() => {
+    function handler(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    }
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [onClose]);
+
+  // Close on Escape.
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  const sorted = [...rows].sort((a, b) => {
+    let cmp = 0;
+    switch (sortKey) {
+      case "role":        cmp = a.role.localeCompare(b.role); break;
+      case "pool_name":   cmp = a.pool_name.localeCompare(b.pool_name); break;
+      case "model":       cmp = a.model.localeCompare(b.model); break;
+      case "started_at":  cmp = a.started_at.localeCompare(b.started_at); break;
+      case "duration_s":  cmp = a.duration_s - b.duration_s; break;
+      case "cost_usd":    cmp = a.cost_usd - b.cost_usd; break;
+      case "input_tokens":cmp = a.input_tokens + a.output_tokens - (b.input_tokens + b.output_tokens); break;
+      case "outcome":     cmp = a.outcome.localeCompare(b.outcome); break;
+    }
+    return sortDir === "asc" ? cmp : -cmp;
+  });
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) setSortDir(d => d === "asc" ? "desc" : "asc");
+    else { setSortKey(key); setSortDir("desc"); }
+  }
+
+  const totalCost = rows.reduce((s, r) => s + r.cost_usd, 0);
+  const totalIn   = rows.reduce((s, r) => s + r.input_tokens, 0);
+  const totalOut  = rows.reduce((s, r) => s + r.output_tokens, 0);
+  const totalSecs = rows.reduce((s, r) => s + r.duration_s, 0);
+
+  // Role roll-up aggregates.
+  const roleMap: Record<string, { count: number; cost: number; secs: number }> = {};
+  for (const r of rows) {
+    const e = roleMap[r.role] ?? { count: 0, cost: 0, secs: 0 };
+    e.count++;
+    e.cost += r.cost_usd;
+    e.secs += r.duration_s;
+    roleMap[r.role] = e;
+  }
+
+  async function doExport() {
+    setExporting(true);
+    try {
+      await ExportSessionLedgerCSV(workspaceID, issueNumber);
+    } catch (e: any) {
+      alert(String(e?.message ?? e));
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  const useModal = !loading && rows.length > POPOVER_THRESHOLD;
+
+  const headerRow = (
+    <div className="flex items-center justify-between px-3 py-2 border-b border-slate-700 bg-slate-800/50">
+      <span className="text-slate-200 text-xs font-semibold">
+        Session Ledger <span className="text-slate-500 font-normal ml-1">#{issueNumber}</span>
+        {!loading && <span className="ml-2 text-slate-500 font-normal">{rows.length} session{rows.length !== 1 ? "s" : ""}</span>}
+      </span>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={doExport}
+          disabled={exporting || loading || rows.length === 0}
+          className="text-[10px] text-slate-400 hover:text-slate-200 disabled:opacity-40 border border-slate-700 rounded px-1.5 py-0.5"
+        >
+          {exporting ? "Saving…" : "Export CSV"}
+        </button>
+        <button onClick={onClose} className="text-slate-400 hover:text-slate-200 text-xs leading-none">✕</button>
+      </div>
+    </div>
+  );
+
+  const Th = ({ label, col, className = "" }: { label: string; col: SortKey; className?: string }) => (
+    <th
+      className={`px-2 py-1 text-left text-[10px] text-slate-400 font-medium cursor-pointer select-none hover:text-slate-200 ${className}`}
+      onClick={() => toggleSort(col)}
+    >
+      {label}{sortKey === col ? (sortDir === "asc" ? " ↑" : " ↓") : ""}
+    </th>
+  );
+
+  const tableContent = (
+    <div className="overflow-auto max-h-[400px]">
+      {loading ? (
+        <div className="px-3 py-4 text-xs text-slate-500">Loading…</div>
+      ) : err ? (
+        <div className="px-3 py-4 text-xs text-red-400">{err}</div>
+      ) : rows.length === 0 ? (
+        <div className="px-3 py-4 text-xs text-slate-500">No sessions recorded for this issue.</div>
+      ) : (
+        <table className="w-full text-[10px] font-mono border-collapse">
+          <thead className="sticky top-0 bg-slate-900 z-10">
+            <tr>
+              <Th label="Role"    col="role"         className="w-20" />
+              <Th label="Pool"    col="pool_name"    className="w-20" />
+              <Th label="Model"   col="model"        className="w-24" />
+              <Th label="Started" col="started_at"   className="w-28" />
+              <Th label="Time"    col="duration_s"   className="w-16 text-right" />
+              <Th label="Cost"    col="cost_usd"     className="w-16 text-right" />
+              <Th label="Tokens"  col="input_tokens" className="w-20 text-right" />
+              <Th label="Outcome" col="outcome"      className="w-20" />
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((r) => (
+              <tr key={r.session_id} className="border-t border-slate-800 hover:bg-slate-800/40">
+                <td className="px-2 py-1 text-slate-300">{r.role}</td>
+                <td className="px-2 py-1 text-slate-400 truncate max-w-[80px]" title={r.pool_name}>{r.pool_name}</td>
+                <td className="px-2 py-1 text-slate-400 truncate max-w-[96px]" title={r.model}>{r.model || "—"}</td>
+                <td className="px-2 py-1 text-slate-400">{formatDate(r.started_at)}</td>
+                <td className="px-2 py-1 text-right text-slate-300">{formatDuration(r.duration_s)}</td>
+                <td className="px-2 py-1 text-right text-emerald-400">{formatCost(r.cost_usd)}</td>
+                <td className="px-2 py-1 text-right text-slate-400">{formatTokens(r.input_tokens + r.output_tokens)}</td>
+                <td className="px-2 py-1">
+                  <OutcomeChip outcome={r.outcome} cause={r.failure_cause} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+          <tfoot>
+            <tr className="border-t-2 border-slate-700 bg-slate-900/60 font-semibold">
+              <td className="px-2 py-1 text-slate-400 text-[10px]" colSpan={4}>Totals ({rows.length})</td>
+              <td className="px-2 py-1 text-right text-slate-300">{formatDuration(totalSecs)}</td>
+              <td className="px-2 py-1 text-right text-emerald-400">{formatCost(totalCost)}</td>
+              <td className="px-2 py-1 text-right text-slate-400">{formatTokens(totalIn + totalOut)}</td>
+              <td />
+            </tr>
+          </tfoot>
+        </table>
+      )}
+    </div>
+  );
+
+  const roleRollup = !loading && !err && rows.length > 0 && (
+    <div className="border-t border-slate-700">
+      <button
+        className="w-full flex items-center justify-between px-3 py-1.5 text-[10px] text-slate-400 hover:text-slate-200"
+        onClick={() => setRoleFolded(f => !f)}
+      >
+        <span>By role</span>
+        <span>{roleFolded ? "▸" : "▾"}</span>
+      </button>
+      {!roleFolded && (
+        <table className="w-full text-[10px] font-mono px-3 pb-2">
+          <thead>
+            <tr>
+              <th className="px-2 text-left text-slate-500 font-normal">Role</th>
+              <th className="px-2 text-right text-slate-500 font-normal">Sessions</th>
+              <th className="px-2 text-right text-slate-500 font-normal">Time</th>
+              <th className="px-2 text-right text-slate-500 font-normal">Cost</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.entries(roleMap).sort(([a], [b]) => a.localeCompare(b)).map(([role, agg]) => (
+              <tr key={role} className="border-t border-slate-800">
+                <td className="px-2 py-0.5 text-slate-300">{role}</td>
+                <td className="px-2 py-0.5 text-right text-slate-400">{agg.count}</td>
+                <td className="px-2 py-0.5 text-right text-slate-300">{formatDuration(agg.secs)}</td>
+                <td className="px-2 py-0.5 text-right text-emerald-400">{formatCost(agg.cost)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+
+  // Note: model reflects pool's current config — pools edited after a session
+  // ran will show their new model here (resolve-on-read, no migration needed).
+  const caveat = !loading && rows.length > 0 && (
+    <div className="px-3 py-1.5 text-[9px] text-slate-600 border-t border-slate-800">
+      Model reflects pool's current config. Edited pools show new model values.
+    </div>
+  );
+
+  const inner = (
+    <div ref={ref} className="flex flex-col bg-slate-900 border border-slate-700 rounded-lg shadow-2xl overflow-hidden min-w-[620px]">
+      {headerRow}
+      {tableContent}
+      {roleRollup}
+      {caveat}
+    </div>
+  );
+
+  if (useModal) {
+    return (
+      <div
+        className="fixed inset-0 bg-black/60 flex items-center justify-center z-[60]"
+        onClick={(e) => e.stopPropagation()}
+        onMouseDown={(e) => e.stopPropagation()}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        <div className="max-w-[800px] w-full mx-4">
+          {inner}
+        </div>
+      </div>
+    );
+  }
+
+  // Popover positioning.
+  const left = anchor ? Math.min(anchor.x, window.innerWidth - 640) : 100;
+  const top  = anchor ? anchor.y + 8 : 100;
+  const style: React.CSSProperties = { position: "fixed", zIndex: 100, left, top };
+
+  return (
+    <div style={style} onClick={(e) => e.stopPropagation()} onMouseDown={(e) => e.stopPropagation()}>
+      {inner}
+    </div>
+  );
+}
+
+// --- helpers ---
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return "—";
+  return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+function formatDuration(secs: number): string {
+  if (!secs || secs <= 0) return "—";
+  if (secs < 60) return `${Math.round(secs)}s`;
+  if (secs < 3600) {
+    const m = Math.floor(secs / 60);
+    const s = Math.round(secs % 60);
+    return `${m}m${String(s).padStart(2, "0")}s`;
+  }
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  return `${h}h${String(m).padStart(2, "0")}m`;
+}
+
+function formatCost(usd: number): string {
+  if (usd <= 0) return "$0.00";
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
+function formatTokens(n: number): string {
+  if (!n || n <= 0) return "—";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+type FailureCause = { kind: string; reason?: string } | null | undefined;
+
+function OutcomeChip({ outcome, cause }: { outcome: string; cause: FailureCause }) {
+  const label = outcome === "completed" ? "done"
+    : outcome === "failed" ? "failed"
+    : outcome === "blocked" ? "blocked"
+    : outcome === "running" ? "running"
+    : outcome === "waiting_for_input" ? "waiting"
+    : outcome;
+
+  const cls = outcome === "completed" ? "text-emerald-400"
+    : outcome === "failed" || outcome === "blocked" ? "text-red-400"
+    : outcome === "running" || outcome === "waiting_for_input" ? "text-blue-400"
+    : "text-slate-400";
+
+  const title = cause ? (cause.reason || cause.kind || "") : undefined;
+
+  return (
+    <span className={cls} title={title}>
+      {label}
+    </span>
+  );
+}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -20,9 +20,9 @@ export function ActivateGoal(arg1:string):Promise<void>;
 
 export function AddIssueDep(arg1:string,arg2:number,arg3:types.IssueDep):Promise<void>;
 
-export function AddManualIssue(arg1:string,arg2:number,arg3:string,arg4:string,arg5:Array<string>,arg6:string):Promise<types.Issue>;
-
 export function AddJiraWorkspace(arg1:main.JiraWorkspaceForm):Promise<void>;
+
+export function AddManualIssue(arg1:string,arg2:number,arg3:string,arg4:string,arg5:Array<string>,arg6:string):Promise<types.Issue>;
 
 export function AddWorkspace(arg1:types.Workspace):Promise<void>;
 
@@ -70,6 +70,8 @@ export function DiscoverWorkspaceSkills(arg1:string):Promise<Array<types.SkillRe
 
 export function EstimateSpawnCost(arg1:string,arg2:number,arg3:string):Promise<main.SpawnEstimate>;
 
+export function ExportSessionLedgerCSV(arg1:string,arg2:number):Promise<void>;
+
 export function FetchIssueDetail(arg1:string,arg2:number):Promise<types.Issue>;
 
 export function FetchPRChecks(arg1:string,arg2:number):Promise<string>;
@@ -103,6 +105,8 @@ export function GetPoolUsage():Promise<Array<types.PoolUsage>>;
 export function GetRepoDefaultBranch(arg1:string,arg2:string,arg3:string):Promise<string>;
 
 export function GetRetryQueue(arg1:string):Promise<Array<retry.PendingRetry>>;
+
+export function GetSessionLedger(arg1:string,arg2:number):Promise<Array<types.SessionLedgerRow>>;
 
 export function GetWorkspaceCostProjection(arg1:string):Promise<Array<main.PoolCostProjection>>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -14,12 +14,12 @@ export function AddIssueDep(arg1, arg2, arg3) {
   return window['go']['main']['App']['AddIssueDep'](arg1, arg2, arg3);
 }
 
-export function AddManualIssue(arg1, arg2, arg3, arg4, arg5, arg6) {
-  return window['go']['main']['App']['AddManualIssue'](arg1, arg2, arg3, arg4, arg5, arg6);
-}
-
 export function AddJiraWorkspace(arg1) {
   return window['go']['main']['App']['AddJiraWorkspace'](arg1);
+}
+
+export function AddManualIssue(arg1, arg2, arg3, arg4, arg5, arg6) {
+  return window['go']['main']['App']['AddManualIssue'](arg1, arg2, arg3, arg4, arg5, arg6);
 }
 
 export function AddWorkspace(arg1) {
@@ -114,6 +114,10 @@ export function EstimateSpawnCost(arg1, arg2, arg3) {
   return window['go']['main']['App']['EstimateSpawnCost'](arg1, arg2, arg3);
 }
 
+export function ExportSessionLedgerCSV(arg1, arg2) {
+  return window['go']['main']['App']['ExportSessionLedgerCSV'](arg1, arg2);
+}
+
 export function FetchIssueDetail(arg1, arg2) {
   return window['go']['main']['App']['FetchIssueDetail'](arg1, arg2);
 }
@@ -180,6 +184,10 @@ export function GetRepoDefaultBranch(arg1, arg2, arg3) {
 
 export function GetRetryQueue(arg1) {
   return window['go']['main']['App']['GetRetryQueue'](arg1);
+}
+
+export function GetSessionLedger(arg1, arg2) {
+  return window['go']['main']['App']['GetSessionLedger'](arg1, arg2);
 }
 
 export function GetWorkspaceCostProjection(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1221,6 +1221,32 @@ export namespace main {
 	        this.run_count = source["run_count"];
 	    }
 	}
+	export class JiraWorkspaceForm {
+	    id: string;
+	    display_name: string;
+	    color: string;
+	    instance_url: string;
+	    email: string;
+	    api_token: string;
+	    project_key: string;
+	    jql: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new JiraWorkspaceForm(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
+	        this.display_name = source["display_name"];
+	        this.color = source["color"];
+	        this.instance_url = source["instance_url"];
+	        this.email = source["email"];
+	        this.api_token = source["api_token"];
+	        this.project_key = source["project_key"];
+	        this.jql = source["jql"];
+	    }
+	}
 	export class LabelFilterState {
 	    labels: string[];
 	    mode: string;
@@ -1359,32 +1385,6 @@ export namespace main {
 	        this.keyring_unavailable = source["keyring_unavailable"];
 	    }
 	}
-	export class JiraWorkspaceForm {
-	    id: string;
-	    display_name: string;
-	    color: string;
-	    instance_url: string;
-	    email: string;
-	    api_token: string;
-	    project_key: string;
-	    jql: string;
-
-	    static createFrom(source: any = {}) {
-	        return new JiraWorkspaceForm(source);
-	    }
-
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.id = source["id"];
-	        this.display_name = source["display_name"];
-	        this.color = source["color"];
-	        this.instance_url = source["instance_url"];
-	        this.email = source["email"];
-	        this.api_token = source["api_token"];
-	        this.project_key = source["project_key"];
-	        this.jql = source["jql"];
-	    }
-	}
 	export class RemoteWorkspaceForm {
 	    cf_token: string;
 	    github_pat: string;
@@ -1394,11 +1394,11 @@ export namespace main {
 	    github_repo: string;
 	    default_branch: string;
 	    color: string;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new RemoteWorkspaceForm(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.cf_token = source["cf_token"];
@@ -1752,6 +1752,20 @@ export namespace types {
 		    return a;
 		}
 	}
+	export class TrackerRef {
+	    kind: string;
+	    identifier: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new TrackerRef(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.kind = source["kind"];
+	        this.identifier = source["identifier"];
+	    }
+	}
 	export class NeedsPRInfo {
 	    branch: string;
 	    worktree_dir: string;
@@ -1774,21 +1788,7 @@ export namespace types {
 	        this.commit_msg = source["commit_msg"];
 	    }
 	}
-	export class TrackerRef {
-	    kind: string;
-	    identifier: string;
-
-	    static createFrom(source: any = {}) {
-	        return new TrackerRef(source);
-	    }
-
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.kind = source["kind"];
-	        this.identifier = source["identifier"];
-	    }
-	}
-		export class Question {
+	export class Question {
 	    id: string;
 	    type: string;
 	    prompt: string;
@@ -1925,11 +1925,11 @@ export namespace types {
 	    needs_pr_info?: NeedsPRInfo;
 	    failure_reason?: string;
 	    tracker_ref?: TrackerRef;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new Issue(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.number = source["number"];
@@ -1966,7 +1966,7 @@ export namespace types {
 	        this.failure_reason = source["failure_reason"];
 	        this.tracker_ref = this.convertValues(source["tracker_ref"], TrackerRef);
 	    }
-
+	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
 		    if (!a) {
 		        return a;
@@ -2451,6 +2451,61 @@ export namespace types {
 		    return a;
 		}
 	}
+	export class SessionLedgerRow {
+	    session_id: string;
+	    role: string;
+	    pool_id: string;
+	    pool_name: string;
+	    provider: string;
+	    model: string;
+	    // Go type: time
+	    started_at: any;
+	    duration_s: number;
+	    cost_usd: number;
+	    input_tokens: number;
+	    output_tokens: number;
+	    outcome: string;
+	    failure_cause?: FailureCause;
+	
+	    static createFrom(source: any = {}) {
+	        return new SessionLedgerRow(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.session_id = source["session_id"];
+	        this.role = source["role"];
+	        this.pool_id = source["pool_id"];
+	        this.pool_name = source["pool_name"];
+	        this.provider = source["provider"];
+	        this.model = source["model"];
+	        this.started_at = this.convertValues(source["started_at"], null);
+	        this.duration_s = source["duration_s"];
+	        this.cost_usd = source["cost_usd"];
+	        this.input_tokens = source["input_tokens"];
+	        this.output_tokens = source["output_tokens"];
+	        this.outcome = source["outcome"];
+	        this.failure_cause = this.convertValues(source["failure_cause"], FailureCause);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
 	export class SkillProfile {
 	    mode: string;
 	    use_conductor_plan: boolean;
@@ -2514,6 +2569,7 @@ export namespace types {
 		}
 	}
 	
+	
 	export class WorkspacePipeline {
 	    steps: PipelineStep[];
 	    version: number;
@@ -2569,12 +2625,12 @@ export namespace types {
 	    retry_policy?: RetryPolicy;
 	    complexity_scale?: string;
 	    tracker_kind?: string;
-	    tracker_config?: any;
-
+	    tracker_config?: number[];
+	
 	    static createFrom(source: any = {}) {
 	        return new Workspace(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];

--- a/internal/issueview/assembler.go
+++ b/internal/issueview/assembler.go
@@ -551,6 +551,68 @@ func (a *Assembler) SetSelfHealAttempts(workspaceID string, issueNumber, attempt
 	}
 }
 
+// BuildSessionLedger returns a per-session ledger for the given issue, ordered
+// newest-first. Pool lookup is resolve-on-read: deleted pools produce "(pool deleted)".
+// Capped at 1000 rows to prevent pathological returns.
+func (a *Assembler) BuildSessionLedger(workspaceID string, issueNumber int) ([]types.SessionLedgerRow, error) {
+	sessions, err := a.store.ListSessionsForIssue(workspaceID, issueNumber)
+	if err != nil {
+		return nil, err
+	}
+	const maxRows = 1000
+	if len(sessions) > maxRows {
+		sessions = sessions[:maxRows]
+	}
+
+	out := make([]types.SessionLedgerRow, 0, len(sessions))
+	poolCache := map[string]types.Pool{}
+	for _, sess := range sessions {
+		row := types.SessionLedgerRow{
+			SessionID:    sess.ID,
+			Role:         deriveRole(sess),
+			PoolID:       sess.PoolID,
+			InputTokens:  sess.InputTokens,
+			OutputTokens: sess.OutputTokens,
+			CostUSD:      sess.EstimatedCostCents / 100.0,
+			StartedAt:    sess.StartedAt,
+			Outcome:      string(sess.State),
+			FailureCause: sess.FailureCause,
+		}
+		if sess.EndedAt != nil {
+			row.DurationS = sess.EndedAt.Sub(sess.StartedAt).Seconds()
+		}
+		if sess.PoolID != "" {
+			pool, ok := poolCache[sess.PoolID]
+			if !ok {
+				if p, err := a.store.GetPool(sess.PoolID); err == nil {
+					pool = p
+					poolCache[sess.PoolID] = p
+				}
+			}
+			if pool.ID != "" {
+				row.PoolName = pool.Name
+				row.Provider = string(pool.Provider)
+				row.Model = pool.Model
+			} else {
+				row.PoolName = "(pool deleted)"
+			}
+		}
+		out = append(out, row)
+	}
+	return out, nil
+}
+
+// deriveRole maps a session to a human-readable role string.
+func deriveRole(sess types.Session) string {
+	if sess.PipelineStepName != "" {
+		return "pipeline:" + sess.PipelineStepName
+	}
+	if sess.Mode == types.ModePlan {
+		return "plan"
+	}
+	return "execute"
+}
+
 // ListForWorkspace assembles an IssueView for every non-archived issue in the workspace.
 func (a *Assembler) ListForWorkspace(workspaceID string) ([]IssueView, error) {
 	issues, err := a.store.ListIssues(workspaceID)

--- a/internal/issueview/assembler_ledger_test.go
+++ b/internal/issueview/assembler_ledger_test.go
@@ -1,0 +1,218 @@
+package issueview
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"prismconductor/internal/eventbus"
+	"prismconductor/internal/types"
+)
+
+// poolStore extends fakeStore with a controllable pool lookup.
+type poolStore struct {
+	fakeStore
+	pools map[string]types.Pool
+}
+
+func (p *poolStore) GetPool(id string) (types.Pool, error) {
+	if pool, ok := p.pools[id]; ok {
+		return pool, nil
+	}
+	return types.Pool{}, fmt.Errorf("pool not found: %s", id)
+}
+
+func newPoolStore(sessions map[int][]types.Session, pools map[string]types.Pool) *poolStore {
+	return &poolStore{
+		fakeStore: fakeStore{sessions: sessions},
+		pools:     pools,
+	}
+}
+
+func newLedgerAssembler(st issueStore) *Assembler {
+	bus := eventbus.New()
+	return New(bus, st)
+}
+
+func TestBuildSessionLedger_Empty(t *testing.T) {
+	st := newPoolStore(nil, nil)
+	a := newLedgerAssembler(st)
+	rows, err := a.BuildSessionLedger("ws1", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows, got %d", len(rows))
+	}
+}
+
+func TestBuildSessionLedger_PoolResolved(t *testing.T) {
+	now := time.Now()
+	ended := now.Add(2 * time.Minute)
+	sess := types.Session{
+		ID:                 "s1",
+		WorkspaceID:        "ws1",
+		IssueNumber:        42,
+		Mode:               types.ModeExecute,
+		State:              types.StateCompleted,
+		StartedAt:          now,
+		EndedAt:            &ended,
+		PoolID:             "pool-a",
+		InputTokens:        100,
+		OutputTokens:       200,
+		EstimatedCostCents: 50,
+	}
+	pool := types.Pool{ID: "pool-a", Name: "MyPool", Provider: types.ProviderClaude, Model: "claude-opus-4-7"}
+	st := newPoolStore(map[int][]types.Session{42: {sess}}, map[string]types.Pool{"pool-a": pool})
+	a := newLedgerAssembler(st)
+
+	rows, err := a.BuildSessionLedger("ws1", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	r := rows[0]
+	if r.SessionID != "s1" {
+		t.Errorf("session_id: got %q, want %q", r.SessionID, "s1")
+	}
+	if r.Role != "execute" {
+		t.Errorf("role: got %q, want %q", r.Role, "execute")
+	}
+	if r.PoolName != "MyPool" {
+		t.Errorf("pool_name: got %q, want %q", r.PoolName, "MyPool")
+	}
+	if r.Provider != "claude" {
+		t.Errorf("provider: got %q, want %q", r.Provider, "claude")
+	}
+	if r.Model != "claude-opus-4-7" {
+		t.Errorf("model: got %q, want %q", r.Model, "claude-opus-4-7")
+	}
+	if r.CostUSD != 0.5 {
+		t.Errorf("cost_usd: got %f, want 0.5", r.CostUSD)
+	}
+	if r.InputTokens != 100 || r.OutputTokens != 200 {
+		t.Errorf("tokens: got in=%d out=%d, want in=100 out=200", r.InputTokens, r.OutputTokens)
+	}
+	if r.Outcome != "completed" {
+		t.Errorf("outcome: got %q, want %q", r.Outcome, "completed")
+	}
+	wantDuration := ended.Sub(now).Seconds()
+	if r.DurationS != wantDuration {
+		t.Errorf("duration_s: got %f, want %f", r.DurationS, wantDuration)
+	}
+}
+
+func TestBuildSessionLedger_DeletedPool(t *testing.T) {
+	now := time.Now()
+	sess := types.Session{
+		ID:          "s2",
+		WorkspaceID: "ws1",
+		IssueNumber: 10,
+		Mode:        types.ModePlan,
+		State:       types.StateCompleted,
+		StartedAt:   now,
+		PoolID:      "pool-gone",
+	}
+	// No pool registered — simulates a deleted pool.
+	st := newPoolStore(map[int][]types.Session{10: {sess}}, nil)
+	a := newLedgerAssembler(st)
+
+	rows, err := a.BuildSessionLedger("ws1", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	r := rows[0]
+	if r.PoolName != "(pool deleted)" {
+		t.Errorf("pool_name: got %q, want %q", r.PoolName, "(pool deleted)")
+	}
+	if r.Role != "plan" {
+		t.Errorf("role: got %q, want %q", r.Role, "plan")
+	}
+}
+
+func TestBuildSessionLedger_PipelineStepRole(t *testing.T) {
+	now := time.Now()
+	sess := types.Session{
+		ID:               "s3",
+		WorkspaceID:      "ws1",
+		IssueNumber:      7,
+		Mode:             types.ModeExecute,
+		State:            types.StateCompleted,
+		StartedAt:        now,
+		PipelineStepName: "adversarial-review",
+	}
+	st := newPoolStore(map[int][]types.Session{7: {sess}}, nil)
+	a := newLedgerAssembler(st)
+
+	rows, err := a.BuildSessionLedger("ws1", 7)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].Role != "pipeline:adversarial-review" {
+		t.Errorf("role: got %q, want %q", rows[0].Role, "pipeline:adversarial-review")
+	}
+}
+
+func TestBuildSessionLedger_FailureCausePassthrough(t *testing.T) {
+	now := time.Now()
+	cause := &types.FailureCause{Kind: "blocked", Reason: "lint failed — go vet exited 1"}
+	sess := types.Session{
+		ID:           "s4",
+		WorkspaceID:  "ws1",
+		IssueNumber:  5,
+		Mode:         types.ModeExecute,
+		State:        types.StateBlocked,
+		StartedAt:    now,
+		BlockedReason: "lint failed",
+		FailureCause: cause,
+	}
+	st := newPoolStore(map[int][]types.Session{5: {sess}}, nil)
+	a := newLedgerAssembler(st)
+
+	rows, err := a.BuildSessionLedger("ws1", 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	r := rows[0]
+	if r.Outcome != "blocked" {
+		t.Errorf("outcome: got %q, want %q", r.Outcome, "blocked")
+	}
+	if r.FailureCause == nil || r.FailureCause.Kind != "blocked" {
+		t.Errorf("failure_cause: got %+v, want kind=blocked", r.FailureCause)
+	}
+}
+
+func TestBuildSessionLedger_PoolCacheHit(t *testing.T) {
+	now := time.Now()
+	pool := types.Pool{ID: "pool-x", Name: "CachedPool", Provider: types.ProviderOpenAI, Model: "gpt-4o"}
+	sessions := []types.Session{
+		{ID: "s5", WorkspaceID: "ws1", IssueNumber: 99, Mode: types.ModeExecute, State: types.StateCompleted, StartedAt: now, PoolID: "pool-x"},
+		{ID: "s6", WorkspaceID: "ws1", IssueNumber: 99, Mode: types.ModeExecute, State: types.StateCompleted, StartedAt: now.Add(-time.Minute), PoolID: "pool-x"},
+	}
+	st := newPoolStore(map[int][]types.Session{99: sessions}, map[string]types.Pool{"pool-x": pool})
+	a := newLedgerAssembler(st)
+
+	rows, err := a.BuildSessionLedger("ws1", 99)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	for _, r := range rows {
+		if r.PoolName != "CachedPool" {
+			t.Errorf("pool_name: got %q, want %q", r.PoolName, "CachedPool")
+		}
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -830,6 +830,28 @@ type Collection struct {
 // workspace is already a member of any collection (v1 single-membership rule).
 var ErrAlreadyInCollection = errors.New("workspace already belongs to a collection")
 
+// --- Session Ledger (issue #298) ---
+
+// SessionLedgerRow is one entry in the per-issue session ledger. Derived at
+// read time by BuildSessionLedger in the issueview assembler; no DB migration
+// required. Model/provider reflect the pool's current configuration — pools
+// edited after a session ran will show their new values here (resolve-on-read).
+type SessionLedgerRow struct {
+	SessionID    string        `json:"session_id"`
+	Role         string        `json:"role"`          // "plan", "execute", "pipeline:<step>"
+	PoolID       string        `json:"pool_id"`
+	PoolName     string        `json:"pool_name"`     // "(pool deleted)" if lookup fails
+	Provider     string        `json:"provider"`
+	Model        string        `json:"model"`
+	StartedAt    time.Time     `json:"started_at"`
+	DurationS    float64       `json:"duration_s"`    // 0 if session never ended
+	CostUSD      float64       `json:"cost_usd"`
+	InputTokens  int64         `json:"input_tokens"`
+	OutputTokens int64         `json:"output_tokens"`
+	Outcome      string        `json:"outcome"`       // mirrors SessionState values
+	FailureCause *FailureCause `json:"failure_cause,omitempty"`
+}
+
 // --- Pool usage / rate limits (issue #52) ---
 
 // PoolUsage is a last-seen snapshot of rate-limit consumption for one


### PR DESCRIPTION
## Summary

- Adds a clickable CostChip on each card that opens a per-issue **Session Ledger** — a sortable table listing every session that touched the card with role, pool, model, start time, duration, cost (USD), token counts (in/out), and outcome
- Totals footer row cross-checks existing CostChip/WorkTimerChip cumulative sums; role roll-up collapses by plan/execute/pipeline step
- CSV export opens a native Save As dialog and writes a valid CSV with one row per session
- Ledger data assembled on-demand from existing session rows and the pool registry — no DB migration required (resolve-on-read; deleted pools show "(pool deleted)")

## Files modified

- `internal/types/types.go` — `SessionLedgerRow` struct
- `internal/issueview/assembler.go` — `BuildSessionLedger()` with pool cache
- `internal/issueview/assembler_ledger_test.go` — 6 new unit tests
- `app.go` — `GetSessionLedger` and `ExportSessionLedgerCSV` Wails bindings
- `frontend/src/components/SessionLedger.tsx` — new UI component (popover <=8 rows, modal >8)
- `frontend/src/components/Card.tsx` — CostChip is now a button that opens the ledger
- `frontend/wailsjs/go/main/App.js` / `App.d.ts` / `models.ts` — regenerated by wails dev

## Verification

| Gate | Command | Result |
|---|---|---|
| Lint | `go vet ./...` | pass |
| Build | `go build .` | pass |
| TypeScript | `tsc --noEmit` | pass |
| Smoke test | `playwright test tests/e2e/startup.spec.ts` | 1 passed |
| Go tests | `go test ./...` | all pass (6 new ledger tests) |

**Commit tier:** Tier 1 (GitHub API signed commit `559f06c`)

**Note:** Model column reflects the pool's current config. Pools edited after a session ran will show their new model here (resolve-on-read; no migration needed for initial ship per answered question q1).

**Workspace mode:** per-execute worktree at `/Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-298`

Closes #298
