### PR TITLE
feat(#291): Slack as bidirectional command surface (v1)

### DIFF
--- a/app.go
+++ b/app.go
@@ -52,6 +52,7 @@ import (
 	"prismconductor/internal/store"
 	pcjira "prismconductor/internal/tracker/jira"
 	"prismconductor/internal/types"
+	pcslack "prismconductor/internal/slack"
 	"prismconductor/internal/wailsbus"
 	"prismconductor/internal/workerpool"
 	"prismconductor/internal/workspace"
@@ -98,6 +99,13 @@ type App struct {
 
 	// Issue #221: auto-retry scheduler for transient execute failures.
 	retryScheduler *retry.Scheduler
+
+	// Issue #291: Slack integration — per-workspace Socket Mode managers,
+	// the shared auth registry, and the notification router.
+	slackMu      sync.RWMutex
+	slackMgrs    map[string]*pcslack.Manager // wsID → manager
+	slackAuthz   *pcslack.AuthRegistry
+	slackRouter  *pcslack.Router
 }
 
 type issueDetailEntry struct {
@@ -495,6 +503,18 @@ func (a *App) startup(ctx context.Context) {
 		a.jiraPoller = pcjira.NewPoller(a.bus, a.store, a.wsReg, jiraInterval)
 		go a.jiraPoller.Run(a.ctx)
 	}
+
+	// Issue #291: Slack integration — initialise per-workspace Socket Mode managers.
+	a.slackAuthz = pcslack.NewAuthRegistry()
+	a.slackMgrs = make(map[string]*pcslack.Manager)
+	if a.wsReg != nil {
+		for _, ws := range a.wsReg.List() {
+			if ws.SlackConfig == nil || !ws.SlackConfig.Enabled {
+				continue
+			}
+			go a.startSlackForWorkspace(ws)
+		}
+	}
 }
 
 // handleSessionStateChange runs on every session state transition. Fans the
@@ -619,6 +639,9 @@ func (a *App) handleSessionStateChange(sess types.Session, prev types.SessionSta
 			"issue_number": sess.IssueNumber,
 			"action":       "focus_card",
 		})
+
+		// Issue #291: fan out to Slack if the workspace has Slack configured.
+		a.routeSessionEventToSlack(sess)
 	}
 }
 
@@ -3188,6 +3211,15 @@ func (a *App) handlePlanReady(sess types.Session, relPath string) {
 			"issue_number": sess.IssueNumber,
 			"action":       "open_plan",
 		})
+
+	// Issue #291: notify Slack that a plan is ready for approval.
+	if a.slackRouter != nil {
+		issTitle := ""
+		if iss, err2 := a.store.LoadIssue(sess.WorkspaceID, sess.IssueNumber); err2 == nil {
+			issTitle = iss.Title
+		}
+		a.slackRouter.NotifyPlanReady(sess.WorkspaceID, ws.DisplayName, sess.IssueNumber, issTitle)
+	}
 }
 
 // pullNumberRegexp extracts the PR number from a github.com pull URL.
@@ -5768,4 +5800,386 @@ func (a *App) handleFanoutWritten(sess types.Session, path string) {
 		"workspace_id":  sess.WorkspaceID,
 		"count":         len(analysis.Proposals),
 	})
+}
+
+// --- Slack integration (issue #291) ---
+
+// SlackStatus describes the connection state of the Slack integration for one workspace.
+type SlackStatus struct {
+	Connected bool   `json:"connected"`
+	TeamName  string `json:"team_name,omitempty"`
+	BotUserID string `json:"bot_user_id,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+// GetSlackConfig returns the Slack configuration for a workspace. Returns nil
+// when Slack is not configured. Credentials are refs only, never raw tokens.
+func (a *App) GetSlackConfig(workspaceID string) (*types.SlackConfig, error) {
+	if a.wsReg == nil {
+		return nil, fmt.Errorf("workspace registry unavailable")
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return nil, fmt.Errorf("unknown workspace %q", workspaceID)
+	}
+	return ws.SlackConfig, nil
+}
+
+// SaveSlackConfig persists Slack configuration for a workspace and (re)starts
+// the Socket Mode connection when enabled=true.
+func (a *App) SaveSlackConfig(workspaceID string, cfg types.SlackConfig) error {
+	if a.wsReg == nil {
+		return fmt.Errorf("workspace registry unavailable")
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return fmt.Errorf("unknown workspace %q", workspaceID)
+	}
+	ws.SlackConfig = &cfg
+	if err := a.wsReg.Update(ws); err != nil {
+		return fmt.Errorf("save workspace: %w", err)
+	}
+
+	// Reload auth registry entries for this workspace.
+	if a.slackAuthz != nil && cfg.UserMap != nil {
+		a.slackAuthz.LoadWorkspace(workspaceID, cfg.UserMap)
+	}
+
+	// Stop any existing manager for this workspace.
+	a.stopSlackForWorkspace(workspaceID)
+
+	if cfg.Enabled {
+		go a.startSlackForWorkspace(ws)
+	}
+
+	wailsbus.EmitEvent(a.ctx, "slack.config_updated", map[string]any{"workspace_id": workspaceID})
+	return nil
+}
+
+// SaveSlackCredentials stores Slack tokens in the OS keyring and updates the
+// workspace config refs. The raw token values are never persisted in workspaces.json.
+func (a *App) SaveSlackCredentials(workspaceID, botToken, appLevelToken string) error {
+	if botToken == "" || appLevelToken == "" {
+		return fmt.Errorf("bot token and app-level token are required")
+	}
+
+	botKey := secretstore.SlackBotTokenKey(workspaceID)
+	appKey := secretstore.SlackAppLevelTokenKey(workspaceID)
+
+	if err := a.secretStore.Set(botKey, botToken); err != nil {
+		return fmt.Errorf("store bot token: %w", err)
+	}
+	if err := a.secretStore.Set(appKey, appLevelToken); err != nil {
+		return fmt.Errorf("store app-level token: %w", err)
+	}
+
+	if a.wsReg == nil {
+		return nil
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return fmt.Errorf("unknown workspace %q", workspaceID)
+	}
+	if ws.SlackConfig == nil {
+		ws.SlackConfig = &types.SlackConfig{}
+	}
+	ws.SlackConfig.BotTokenRef = botKey
+	ws.SlackConfig.AppLevelTokenRef = appKey
+	return a.wsReg.Update(ws)
+}
+
+// DisconnectSlack stops the Slack integration for a workspace and clears
+// the credentials from the keyring.
+func (a *App) DisconnectSlack(workspaceID string) error {
+	a.stopSlackForWorkspace(workspaceID)
+
+	if a.wsReg == nil {
+		return fmt.Errorf("workspace registry unavailable")
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return fmt.Errorf("unknown workspace %q", workspaceID)
+	}
+	if ws.SlackConfig != nil {
+		// Remove keyring entries.
+		_ = a.secretStore.Delete(ws.SlackConfig.BotTokenRef)
+		_ = a.secretStore.Delete(ws.SlackConfig.AppLevelTokenRef)
+		ws.SlackConfig = nil
+		if err := a.wsReg.Update(ws); err != nil {
+			return fmt.Errorf("save workspace: %w", err)
+		}
+	}
+	wailsbus.EmitEvent(a.ctx, "slack.config_updated", map[string]any{"workspace_id": workspaceID})
+	return nil
+}
+
+// GetSlackStatus returns the live connection status for a workspace's Slack bot.
+func (a *App) GetSlackStatus(workspaceID string) SlackStatus {
+	a.slackMu.RLock()
+	mgr, ok := a.slackMgrs[workspaceID]
+	a.slackMu.RUnlock()
+	if !ok || mgr == nil {
+		return SlackStatus{Connected: false}
+	}
+	return SlackStatus{
+		Connected: true,
+		BotUserID: mgr.BotUserID(),
+	}
+}
+
+// startSlackForWorkspace loads credentials from the keyring and starts a
+// Socket Mode manager for the workspace. Called from startup and SaveSlackConfig.
+func (a *App) startSlackForWorkspace(ws types.Workspace) {
+	if ws.SlackConfig == nil || !ws.SlackConfig.Enabled {
+		return
+	}
+	sc := ws.SlackConfig
+
+	botToken, err := a.secretStore.Get(sc.BotTokenRef)
+	if err != nil {
+		log.Printf("slack[%s]: load bot token: %v", ws.ID, err)
+		return
+	}
+	appToken, err := a.secretStore.Get(sc.AppLevelTokenRef)
+	if err != nil {
+		log.Printf("slack[%s]: load app-level token: %v", ws.ID, err)
+		return
+	}
+
+	// Populate auth registry from workspace user map.
+	if a.slackAuthz != nil && sc.UserMap != nil {
+		a.slackAuthz.LoadWorkspace(ws.ID, sc.UserMap)
+	}
+
+	mgr, err := pcslack.NewManager(pcslack.Config{
+		BotToken:      botToken,
+		AppLevelToken: appToken,
+		WorkspaceID:   ws.ID,
+	}, a, a.slackAuthz)
+	if err != nil {
+		log.Printf("slack[%s]: init manager: %v", ws.ID, err)
+		return
+	}
+
+	a.slackMu.Lock()
+	a.slackMgrs[ws.ID] = mgr
+	// Attach a router if one doesn't exist yet.
+	if a.slackRouter == nil {
+		a.slackRouter = pcslack.NewRouter(mgr)
+	}
+	a.slackMu.Unlock()
+
+	// Register notification routing for this workspace.
+	if a.slackRouter != nil {
+		channel := sc.DefaultChannel
+		routing := pcslack.EventRouting{
+			PlanReady:   sc.EventRouting.PlanReady,
+			Blocked:     sc.EventRouting.Blocked,
+			Completed:   sc.EventRouting.Completed,
+			BudgetAlert: sc.EventRouting.BudgetAlert,
+			AutoArchive: sc.EventRouting.AutoArchive,
+		}
+		// Default plan_ready and blocked to true for new configs.
+		if !sc.EventRouting.PlanReady && !sc.EventRouting.Blocked &&
+			!sc.EventRouting.Completed && !sc.EventRouting.BudgetAlert {
+			def := pcslack.DefaultEventRouting()
+			routing = def
+		}
+		a.slackRouter.SetWorkspaceRoute(ws.ID, pcslack.WorkspaceRoute{
+			Channel: channel,
+			Routing: routing,
+			Muted:   sc.Muted,
+		})
+	}
+
+	mgr.Start(a.ctx)
+	log.Printf("slack[%s]: socket mode started (bot=%s)", ws.ID, mgr.BotUserID())
+}
+
+// stopSlackForWorkspace stops and removes the manager for a workspace.
+func (a *App) stopSlackForWorkspace(workspaceID string) {
+	a.slackMu.Lock()
+	mgr, ok := a.slackMgrs[workspaceID]
+	if ok {
+		delete(a.slackMgrs, workspaceID)
+	}
+	a.slackMu.Unlock()
+
+	if ok && mgr != nil {
+		mgr.Stop()
+	}
+	if a.slackRouter != nil {
+		a.slackRouter.RemoveWorkspaceRoute(workspaceID)
+	}
+}
+
+// routeSessionEventToSlack fans a session state change to the Slack router.
+func (a *App) routeSessionEventToSlack(sess types.Session) {
+	if a.slackRouter == nil {
+		return
+	}
+	wsName := toastWorkspaceName(a.wsReg, sess.WorkspaceID)
+	switch sess.State {
+	case types.StateBlocked, types.StateFailed:
+		a.slackRouter.NotifyBlocked(sess.WorkspaceID, wsName, sess.IssueNumber, sess.BlockedReason)
+	case types.StateCompleted:
+		a.slackRouter.NotifyCompleted(sess.WorkspaceID, wsName, sess.IssueNumber)
+	}
+}
+
+// --- AppFacade implementation (pcslack.AppFacade interface) ---
+
+// SlackCommandListWorkspaces returns a formatted workspace list for Slack.
+func (a *App) SlackCommandListWorkspaces() string {
+	if a.wsReg == nil {
+		return "No workspaces configured."
+	}
+	workspaces := a.wsReg.List()
+	if len(workspaces) == 0 {
+		return "No workspaces configured."
+	}
+	var sb strings.Builder
+	sb.WriteString("*Workspaces*\n")
+	for _, ws := range workspaces {
+		if !ws.Enabled {
+			continue
+		}
+		cost := 0.0
+		if a.store != nil {
+			cost = a.WorkspaceSpendToday(ws.ID)
+		}
+		sb.WriteString(fmt.Sprintf("• *%s* (`%s`) — today: $%.2f\n", ws.DisplayName, ws.ID, cost))
+	}
+	return sb.String()
+}
+
+// SlackCommandStatus returns a workspace status summary for Slack.
+func (a *App) SlackCommandStatus(workspaceID string) string {
+	if a.wsReg == nil || a.store == nil {
+		return "Store unavailable."
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return fmt.Sprintf("Unknown workspace `%s`.", workspaceID)
+	}
+	issues, err := a.store.ListIssues(workspaceID)
+	if err != nil {
+		return fmt.Sprintf("Error loading issues: %v", err)
+	}
+
+	var inProgress, inPlan, blocked int
+	for _, iss := range issues {
+		switch iss.Column {
+		case types.ColInProgress:
+			inProgress++
+		case types.ColPlan:
+			inPlan++
+		case types.ColBlocked:
+			blocked++
+		}
+	}
+
+	todayCost := a.WorkspaceSpendToday(workspaceID)
+	return fmt.Sprintf("*%s* status\n• In-progress: %d | Plan ready: %d | Blocked: %d\n• Cost today: $%.2f",
+		ws.DisplayName, inProgress, inPlan, blocked, todayCost)
+}
+
+// SlackCommandPlan spawns a planner for the given issue. Satisfies AppFacade.
+func (a *App) SlackCommandPlan(workspaceID string, issueNumber int) error {
+	_, err := a.SpawnPlanForIssue(workspaceID, issueNumber)
+	return err
+}
+
+// SlackCommandApprove approves the latest ready plan for a given issue.
+func (a *App) SlackCommandApprove(workspaceID string, issueNumber int) error {
+	if a.store == nil {
+		return fmt.Errorf("store unavailable")
+	}
+	plan, err := a.store.LatestPlan(workspaceID, issueNumber)
+	if err != nil || plan == nil {
+		return fmt.Errorf("no plan found for #%d", issueNumber)
+	}
+	return a.ApprovePlan(workspaceID, issueNumber, plan.Revision)
+}
+
+// SlackCommandCancel cancels the active session for a given issue.
+func (a *App) SlackCommandCancel(workspaceID string, issueNumber int) error {
+	if a.mgr == nil {
+		return fmt.Errorf("session manager unavailable")
+	}
+	for _, sess := range a.mgr.Snapshot() {
+		if sess.WorkspaceID == workspaceID && sess.IssueNumber == issueNumber {
+			switch sess.State {
+			case types.StateRunning, types.StateWaitingForInput, types.StatePausedForQuestion:
+				return a.CancelSession(sess.ID)
+			}
+		}
+	}
+	return fmt.Errorf("no active session found for #%d in workspace %s", issueNumber, workspaceID)
+}
+
+// SlackCommandCostThisWeek returns a this-week cost summary for Slack.
+func (a *App) SlackCommandCostThisWeek(workspaceID string) string {
+	if a.wsReg == nil {
+		return "Workspace registry unavailable."
+	}
+	ws, ok := a.wsReg.Get(workspaceID)
+	if !ok {
+		return fmt.Sprintf("Unknown workspace `%s`.", workspaceID)
+	}
+	if a.store == nil {
+		return "Store unavailable."
+	}
+	week := thisWeekUTC()
+	cents, err := a.store.WorkspaceSpendCents(workspaceID, week)
+	if err != nil {
+		return fmt.Sprintf("Error computing spend: %v", err)
+	}
+	return fmt.Sprintf("*%s* — spend this week: *$%.2f*", ws.DisplayName, cents/100)
+}
+
+// SlackCommandGoalStatus returns a goal status summary for Slack.
+func (a *App) SlackCommandGoalStatus(goalID string) string {
+	if a.store == nil {
+		return "Store unavailable."
+	}
+	goals, err := a.store.ListGoals()
+	if err != nil {
+		return fmt.Sprintf("Error loading goals: %v", err)
+	}
+	for _, g := range goals {
+		if g.ID == goalID || strings.EqualFold(g.Title, goalID) {
+			return fmt.Sprintf("*Goal: %s*\nStatus: %s\nIntent: %s",
+				g.Title, g.Status, g.Intent)
+		}
+	}
+	return fmt.Sprintf("Goal `%s` not found.", goalID)
+}
+
+// SlackResolveWorkspaceByChannel finds the conductor workspace mapped to a
+// Slack channel ID. It checks each workspace's SlackConfig.ChannelMap;
+// if only one workspace maps that channel it is returned directly.
+// Returns ok=false when ambiguous or no mapping exists.
+func (a *App) SlackResolveWorkspaceByChannel(channelID string) (string, bool) {
+	if a.wsReg == nil {
+		return "", false
+	}
+	var matches []string
+	for _, ws := range a.wsReg.List() {
+		if ws.SlackConfig == nil {
+			continue
+		}
+		if wsID, found := ws.SlackConfig.ChannelMap[channelID]; found {
+			matches = append(matches, wsID)
+			continue
+		}
+		// Fall back: default channel matches.
+		if ws.SlackConfig.DefaultChannel == channelID {
+			matches = append(matches, ws.ID)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], true
+	}
+	return "", false
 }

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -4,6 +4,7 @@ import { BundledSkillsViewer } from "./BundledSkillsViewer";
 import { PoolsPanel } from "./PoolsPanel";
 import { ProvidersPanel } from "./ProvidersPanel";
 import { NotifyPanel } from "./NotifyPanel";
+import { SlackIntegrationPanel } from "./SlackIntegrationPanel";
 import { LogsPanel } from "./LogsPanel";
 import { AppearancePanel } from "./AppearancePanel";
 import { CollectionsPanel } from "./CollectionsPanel";
@@ -70,7 +71,7 @@ function AdvancedPanel({
   );
 }
 
-type Tab = "workspaces" | "collections" | "providers" | "pools" | "spending" | "skills" | "notify" | "appearance" | "logs" | "advanced" | "diagnostics";
+type Tab = "workspaces" | "collections" | "providers" | "pools" | "spending" | "skills" | "notify" | "slack" | "appearance" | "logs" | "advanced" | "diagnostics";
 
 export function Settings({
   open,
@@ -108,6 +109,7 @@ export function Settings({
                 ["spending", "Spending"],
                 ["skills", "Bundled skills"],
                 ["notify", "Notifications"],
+                ["slack", "Slack"],
                 ["appearance", "Appearance"],
                 ["logs", "Logs"],
                 ["advanced", "Advanced"],
@@ -134,6 +136,7 @@ export function Settings({
             {tab === "spending" && <SpendingPanel workspaceID={selectedWorkspaceID ?? ""} />}
             {tab === "skills" && <BundledSkillsViewer />}
             {tab === "notify" && <NotifyPanel />}
+            {tab === "slack" && <SlackIntegrationPanel />}
             {tab === "appearance" && <AppearancePanel />}
             {tab === "logs" && <LogsPanel />}
             {tab === "advanced" && (

--- a/frontend/src/components/SlackIntegrationPanel.tsx
+++ b/frontend/src/components/SlackIntegrationPanel.tsx
@@ -1,0 +1,355 @@
+import { useEffect, useState } from "react";
+import { useWorkspaceStore } from "../stores/workspaceStore";
+import {
+  GetSlackConfig,
+  GetSlackStatus,
+  SaveSlackConfig,
+  SaveSlackCredentials,
+  DisconnectSlack,
+} from "../../wailsjs/go/main/App";
+
+interface SlackEventRouting {
+  plan_ready: boolean;
+  blocked: boolean;
+  completed: boolean;
+  budget_alert: boolean;
+  auto_archive: boolean;
+}
+
+interface SlackConfig {
+  enabled: boolean;
+  bot_token_ref?: string;
+  app_level_token_ref?: string;
+  app_id?: string;
+  team_id?: string;
+  team_name?: string;
+  default_channel?: string;
+  channel_map?: Record<string, string>;
+  event_routing?: SlackEventRouting;
+  user_map?: Record<string, string>;
+  muted?: boolean;
+}
+
+interface SlackStatus {
+  connected: boolean;
+  team_name?: string;
+  bot_user_id?: string;
+  error?: string;
+}
+
+const DEFAULT_ROUTING: SlackEventRouting = {
+  plan_ready: true,
+  blocked: true,
+  completed: false,
+  budget_alert: true,
+  auto_archive: false,
+};
+
+export function SlackIntegrationPanel() {
+  const workspaceID = useWorkspaceStore((s) => s.selectedID) ?? "";
+
+  const [cfg, setCfg] = useState<SlackConfig | null>(null);
+  const [status, setStatus] = useState<SlackStatus>({ connected: false });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  // Credential form (tokens are write-only — we never show them back).
+  const [botToken, setBotToken] = useState("");
+  const [appToken, setAppToken] = useState("");
+  const [showTokenForm, setShowTokenForm] = useState(false);
+
+  // Editable fields.
+  const [defaultChannel, setDefaultChannel] = useState("");
+  const [muted, setMuted] = useState(false);
+  const [routing, setRouting] = useState<SlackEventRouting>(DEFAULT_ROUTING);
+  const [userMapRaw, setUserMapRaw] = useState("");
+
+  useEffect(() => {
+    if (!workspaceID) return;
+    setLoading(true);
+    Promise.all([
+      GetSlackConfig(workspaceID).catch(() => null),
+      GetSlackStatus(workspaceID).catch(() => ({ connected: false })),
+    ]).then(([c, s]) => {
+      if (c) {
+        setCfg(c as SlackConfig);
+        setDefaultChannel((c as SlackConfig).default_channel ?? "");
+        setMuted((c as SlackConfig).muted ?? false);
+        setRouting((c as SlackConfig).event_routing ?? DEFAULT_ROUTING);
+        const um = (c as SlackConfig).user_map ?? {};
+        setUserMapRaw(
+          Object.entries(um)
+            .map(([k, v]) => `${k}:${v}`)
+            .join("\n")
+        );
+      }
+      setStatus(s as SlackStatus);
+      setLoading(false);
+    });
+  }, [workspaceID]);
+
+  function parseUserMap(raw: string): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const line of raw.split("\n")) {
+      const [k, v] = line.trim().split(":");
+      if (k && v) out[k.trim()] = v.trim();
+    }
+    return out;
+  }
+
+  async function saveCredentials() {
+    if (!botToken || !appToken) {
+      setMsg("Both bot token and app-level token are required.");
+      return;
+    }
+    setSaving(true);
+    setMsg(null);
+    try {
+      await SaveSlackCredentials(workspaceID, botToken, appToken);
+      setBotToken("");
+      setAppToken("");
+      setShowTokenForm(false);
+      setMsg("Credentials saved to keychain.");
+      // Reload config so refs are updated.
+      const c = await GetSlackConfig(workspaceID).catch(() => null);
+      if (c) setCfg(c as SlackConfig);
+    } catch (e: any) {
+      setMsg(String(e?.message ?? e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function saveConfig() {
+    setSaving(true);
+    setMsg(null);
+    const newCfg: SlackConfig = {
+      ...(cfg ?? {}),
+      enabled: true,
+      default_channel: defaultChannel,
+      muted,
+      event_routing: routing,
+      user_map: parseUserMap(userMapRaw),
+    };
+    try {
+      await SaveSlackConfig(workspaceID, newCfg as any);
+      setCfg(newCfg);
+      const s = await GetSlackStatus(workspaceID).catch(() => ({ connected: false }));
+      setStatus(s as SlackStatus);
+      setMsg("Saved.");
+    } catch (e: any) {
+      setMsg(String(e?.message ?? e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function disconnect() {
+    if (!confirm("Disconnect Slack? This will remove stored credentials from the keychain.")) return;
+    setSaving(true);
+    try {
+      await DisconnectSlack(workspaceID);
+      setCfg(null);
+      setStatus({ connected: false });
+      setDefaultChannel("");
+      setMuted(false);
+      setRouting(DEFAULT_ROUTING);
+      setUserMapRaw("");
+      setMsg("Disconnected.");
+    } catch (e: any) {
+      setMsg(String(e?.message ?? e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!workspaceID) {
+    return (
+      <div className="text-slate-500 text-sm">Select a workspace to configure Slack.</div>
+    );
+  }
+
+  if (loading) {
+    return <div className="text-slate-500 text-sm">Loading…</div>;
+  }
+
+  const isConnected = status.connected;
+  const hasCredentials = !!(cfg?.bot_token_ref && cfg?.app_level_token_ref);
+
+  return (
+    <div className="space-y-5 text-sm">
+      {/* Connection status */}
+      <div className="flex items-center gap-3">
+        <span
+          className={
+            "w-2 h-2 rounded-full " + (isConnected ? "bg-emerald-500" : "bg-slate-600")
+          }
+        />
+        <span className="text-slate-300">
+          {isConnected
+            ? `Connected${status.team_name ? ` to ${status.team_name}` : ""}${status.bot_user_id ? ` (bot: ${status.bot_user_id})` : ""}`
+            : hasCredentials
+            ? "Credentials saved — start the app to connect."
+            : "Not configured"}
+        </span>
+        {hasCredentials && (
+          <button
+            onClick={() => setShowTokenForm((v) => !v)}
+            className="ml-auto text-xs text-slate-400 hover:text-slate-200 underline"
+          >
+            Replace tokens
+          </button>
+        )}
+      </div>
+
+      {/* Token form — shown when not configured or user clicks Replace */}
+      {(!hasCredentials || showTokenForm) && (
+        <div className="bg-slate-800 rounded p-3 space-y-3 border border-slate-700">
+          <div className="text-slate-300 font-medium">Slack credentials</div>
+          <p className="text-slate-500 text-xs">
+            Create a Slack App with Socket Mode enabled. Provide a bot token (
+            <code className="text-slate-300">xoxb-</code>) and an app-level token (
+            <code className="text-slate-300">xapp-</code>).
+          </p>
+          <label className="block">
+            <span className="text-slate-400 text-xs">Bot token (xoxb-…)</span>
+            <input
+              type="password"
+              value={botToken}
+              onChange={(e) => setBotToken(e.target.value)}
+              placeholder="xoxb-…"
+              className="mt-1 w-full bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs font-mono"
+            />
+          </label>
+          <label className="block">
+            <span className="text-slate-400 text-xs">App-level token (xapp-…)</span>
+            <input
+              type="password"
+              value={appToken}
+              onChange={(e) => setAppToken(e.target.value)}
+              placeholder="xapp-…"
+              className="mt-1 w-full bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs font-mono"
+            />
+          </label>
+          <div className="flex gap-2">
+            <button
+              onClick={saveCredentials}
+              disabled={saving}
+              className="px-3 py-1 bg-sky-700 hover:bg-sky-600 rounded disabled:opacity-50 text-xs"
+            >
+              Save to keychain
+            </button>
+            {showTokenForm && (
+              <button
+                onClick={() => setShowTokenForm(false)}
+                className="px-3 py-1 text-slate-400 hover:text-slate-200 text-xs"
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Config — shown once credentials exist */}
+      {hasCredentials && (
+        <>
+          <div>
+            <div className="text-slate-300 font-medium mb-1">Default channel</div>
+            <input
+              type="text"
+              value={defaultChannel}
+              onChange={(e) => setDefaultChannel(e.target.value)}
+              placeholder="#conductor"
+              className="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-200"
+            />
+            <p className="text-slate-500 text-xs mt-1">
+              Fallback channel for notifications when no channel mapping matches.
+            </p>
+          </div>
+
+          <div>
+            <div className="text-slate-300 font-medium mb-2">Notifications</div>
+            <div className="space-y-1">
+              {(
+                [
+                  ["plan_ready", "Plan ready for approval"],
+                  ["blocked", "Session blocked or failed"],
+                  ["completed", "Session completed"],
+                  ["budget_alert", "Budget cap alert"],
+                  ["auto_archive", "Auto-archive sweep summary"],
+                ] as [keyof SlackEventRouting, string][]
+              ).map(([key, label]) => (
+                <label key={key} className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={routing[key]}
+                    onChange={(e) =>
+                      setRouting((r) => ({ ...r, [key]: e.target.checked }))
+                    }
+                    className="accent-sky-500"
+                  />
+                  <span className="text-slate-400">{label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={muted}
+                onChange={(e) => setMuted(e.target.checked)}
+                className="accent-sky-500"
+              />
+              <span className="text-slate-300">Mute all Slack notifications</span>
+            </label>
+          </div>
+
+          <div>
+            <div className="text-slate-300 font-medium mb-1">
+              Authorized users{" "}
+              <span className="text-slate-500 font-normal">(Slack user ID → permission)</span>
+            </div>
+            <textarea
+              value={userMapRaw}
+              onChange={(e) => setUserMapRaw(e.target.value)}
+              rows={4}
+              placeholder={"U0123456789:full\nU9876543210:read_only"}
+              className="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-200 text-xs font-mono"
+            />
+            <p className="text-slate-500 text-xs mt-1">
+              One entry per line: <code>slackUserID:full</code> or{" "}
+              <code>slackUserID:read_only</code>. Mutating commands (plan/approve/cancel)
+              require <code>full</code>.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3 pt-2 border-t border-slate-800">
+            <button
+              onClick={saveConfig}
+              disabled={saving}
+              className="px-3 py-1 bg-emerald-700 hover:bg-emerald-600 rounded disabled:opacity-50"
+            >
+              Save
+            </button>
+            <button
+              onClick={disconnect}
+              disabled={saving}
+              className="px-3 py-1 bg-red-900 hover:bg-red-800 rounded disabled:opacity-50"
+            >
+              Disconnect
+            </button>
+            {msg && <span className="text-xs text-slate-400">{msg}</span>}
+          </div>
+        </>
+      )}
+
+      {!hasCredentials && msg && (
+        <div className="text-xs text-slate-400">{msg}</div>
+      )}
+    </div>
+  );
+}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -68,6 +68,8 @@ export function DeployRemoteWorker(arg1:string,arg2:string,arg3:string):Promise<
 
 export function DiagnoseIssue(arg1:string,arg2:number):Promise<diagnose.IssueDiagnosis>;
 
+export function DisconnectSlack(arg1:string):Promise<void>;
+
 export function DiscoverWorkspaceSkills(arg1:string):Promise<Array<types.SkillRef>>;
 
 export function DismissFanoutProposal(arg1:string):Promise<void>;
@@ -111,6 +113,10 @@ export function GetRepoDefaultBranch(arg1:string,arg2:string,arg3:string):Promis
 export function GetRetryQueue(arg1:string):Promise<Array<retry.PendingRetry>>;
 
 export function GetSessionLedger(arg1:string,arg2:number):Promise<Array<types.SessionLedgerRow>>;
+
+export function GetSlackConfig(arg1:string):Promise<types.SlackConfig>;
+
+export function GetSlackStatus(arg1:string):Promise<main.SlackStatus>;
 
 export function GetWorkspaceCostProjection(arg1:string):Promise<Array<main.PoolCostProjection>>;
 
@@ -252,6 +258,10 @@ export function SavePool(arg1:types.Pool):Promise<void>;
 
 export function SaveProviderEntity(arg1:types.ProviderEntity):Promise<void>;
 
+export function SaveSlackConfig(arg1:string,arg2:types.SlackConfig):Promise<void>;
+
+export function SaveSlackCredentials(arg1:string,arg2:string,arg3:string):Promise<void>;
+
 export function SaveWorkspacePipeline(arg1:string,arg2:types.WorkspacePipeline):Promise<void>;
 
 export function SelfHeal(arg1:string,arg2:number):Promise<void>;
@@ -269,6 +279,22 @@ export function SetLabelFilter(arg1:string,arg2:Array<string>,arg3:string):Promi
 export function SetNotifyPrefs(arg1:main.NotifyPrefs):Promise<void>;
 
 export function SetPollInterval(arg1:number):Promise<void>;
+
+export function SlackCommandApprove(arg1:string,arg2:number):Promise<void>;
+
+export function SlackCommandCancel(arg1:string,arg2:number):Promise<void>;
+
+export function SlackCommandCostThisWeek(arg1:string):Promise<string>;
+
+export function SlackCommandGoalStatus(arg1:string):Promise<string>;
+
+export function SlackCommandListWorkspaces():Promise<string>;
+
+export function SlackCommandPlan(arg1:string,arg2:number):Promise<void>;
+
+export function SlackCommandStatus(arg1:string):Promise<string>;
+
+export function SlackResolveWorkspaceByChannel(arg1:string):Promise<string|boolean>;
 
 export function SpawnPlanForIssue(arg1:string,arg2:number):Promise<types.Session>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -110,6 +110,10 @@ export function DiagnoseIssue(arg1, arg2) {
   return window['go']['main']['App']['DiagnoseIssue'](arg1, arg2);
 }
 
+export function DisconnectSlack(arg1) {
+  return window['go']['main']['App']['DisconnectSlack'](arg1);
+}
+
 export function DiscoverWorkspaceSkills(arg1) {
   return window['go']['main']['App']['DiscoverWorkspaceSkills'](arg1);
 }
@@ -196,6 +200,14 @@ export function GetRetryQueue(arg1) {
 
 export function GetSessionLedger(arg1, arg2) {
   return window['go']['main']['App']['GetSessionLedger'](arg1, arg2);
+}
+
+export function GetSlackConfig(arg1) {
+  return window['go']['main']['App']['GetSlackConfig'](arg1);
+}
+
+export function GetSlackStatus(arg1) {
+  return window['go']['main']['App']['GetSlackStatus'](arg1);
 }
 
 export function GetWorkspaceCostProjection(arg1) {
@@ -478,6 +490,14 @@ export function SaveProviderEntity(arg1) {
   return window['go']['main']['App']['SaveProviderEntity'](arg1);
 }
 
+export function SaveSlackConfig(arg1, arg2) {
+  return window['go']['main']['App']['SaveSlackConfig'](arg1, arg2);
+}
+
+export function SaveSlackCredentials(arg1, arg2, arg3) {
+  return window['go']['main']['App']['SaveSlackCredentials'](arg1, arg2, arg3);
+}
+
 export function SaveWorkspacePipeline(arg1, arg2) {
   return window['go']['main']['App']['SaveWorkspacePipeline'](arg1, arg2);
 }
@@ -512,6 +532,38 @@ export function SetNotifyPrefs(arg1) {
 
 export function SetPollInterval(arg1) {
   return window['go']['main']['App']['SetPollInterval'](arg1);
+}
+
+export function SlackCommandApprove(arg1, arg2) {
+  return window['go']['main']['App']['SlackCommandApprove'](arg1, arg2);
+}
+
+export function SlackCommandCancel(arg1, arg2) {
+  return window['go']['main']['App']['SlackCommandCancel'](arg1, arg2);
+}
+
+export function SlackCommandCostThisWeek(arg1) {
+  return window['go']['main']['App']['SlackCommandCostThisWeek'](arg1);
+}
+
+export function SlackCommandGoalStatus(arg1) {
+  return window['go']['main']['App']['SlackCommandGoalStatus'](arg1);
+}
+
+export function SlackCommandListWorkspaces() {
+  return window['go']['main']['App']['SlackCommandListWorkspaces']();
+}
+
+export function SlackCommandPlan(arg1, arg2) {
+  return window['go']['main']['App']['SlackCommandPlan'](arg1, arg2);
+}
+
+export function SlackCommandStatus(arg1) {
+  return window['go']['main']['App']['SlackCommandStatus'](arg1);
+}
+
+export function SlackResolveWorkspaceByChannel(arg1) {
+  return window['go']['main']['App']['SlackResolveWorkspaceByChannel'](arg1);
 }
 
 export function SpawnPlanForIssue(arg1, arg2) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1411,6 +1411,24 @@ export namespace main {
 	        this.color = source["color"];
 	    }
 	}
+	export class SlackStatus {
+	    connected: boolean;
+	    team_name?: string;
+	    bot_user_id?: string;
+	    error?: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new SlackStatus(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.connected = source["connected"];
+	        this.team_name = source["team_name"];
+	        this.bot_user_id = source["bot_user_id"];
+	        this.error = source["error"];
+	    }
+	}
 	export class SpawnEstimate {
 	    tokens: number;
 	    cost_cents: number;
@@ -2642,6 +2660,77 @@ export namespace types {
 		}
 	}
 	
+	export class SlackEventRouting {
+	    plan_ready: boolean;
+	    blocked: boolean;
+	    completed: boolean;
+	    budget_alert: boolean;
+	    auto_archive: boolean;
+	
+	    static createFrom(source: any = {}) {
+	        return new SlackEventRouting(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.plan_ready = source["plan_ready"];
+	        this.blocked = source["blocked"];
+	        this.completed = source["completed"];
+	        this.budget_alert = source["budget_alert"];
+	        this.auto_archive = source["auto_archive"];
+	    }
+	}
+	export class SlackConfig {
+	    enabled: boolean;
+	    bot_token_ref?: string;
+	    app_level_token_ref?: string;
+	    app_id?: string;
+	    team_id?: string;
+	    team_name?: string;
+	    default_channel?: string;
+	    channel_map?: Record<string, string>;
+	    event_routing?: SlackEventRouting;
+	    user_map?: Record<string, string>;
+	    muted?: boolean;
+	
+	    static createFrom(source: any = {}) {
+	        return new SlackConfig(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.enabled = source["enabled"];
+	        this.bot_token_ref = source["bot_token_ref"];
+	        this.app_level_token_ref = source["app_level_token_ref"];
+	        this.app_id = source["app_id"];
+	        this.team_id = source["team_id"];
+	        this.team_name = source["team_name"];
+	        this.default_channel = source["default_channel"];
+	        this.channel_map = source["channel_map"];
+	        this.event_routing = this.convertValues(source["event_routing"], SlackEventRouting);
+	        this.user_map = source["user_map"];
+	        this.muted = source["muted"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	
 	
 	export class WorkspacePipeline {
 	    steps: PipelineStep[];
@@ -2699,6 +2788,7 @@ export namespace types {
 	    complexity_scale?: string;
 	    tracker_kind?: string;
 	    tracker_config?: number[];
+	    slack_config?: SlackConfig;
 	
 	    static createFrom(source: any = {}) {
 	        return new Workspace(source);
@@ -2728,6 +2818,7 @@ export namespace types {
 	        this.complexity_scale = source["complexity_scale"];
 	        this.tracker_kind = source["tracker_kind"];
 	        this.tracker_config = source["tracker_config"];
+	        this.slack_config = this.convertValues(source["slack_config"], SlackConfig);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/go-github/v62 v62.0.0
 	github.com/google/uuid v1.6.0
 	github.com/mozilla-ai/any-llm-go v0.9.0
+	github.com/slack-go/slack v0.23.1
 	github.com/wailsapp/wails/v2 v2.11.0
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/tools v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
+github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
+github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -110,6 +112,8 @@ github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/samber/lo v1.49.1 h1:4BIFyVfuQSEpluc7Fua+j1NolZHiEHEpaSEKdsH0tew=
 github.com/samber/lo v1.49.1/go.mod h1:dO6KHFzUKXgP8LDhU0oI8d2hekjXnGOu0DB8Jecxd6o=
+github.com/slack-go/slack v0.23.1 h1:ZS5B96wxxYQRwvJ3/vJFtqtUZi3tXhsZCyT44Nv7M80=
+github.com/slack-go/slack v0.23.1/go.mod h1:H0yR/YBuRJ39RkE+JpV/d/oEsbanzTRowR82bCN0cEs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/internal/secretstore/keychain.go
+++ b/internal/secretstore/keychain.go
@@ -45,6 +45,17 @@ func CFTokenKey(workspaceID string) string {
 	return KeyPrefix + workspaceID + ".cf_api_token"
 }
 
+// SlackBotTokenKey returns the keyring key for a workspace's Slack bot token.
+func SlackBotTokenKey(workspaceID string) string {
+	return KeyPrefix + workspaceID + ".slack_bot_token"
+}
+
+// SlackAppLevelTokenKey returns the keyring key for a workspace's Slack app-level
+// Socket Mode token (xapp- prefix).
+func SlackAppLevelTokenKey(workspaceID string) string {
+	return KeyPrefix + workspaceID + ".slack_app_level_token"
+}
+
 // KeychainStore persists secrets in the OS-native keyring.
 type KeychainStore struct{}
 

--- a/internal/slack/auth.go
+++ b/internal/slack/auth.go
@@ -1,0 +1,91 @@
+package slack
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Permission levels for Slack users within a conductor workspace.
+const (
+	PermNone     = ""          // no access (not mapped)
+	PermReadOnly = "read_only" // may run read-only commands
+	PermFull     = "full"      // may run mutating commands
+)
+
+// AuthRegistry maps Slack user IDs to conductor permission levels per workspace.
+// It is safe for concurrent use. Entries are loaded from the workspace's
+// SlackConfig.UserMap at startup and refreshed via UpdateWorkspace.
+type AuthRegistry struct {
+	mu      sync.RWMutex
+	entries map[string]string // key: wsID+":"+slackUserID → perm
+}
+
+// NewAuthRegistry returns an empty AuthRegistry.
+func NewAuthRegistry() *AuthRegistry {
+	return &AuthRegistry{entries: make(map[string]string)}
+}
+
+func registryKey(workspaceID, slackUserID string) string {
+	return workspaceID + ":" + slackUserID
+}
+
+// Set stores (or updates) the permission level for a Slack user in a workspace.
+func (r *AuthRegistry) Set(workspaceID, slackUserID, perm string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries[registryKey(workspaceID, slackUserID)] = perm
+}
+
+// Delete removes the mapping for a Slack user in a workspace.
+func (r *AuthRegistry) Delete(workspaceID, slackUserID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.entries, registryKey(workspaceID, slackUserID))
+}
+
+// LoadWorkspace replaces all mappings for a workspace with the provided map.
+// userMap is slackUserID → perm string.
+func (r *AuthRegistry) LoadWorkspace(workspaceID string, userMap map[string]string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	prefix := workspaceID + ":"
+	// Remove stale entries for this workspace.
+	for k := range r.entries {
+		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
+			delete(r.entries, k)
+		}
+	}
+	for slackUID, perm := range userMap {
+		r.entries[registryKey(workspaceID, slackUID)] = perm
+	}
+}
+
+// Perm returns the permission level for slackUserID in workspaceID.
+// Returns PermNone when unmapped.
+func (r *AuthRegistry) Perm(workspaceID, slackUserID string) string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.entries[registryKey(workspaceID, slackUserID)]
+}
+
+// CanMutate returns true when the user is authorized for mutating commands.
+func (r *AuthRegistry) CanMutate(workspaceID, slackUserID string) bool {
+	return r.Perm(workspaceID, slackUserID) == PermFull
+}
+
+// CanRead returns true when the user may run read-only commands.
+func (r *AuthRegistry) CanRead(workspaceID, slackUserID string) bool {
+	p := r.Perm(workspaceID, slackUserID)
+	return p == PermFull || p == PermReadOnly
+}
+
+// ErrUnauthorized is returned by command handlers when the caller lacks
+// sufficient permission.
+type ErrUnauthorized struct {
+	SlackUserID string
+	Required    string
+}
+
+func (e *ErrUnauthorized) Error() string {
+	return fmt.Sprintf("slack user %s lacks %s permission", e.SlackUserID, e.Required)
+}

--- a/internal/slack/auth_test.go
+++ b/internal/slack/auth_test.go
@@ -1,0 +1,69 @@
+package slack_test
+
+import (
+	"testing"
+
+	"prismconductor/internal/slack"
+)
+
+func TestAuthRegistry(t *testing.T) {
+	r := slack.NewAuthRegistry()
+
+	// Unmapped user has no permissions.
+	if r.CanRead("ws1", "USTRANGER") {
+		t.Error("unmapped user should not be able to read")
+	}
+	if r.CanMutate("ws1", "USTRANGER") {
+		t.Error("unmapped user should not be able to mutate")
+	}
+
+	// Map a read-only user.
+	r.Set("ws1", "UREADONLY", slack.PermReadOnly)
+	if !r.CanRead("ws1", "UREADONLY") {
+		t.Error("read_only user should be able to read")
+	}
+	if r.CanMutate("ws1", "UREADONLY") {
+		t.Error("read_only user should not be able to mutate")
+	}
+
+	// Map a full user.
+	r.Set("ws1", "UFULL", slack.PermFull)
+	if !r.CanRead("ws1", "UFULL") {
+		t.Error("full user should be able to read")
+	}
+	if !r.CanMutate("ws1", "UFULL") {
+		t.Error("full user should be able to mutate")
+	}
+
+	// Workspace isolation: UFULL in ws1 has no perms in ws2.
+	if r.CanMutate("ws2", "UFULL") {
+		t.Error("full user in ws1 should not have perms in ws2")
+	}
+}
+
+func TestAuthRegistryLoadWorkspace(t *testing.T) {
+	r := slack.NewAuthRegistry()
+
+	r.Set("ws1", "UOLD", slack.PermFull)
+
+	// LoadWorkspace replaces all ws1 entries.
+	r.LoadWorkspace("ws1", map[string]string{
+		"UNEW": slack.PermReadOnly,
+	})
+
+	if r.CanMutate("ws1", "UOLD") {
+		t.Error("UOLD should have been evicted by LoadWorkspace")
+	}
+	if !r.CanRead("ws1", "UNEW") {
+		t.Error("UNEW should be in the registry after LoadWorkspace")
+	}
+}
+
+func TestAuthRegistryDelete(t *testing.T) {
+	r := slack.NewAuthRegistry()
+	r.Set("ws1", "UUSER", slack.PermFull)
+	r.Delete("ws1", "UUSER")
+	if r.CanMutate("ws1", "UUSER") {
+		t.Error("deleted user should not be able to mutate")
+	}
+}

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -1,0 +1,150 @@
+// Package slack manages the Slack bot integration for PrismConductor.
+// v1 scope: OAuth/connect, notifications, core commands via Socket Mode.
+// Thread-reply verbs and mid-run question routing are deferred to v1.1.
+package slack
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+
+	goslack "github.com/slack-go/slack"
+	"github.com/slack-go/slack/socketmode"
+)
+
+// AppFacade is the minimal interface the Manager calls back into app.go.
+// Keeping it narrow prevents the slack package from importing the entire App.
+type AppFacade interface {
+	SlackCommandListWorkspaces() string
+	SlackCommandStatus(workspaceID string) string
+	SlackCommandPlan(workspaceID string, issueNumber int) error
+	SlackCommandApprove(workspaceID string, issueNumber int) error
+	SlackCommandCancel(workspaceID string, issueNumber int) error
+	SlackCommandCostThisWeek(workspaceID string) string
+	SlackCommandGoalStatus(goalID string) string
+	SlackResolveWorkspaceByChannel(channelID string) (workspaceID string, ok bool)
+}
+
+// Manager owns the Socket Mode connection and coordinates inbound events.
+type Manager struct {
+	mu      sync.Mutex
+	client  *goslack.Client
+	sm      *socketmode.Client
+	handler *Handler
+
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	app AppFacade
+	// botID is the bot's own Slack user ID; used to strip self-mentions.
+	botID string
+}
+
+// Config holds the runtime credentials for one workspace's Slack bot.
+type Config struct {
+	BotToken      string
+	AppLevelToken string // required for Socket Mode (xapp- prefix)
+	WorkspaceID   string // conductor workspace ID for channel resolution
+}
+
+// NewManager creates a Manager. Call Start to open the socket.
+func NewManager(cfg Config, app AppFacade, authz *AuthRegistry) (*Manager, error) {
+	if cfg.BotToken == "" || cfg.AppLevelToken == "" {
+		return nil, fmt.Errorf("slack: bot token and app-level token are required")
+	}
+
+	slackClient := goslack.New(cfg.BotToken,
+		goslack.OptionAppLevelToken(cfg.AppLevelToken),
+	)
+
+	// Verify the token and capture the bot user ID.
+	ai, err := slackClient.AuthTest()
+	if err != nil {
+		return nil, fmt.Errorf("slack auth test: %w", err)
+	}
+
+	sm := socketmode.New(slackClient,
+		socketmode.OptionDebug(false),
+		socketmode.OptionLog(log.New(log.Writer(), "slack-sm: ", log.LstdFlags|log.Lshortfile)),
+	)
+
+	m := &Manager{
+		client: slackClient,
+		sm:     sm,
+		app:    app,
+		botID:  ai.UserID,
+		done:   make(chan struct{}),
+	}
+	m.handler = newHandler(m, authz)
+	return m, nil
+}
+
+// Start opens the Socket Mode connection and processes events until ctx is done.
+func (m *Manager) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	m.mu.Lock()
+	m.cancel = cancel
+	m.mu.Unlock()
+
+	go func() {
+		defer close(m.done)
+		go m.sm.RunContext(ctx) //nolint:errcheck — run loop errors are logged internally
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case evt, ok := <-m.sm.Events:
+				if !ok {
+					return
+				}
+				m.handler.dispatch(evt)
+			}
+		}
+	}()
+}
+
+// Stop gracefully shuts down the socket connection.
+func (m *Manager) Stop() {
+	m.mu.Lock()
+	cancel := m.cancel
+	m.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	<-m.done
+}
+
+// PostMessage sends a plain text message to a channel.
+func (m *Manager) PostMessage(channelID, text string) error {
+	_, _, err := m.client.PostMessage(channelID,
+		goslack.MsgOptionText(text, false),
+	)
+	return err
+}
+
+// PostMessageBlocks sends a rich block-kit message to a channel.
+func (m *Manager) PostMessageBlocks(channelID string, blocks ...goslack.Block) error {
+	_, _, err := m.client.PostMessage(channelID,
+		goslack.MsgOptionBlocks(blocks...),
+	)
+	return err
+}
+
+// PostThreadReply sends a reply in an existing thread.
+func (m *Manager) PostThreadReply(channelID, threadTS, text string) error {
+	_, _, err := m.client.PostMessage(channelID,
+		goslack.MsgOptionText(text, false),
+		goslack.MsgOptionTS(threadTS),
+	)
+	return err
+}
+
+// ack acknowledges a socket-mode event so Slack doesn't retry it.
+func (m *Manager) ack(evt socketmode.Event) {
+	m.sm.Ack(*evt.Request)
+}
+
+// BotUserID returns the bot's Slack user ID.
+func (m *Manager) BotUserID() string { return m.botID }

--- a/internal/slack/commands.go
+++ b/internal/slack/commands.go
@@ -1,0 +1,191 @@
+package slack
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParsedCommand is the result of parsing a @conductor mention text.
+type ParsedCommand struct {
+	Verb string   // e.g. "plan", "approve", "cancel", "list", "status", "cost", "goal", "help"
+	Args []string // remaining tokens after the verb
+}
+
+// ParseMention extracts the command from a raw app_mention text.
+// It strips the bot mention (<@UXXXXXXXX>) and splits into verb + args.
+// Returns ok=false when the text contains no recognizable command.
+func ParseMention(text, botUserID string) (ParsedCommand, bool) {
+	// Strip bot mention token(s), e.g. "<@U0123456>"
+	mention := "<@" + botUserID + ">"
+	t := strings.ReplaceAll(text, mention, "")
+	t = strings.TrimSpace(t)
+	if t == "" {
+		return ParsedCommand{}, false
+	}
+	parts := strings.Fields(t)
+	if len(parts) == 0 {
+		return ParsedCommand{}, false
+	}
+	verb := strings.ToLower(parts[0])
+	return ParsedCommand{Verb: verb, Args: parts[1:]}, true
+}
+
+// Dispatcher routes parsed commands to AppFacade calls and returns a
+// human-readable Slack response string.
+type Dispatcher struct {
+	authz *AuthRegistry
+	app   AppFacade
+}
+
+// NewDispatcher creates a Dispatcher.
+func NewDispatcher(app AppFacade, authz *AuthRegistry) *Dispatcher {
+	return &Dispatcher{app: app, authz: authz}
+}
+
+// Dispatch executes cmd on behalf of slackUserID in channelID and returns the
+// response text to post back.
+func (d *Dispatcher) Dispatch(cmd ParsedCommand, slackUserID, channelID string) string {
+	switch cmd.Verb {
+	case "help":
+		return helpText()
+	case "list":
+		if !d.authz.CanRead("", slackUserID) {
+			return d.app.SlackCommandListWorkspaces()
+		}
+		return d.app.SlackCommandListWorkspaces()
+	case "status":
+		wsID, err := d.resolveWorkspace(cmd.Args, channelID)
+		if err != nil {
+			return fmt.Sprintf(":warning: %s", err)
+		}
+		return d.app.SlackCommandStatus(wsID)
+	case "plan":
+		wsID, issueNum, err := d.resolveWorkspaceAndIssue(cmd.Args, channelID)
+		if err != nil {
+			return fmt.Sprintf(":warning: %s", err)
+		}
+		if !d.authz.CanMutate(wsID, slackUserID) {
+			return ":lock: You are not authorized to run mutating commands in that workspace."
+		}
+		if err := d.app.SlackCommandPlan(wsID, issueNum); err != nil {
+			return fmt.Sprintf(":x: plan failed: %s", err)
+		}
+		return fmt.Sprintf(":hourglass_flowing_sand: Planning started for #%d.", issueNum)
+	case "approve":
+		wsID, issueNum, err := d.resolveWorkspaceAndIssue(cmd.Args, channelID)
+		if err != nil {
+			return fmt.Sprintf(":warning: %s", err)
+		}
+		if !d.authz.CanMutate(wsID, slackUserID) {
+			return ":lock: You are not authorized to run mutating commands in that workspace."
+		}
+		if err := d.app.SlackCommandApprove(wsID, issueNum); err != nil {
+			return fmt.Sprintf(":x: approve failed: %s", err)
+		}
+		return fmt.Sprintf(":white_check_mark: Approved plan for #%d — execute session spawned.", issueNum)
+	case "cancel":
+		wsID, issueNum, err := d.resolveWorkspaceAndIssue(cmd.Args, channelID)
+		if err != nil {
+			return fmt.Sprintf(":warning: %s", err)
+		}
+		if !d.authz.CanMutate(wsID, slackUserID) {
+			return ":lock: You are not authorized to run mutating commands in that workspace."
+		}
+		if err := d.app.SlackCommandCancel(wsID, issueNum); err != nil {
+			return fmt.Sprintf(":x: cancel failed: %s", err)
+		}
+		return fmt.Sprintf(":octagonal_sign: Cancelled active session for #%d.", issueNum)
+	case "cost":
+		wsID, err := d.resolveWorkspace(cmd.Args, channelID)
+		if err != nil {
+			return fmt.Sprintf(":warning: %s", err)
+		}
+		return d.app.SlackCommandCostThisWeek(wsID)
+	case "goal":
+		// @conductor goal <goal-id-or-name> status
+		if len(cmd.Args) < 2 || strings.ToLower(cmd.Args[len(cmd.Args)-1]) != "status" {
+			return ":question: Usage: `@conductor goal <goal-id> status`"
+		}
+		goalID := strings.Join(cmd.Args[:len(cmd.Args)-1], " ")
+		return d.app.SlackCommandGoalStatus(goalID)
+	default:
+		return fmt.Sprintf(":question: Unknown command `%s`. Try `@conductor help`.", cmd.Verb)
+	}
+}
+
+// resolveWorkspace derives a workspace ID from args or falls back to channel mapping.
+func (d *Dispatcher) resolveWorkspace(args []string, channelID string) (string, error) {
+	// If first arg looks like a workspace slug, try it.
+	if len(args) > 0 && !strings.HasPrefix(args[0], "#") {
+		return args[0], nil
+	}
+	wsID, ok := d.app.SlackResolveWorkspaceByChannel(channelID)
+	if !ok {
+		return "", fmt.Errorf("no workspace is mapped to this channel — use `@conductor status <workspace-id>`")
+	}
+	return wsID, nil
+}
+
+// resolveWorkspaceAndIssue extracts workspace + issue number from args like
+// "#42" or "workspace-id #42", falling back to channel mapping for the workspace.
+func (d *Dispatcher) resolveWorkspaceAndIssue(args []string, channelID string) (string, int, error) {
+	if len(args) == 0 {
+		return "", 0, fmt.Errorf("missing issue number — e.g. `@conductor plan #42`")
+	}
+
+	// Find the issue number token (starts with #).
+	issueToken := ""
+	wsSlug := ""
+	for _, a := range args {
+		if strings.HasPrefix(a, "#") {
+			issueToken = strings.TrimPrefix(a, "#")
+		} else {
+			wsSlug = a
+		}
+	}
+	if issueToken == "" {
+		// Try bare number as last arg.
+		last := args[len(args)-1]
+		n, err := strconv.Atoi(last)
+		if err != nil {
+			return "", 0, fmt.Errorf("cannot parse issue number from `%s`", strings.Join(args, " "))
+		}
+		issueToken = strconv.Itoa(n)
+		if len(args) > 1 {
+			wsSlug = strings.Join(args[:len(args)-1], " ")
+		}
+	}
+
+	issueNum, err := strconv.Atoi(issueToken)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid issue number: %s", issueToken)
+	}
+
+	var wsID string
+	if wsSlug != "" {
+		wsID = wsSlug
+	} else {
+		var ok bool
+		wsID, ok = d.app.SlackResolveWorkspaceByChannel(channelID)
+		if !ok {
+			return "", 0, fmt.Errorf("no workspace mapped to this channel — specify a workspace: `@conductor plan <workspace-id> #42`")
+		}
+	}
+	return wsID, issueNum, nil
+}
+
+func helpText() string {
+	return `:robot_face: *PrismConductor commands*
+
+• ` + "`@conductor list`" + ` — list workspaces with status
+• ` + "`@conductor status [workspace]`" + ` — workspace overview (cards, cost, active workers)
+• ` + "`@conductor plan [workspace] #<issue>`" + ` — spawn planner for an issue
+• ` + "`@conductor approve [workspace] #<issue>`" + ` — approve ready plan and start execute
+• ` + "`@conductor cancel [workspace] #<issue>`" + ` — cancel active session
+• ` + "`@conductor cost [workspace]`" + ` — spending this week
+• ` + "`@conductor goal <goal-id> status`" + ` — goal progress
+• ` + "`@conductor help`" + ` — this message
+
+Mutating commands (plan/approve/cancel) require your Slack user to be mapped in Settings → Slack.`
+}

--- a/internal/slack/commands_test.go
+++ b/internal/slack/commands_test.go
@@ -1,0 +1,172 @@
+package slack_test
+
+import (
+	"testing"
+
+	"prismconductor/internal/slack"
+)
+
+func TestParseMention(t *testing.T) {
+	botID := "U0BOT1234"
+	mention := "<@" + botID + ">"
+
+	tests := []struct {
+		name     string
+		text     string
+		wantOK   bool
+		wantVerb string
+		wantArgs []string
+	}{
+		{
+			name:     "simple help",
+			text:     mention + " help",
+			wantOK:   true,
+			wantVerb: "help",
+			wantArgs: []string{},
+		},
+		{
+			name:     "list",
+			text:     mention + " list",
+			wantOK:   true,
+			wantVerb: "list",
+			wantArgs: []string{},
+		},
+		{
+			name:     "plan with issue",
+			text:     mention + " plan #42",
+			wantOK:   true,
+			wantVerb: "plan",
+			wantArgs: []string{"#42"},
+		},
+		{
+			name:     "approve with workspace and issue",
+			text:     mention + " approve my-workspace #99",
+			wantOK:   true,
+			wantVerb: "approve",
+			wantArgs: []string{"my-workspace", "#99"},
+		},
+		{
+			name:     "empty after mention",
+			text:     mention,
+			wantOK:   false,
+			wantVerb: "",
+		},
+		{
+			name:     "status uppercase verb is lowercased",
+			text:     mention + " STATUS",
+			wantOK:   true,
+			wantVerb: "status",
+			wantArgs: []string{},
+		},
+		{
+			name:     "cost this-week",
+			text:     mention + " cost this-week",
+			wantOK:   true,
+			wantVerb: "cost",
+			wantArgs: []string{"this-week"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, ok := slack.ParseMention(tc.text, botID)
+			if ok != tc.wantOK {
+				t.Fatalf("ParseMention ok=%v want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if cmd.Verb != tc.wantVerb {
+				t.Errorf("verb=%q want %q", cmd.Verb, tc.wantVerb)
+			}
+			if tc.wantArgs != nil && len(cmd.Args) != len(tc.wantArgs) {
+				t.Errorf("args=%v want %v", cmd.Args, tc.wantArgs)
+			}
+		})
+	}
+}
+
+func TestDispatchHelp(t *testing.T) {
+	authz := slack.NewAuthRegistry()
+	app := &stubApp{}
+	disp := slack.NewDispatcher(app, authz)
+
+	cmd, ok := slack.ParseMention("<@UBOT> help", "UBOT")
+	if !ok {
+		t.Fatal("parse failed")
+	}
+	resp := disp.Dispatch(cmd, "USLACK", "CCHAN")
+	if resp == "" {
+		t.Error("help response should be non-empty")
+	}
+}
+
+func TestDispatchUnknownVerb(t *testing.T) {
+	authz := slack.NewAuthRegistry()
+	app := &stubApp{}
+	disp := slack.NewDispatcher(app, authz)
+
+	cmd := slack.ParsedCommand{Verb: "notacommand"}
+	resp := disp.Dispatch(cmd, "USLACK", "CCHAN")
+	if resp == "" {
+		t.Error("unknown verb should return non-empty error string")
+	}
+}
+
+func TestDispatchPlanRequiresFull(t *testing.T) {
+	authz := slack.NewAuthRegistry()
+	authz.Set("ws1", "UREAD", slack.PermReadOnly)
+
+	app := &stubApp{channelWS: "ws1"}
+	disp := slack.NewDispatcher(app, authz)
+
+	cmd := slack.ParsedCommand{Verb: "plan", Args: []string{"#10"}}
+	resp := disp.Dispatch(cmd, "UREAD", "CCHAN")
+	if resp == "" {
+		t.Fatal("expected response for unauthorized mutate")
+	}
+	// Should mention authorization.
+	if len(resp) < 5 {
+		t.Error("response too short")
+	}
+}
+
+func TestDispatchPlanAuthorized(t *testing.T) {
+	authz := slack.NewAuthRegistry()
+	authz.Set("ws1", "UFULL", slack.PermFull)
+
+	app := &stubApp{channelWS: "ws1"}
+	disp := slack.NewDispatcher(app, authz)
+
+	cmd := slack.ParsedCommand{Verb: "plan", Args: []string{"#10"}}
+	resp := disp.Dispatch(cmd, "UFULL", "CCHAN")
+	if resp == "" {
+		t.Fatal("expected non-empty response")
+	}
+	if app.planCalled == 0 {
+		t.Error("plan command should have invoked SlackCommandPlan")
+	}
+}
+
+// stubApp satisfies slack.AppFacade for testing.
+type stubApp struct {
+	channelWS  string
+	planCalled int
+}
+
+func (s *stubApp) SlackCommandListWorkspaces() string { return "workspaces list" }
+func (s *stubApp) SlackCommandStatus(_ string) string { return "status ok" }
+func (s *stubApp) SlackCommandPlan(_ string, _ int) error {
+	s.planCalled++
+	return nil
+}
+func (s *stubApp) SlackCommandApprove(_ string, _ int) error  { return nil }
+func (s *stubApp) SlackCommandCancel(_ string, _ int) error   { return nil }
+func (s *stubApp) SlackCommandCostThisWeek(_ string) string   { return "$0.00" }
+func (s *stubApp) SlackCommandGoalStatus(_ string) string     { return "goal status" }
+func (s *stubApp) SlackResolveWorkspaceByChannel(_ string) (string, bool) {
+	if s.channelWS != "" {
+		return s.channelWS, true
+	}
+	return "", false
+}

--- a/internal/slack/router.go
+++ b/internal/slack/router.go
@@ -1,0 +1,208 @@
+package slack
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+
+	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
+)
+
+// EventType identifies conductor lifecycle events that can be routed to Slack.
+type EventType string
+
+const (
+	EvtPlanReady    EventType = "plan_ready"
+	EvtBlocked      EventType = "blocked"
+	EvtCompleted    EventType = "completed"
+	EvtFailed       EventType = "failed"
+	EvtBudgetAlert  EventType = "budget_alert"
+	EvtAutoArchive  EventType = "auto_archive"
+)
+
+// EventRouting controls which lifecycle events are posted to Slack per workspace.
+type EventRouting struct {
+	PlanReady   bool `json:"plan_ready"`
+	Blocked     bool `json:"blocked"`
+	Completed   bool `json:"completed"`
+	BudgetAlert bool `json:"budget_alert"`
+	AutoArchive bool `json:"auto_archive"`
+}
+
+// DefaultEventRouting returns a routing config with sensible on/off defaults.
+func DefaultEventRouting() EventRouting {
+	return EventRouting{
+		PlanReady:   true,
+		Blocked:     true,
+		Completed:   false,
+		BudgetAlert: true,
+		AutoArchive: false,
+	}
+}
+
+// WorkspaceRoute is the per-workspace routing configuration used by the Router.
+type WorkspaceRoute struct {
+	Channel  string
+	Routing  EventRouting
+	Muted    bool
+}
+
+// Router fans conductor lifecycle events out to Slack channels, respecting
+// per-workspace mute/routing toggles. It is safe for concurrent use.
+type Router struct {
+	mu     sync.RWMutex
+	routes map[string]WorkspaceRoute // wsID → route
+	mgr    *Manager
+}
+
+// NewRouter creates a Router backed by mgr.
+func NewRouter(mgr *Manager) *Router {
+	return &Router{
+		routes: make(map[string]WorkspaceRoute),
+		mgr:    mgr,
+	}
+}
+
+// SetWorkspaceRoute replaces the routing config for workspaceID.
+func (r *Router) SetWorkspaceRoute(workspaceID string, route WorkspaceRoute) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.routes[workspaceID] = route
+}
+
+// RemoveWorkspaceRoute removes routing for a workspace (e.g. on disconnect).
+func (r *Router) RemoveWorkspaceRoute(workspaceID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.routes, workspaceID)
+}
+
+// Notify posts a lifecycle notification to the configured channel for workspaceID,
+// if the event type is enabled and the workspace is not muted.
+func (r *Router) Notify(workspaceID string, evt EventType, text string) {
+	r.mu.RLock()
+	route, ok := r.routes[workspaceID]
+	r.mu.RUnlock()
+	if !ok || route.Channel == "" || route.Muted {
+		return
+	}
+	if !r.eventEnabled(route.Routing, evt) {
+		return
+	}
+	if err := r.mgr.PostMessage(route.Channel, text); err != nil {
+		log.Printf("slack router: post to %s: %v", route.Channel, err)
+	}
+}
+
+func (r *Router) eventEnabled(routing EventRouting, evt EventType) bool {
+	switch evt {
+	case EvtPlanReady:
+		return routing.PlanReady
+	case EvtBlocked, EvtFailed:
+		return routing.Blocked
+	case EvtCompleted:
+		return routing.Completed
+	case EvtBudgetAlert:
+		return routing.BudgetAlert
+	case EvtAutoArchive:
+		return routing.AutoArchive
+	}
+	return false
+}
+
+// NotifyPlanReady posts a plan-ready notification with issue context.
+func (r *Router) NotifyPlanReady(workspaceID, workspaceName string, issueNum int, issueTitle string) {
+	text := fmt.Sprintf(":pencil: *%s* — Plan ready for *#%d: %s*\nApprove with `@conductor approve #%d`",
+		workspaceName, issueNum, issueTitle, issueNum)
+	r.Notify(workspaceID, EvtPlanReady, text)
+}
+
+// NotifyBlocked posts a blocked/failed notification.
+func (r *Router) NotifyBlocked(workspaceID, workspaceName string, issueNum int, reason string) {
+	short := reason
+	if len(short) > 200 {
+		short = short[:197] + "..."
+	}
+	text := fmt.Sprintf(":red_circle: *%s* — #%d is blocked\n```%s```", workspaceName, issueNum, short)
+	r.Notify(workspaceID, EvtBlocked, text)
+}
+
+// NotifyCompleted posts a completion notification.
+func (r *Router) NotifyCompleted(workspaceID, workspaceName string, issueNum int) {
+	text := fmt.Sprintf(":white_check_mark: *%s* — #%d completed", workspaceName, issueNum)
+	r.Notify(workspaceID, EvtCompleted, text)
+}
+
+// Handler dispatches Socket Mode events to command handlers.
+type Handler struct {
+	mgr    *Manager
+	disp   *Dispatcher
+}
+
+func newHandler(mgr *Manager, authz *AuthRegistry) *Handler {
+	return &Handler{
+		mgr:  mgr,
+		disp: NewDispatcher(mgr.app, authz),
+	}
+}
+
+func (h *Handler) dispatch(evt socketmode.Event) {
+	switch evt.Type {
+	case socketmode.EventTypeEventsAPI:
+		h.mgr.ack(evt)
+		h.handleEventsAPI(evt)
+	case socketmode.EventTypeSlashCommand:
+		h.mgr.ack(evt)
+	case socketmode.EventTypeInteractive:
+		h.mgr.ack(evt)
+	default:
+		h.mgr.ack(evt)
+	}
+}
+
+func (h *Handler) handleEventsAPI(evt socketmode.Event) {
+	payload, ok := evt.Data.(slackevents.EventsAPIEvent)
+	if !ok {
+		return
+	}
+	switch payload.Type {
+	case "event_callback":
+		h.handleInnerEvent(payload)
+	}
+}
+
+func (h *Handler) handleInnerEvent(payload slackevents.EventsAPIEvent) {
+	switch payload.InnerEvent.Type {
+	case "app_mention":
+		h.handleMention(payload)
+	}
+}
+
+func (h *Handler) handleMention(payload slackevents.EventsAPIEvent) {
+	ev, ok := payload.InnerEvent.Data.(*slackevents.AppMentionEvent)
+	if !ok {
+		return
+	}
+
+	// Ignore messages from the bot itself to avoid loops.
+	if ev.User == h.mgr.BotUserID() {
+		return
+	}
+
+	cmd, ok := ParseMention(ev.Text, h.mgr.BotUserID())
+	if !ok {
+		return
+	}
+
+	// Resolve a default workspace via channel mapping.
+	channelID := strings.TrimSpace(ev.Channel)
+	slackUserID := ev.User
+
+	resp := h.disp.Dispatch(cmd, slackUserID, channelID)
+
+	if err := h.mgr.PostMessage(channelID, resp); err != nil {
+		log.Printf("slack handler: reply to mention: %v", err)
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -122,6 +122,56 @@ type Workspace struct {
 	// TrackerConfig holds tracker-specific configuration as a JSON blob.
 	// For kind="jira" this is jira.JiraConfig. Nil for GitHub workspaces.
 	TrackerConfig json.RawMessage `json:"tracker_config,omitempty"`
+
+	// SlackConfig holds workspace-scoped Slack integration settings (issue #291).
+	// Nil means Slack is not configured for this workspace.
+	SlackConfig *SlackConfig `json:"slack_config,omitempty"`
+}
+
+// SlackConfig is workspace-scoped Slack integration configuration (issue #291).
+// All credential values are refs into the OS keyring, never raw tokens.
+type SlackConfig struct {
+	// Enabled gates the entire integration; false means no connection is attempted.
+	Enabled bool `json:"enabled"`
+
+	// BotTokenRef is the keyring key (not the value) for the bot OAuth token.
+	BotTokenRef string `json:"bot_token_ref,omitempty"`
+
+	// AppLevelTokenRef is the keyring key for the Socket Mode app-level token (xapp-).
+	AppLevelTokenRef string `json:"app_level_token_ref,omitempty"`
+
+	// AppID is the Slack App ID for display purposes only.
+	AppID string `json:"app_id,omitempty"`
+
+	// TeamID / TeamName identify the Slack workspace this bot is installed into.
+	TeamID   string `json:"team_id,omitempty"`
+	TeamName string `json:"team_name,omitempty"`
+
+	// DefaultChannel is the fallback notification channel (e.g. "#conductor").
+	DefaultChannel string `json:"default_channel,omitempty"`
+
+	// ChannelMap maps Slack channel IDs to conductor workspace IDs, enabling
+	// channel-to-workspace command resolution (issue #291 q3).
+	ChannelMap map[string]string `json:"channel_map,omitempty"`
+
+	// EventRouting controls which lifecycle events are posted to Slack.
+	EventRouting SlackEventRouting `json:"event_routing,omitempty"`
+
+	// UserMap maps Slack user IDs to permission levels ("full" or "read_only").
+	// Mutating commands (plan/approve/cancel) require "full" (issue #291 q4).
+	UserMap map[string]string `json:"user_map,omitempty"`
+
+	// Muted suspends all outbound Slack notifications for this workspace.
+	Muted bool `json:"muted,omitempty"`
+}
+
+// SlackEventRouting controls which conductor lifecycle events are posted to Slack.
+type SlackEventRouting struct {
+	PlanReady   bool `json:"plan_ready"`
+	Blocked     bool `json:"blocked"`
+	Completed   bool `json:"completed"`
+	BudgetAlert bool `json:"budget_alert"`
+	AutoArchive bool `json:"auto_archive"`
 }
 
 // WorkspacePipeline is the per-workspace pipeline configuration (issue #146).


### PR DESCRIPTION
## Summary

- Adds Socket Mode–based Slack integration enabling PrismConductor to be operated from Slack without the desktop window open
- v1 scope (phased delivery per Q1 answer): OAuth/connect, lifecycle notifications, and 7 core commands; thread-reply verbs and mid-run question routing deferred to v1.1
- All Slack credentials stored in OS keychain, never in workspaces.json

## Files modified

**Backend**
- `internal/slack/` (new): `client.go` (Socket Mode manager), `auth.go` (AuthRegistry — workspace-scoped Slack user → permission), `commands.go` (ParseMention + Dispatcher), `router.go` (notification fanout + Handler)
- `internal/types/types.go`: `SlackConfig` + `SlackEventRouting` structs added to `Workspace`; nil config = disabled (backward compatible)
- `internal/secretstore/keychain.go`: `SlackBotTokenKey` / `SlackAppLevelTokenKey` helpers
- `app.go`: `slackMgrs`, `slackAuthz`, `slackRouter` fields; startup wires per-workspace Socket Mode; notification fanout in `handleSessionStateChange` + `handlePlanReady`; 10 new Wails-bound methods (GetSlackConfig, SaveSlackConfig, SaveSlackCredentials, DisconnectSlack, GetSlackStatus, SlackCommandX facade)

**Frontend**
- `frontend/src/components/SlackIntegrationPanel.tsx` (new): connect form, event routing toggles, mute toggle, user map editor
- `frontend/src/components/Settings.tsx`: "Slack" tab added
- `frontend/wailsjs/go/main/App.js` / `App.d.ts`: manual bindings for 5 new methods

## Verification

| Step | Command | Result |
|---|---|---|
| Lint | `go vet prismconductor/...` | pass |
| Build | `go build prismconductor/...` | pass |
| Frontend typecheck | `tsc --noEmit` | pass |
| Go tests | `go test prismconductor/internal/...` | pass (11/11 new slack tests + all existing) |
| Smoke test | `playwright test startup.spec.ts` | pass (1 passed) |

Commit tier: **Tier 1** (GitHub API signed commit `f98874e`)

Workspace mode: per-execute worktree at `/Users/dino/Documents/git/prismconductor/.prismconductor/worktrees/prismconductor-291`

Closes #291